### PR TITLE
[GEOT-7898] Setup XMLUtils to assist in use of DefaultEntityResolver

### DIFF
--- a/.github/workflows/integration-qa.yml
+++ b/.github/workflows/integration-qa.yml
@@ -36,17 +36,40 @@ jobs:
         run: |
           sudo ethtool -K eth0 tx off rx off
       - name: Build GeoTools (no tests, prepare fresh artifacts)
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
+          echo "Building GeoTools for integration qa tests on $BRANCH_NAME"
           mvn -B -ntp clean install -T1C -Dall --file pom.xml -DskipTests
       - name: Checkout GeoWebCache and GeoServer
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           cd ~
           echo "Preparing git ssh checkouts"
           mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
           echo "Checking out GeoWebCache"
-          git clone https://github.com/GeoWebCache/geowebcache.git geowebcache
+          mkdir geowebcache
+          git clone -q https://github.com/GeoWebCache/geowebcache.git geowebcache
+          cd geowebcache
+          GWC_BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; echo $?)
+          if [ "$GWC_BRANCH_EXISTS" -eq 0 ]; then
+            echo "Branch found on geowebcache. Switching and tracking: $BRANCH_NAME"
+            git switch "$BRANCH_NAME"
+          fi
+          cd ..
+          
           echo "Checking out GeoServer"
-          git clone https://github.com/geoserver/geoserver.git geoserver
+          mkdir geoserver
+          git clone -q https://github.com/geoserver/geoserver.git geoserver
+          cd geoserver
+          GS_BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; echo $?)
+          if [ "$GS_BRANCH_EXISTS" -eq 0 ]; then
+            echo "Branch found on geoserver. Switching and tracking: $BRANCH_NAME"
+            git switch "$BRANCH_NAME"
+          fi
+          cd ..
+          
       - name: Build GeoWebCache with QA checks
         run: |
           cd ~

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,8 +38,6 @@ jobs:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           echo "Building GeoTools for integration tests on $BRANCH_NAME"
-          pwd
-          echo "GitHub workspace: $GITHUB_WORKSPACE"
           mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install -T1C -Dall --file pom.xml -DskipTests
       - name: Checkout GeoWebCache, GeoServer and ...
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,22 +34,56 @@ jobs:
         run: |
           sudo ethtool -K eth0 tx off rx off
       - name: Build GeoTools (no tests, prepare fresh artifacts)
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
+          echo "Building GeoTools for integration tests on $BRANCH_NAME"
+          pwd
+          echo "GitHub workspace: $GITHUB_WORKSPACE"
           mvn -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn clean install -T1C -Dall --file pom.xml -DskipTests
       - name: Checkout GeoWebCache, GeoServer and ...
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
+          echo "Integration tests for $BRANCH_NAME"
+          
           cd ~
           echo "Preparing git ssh checkouts"
-          mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
+          mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config                    
+          
           echo "Checking out GeoWebCache"
           mkdir geowebcache
-          git clone https://github.com/GeoWebCache/geowebcache.git geowebcache
+          git clone -q https://github.com/GeoWebCache/geowebcache.git geowebcache
+          cd geowebcache
+          GWC_BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; echo $?)
+          if [ "$GWC_BRANCH_EXISTS" -eq 0 ]; then
+            echo "Branch found on geowebcache. Switching and tracking: $BRANCH_NAME"
+            git switch "$BRANCH_NAME"
+          fi
+          cd ..
+          
           echo "Checking out GeoServer"
           mkdir geoserver
-          git clone https://github.com/geoserver/geoserver.git geoserver
+          git clone -q https://github.com/geoserver/geoserver.git geoserver
+          cd geoserver
+          GS_BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; echo $?)
+          if [ "$GS_BRANCH_EXISTS" -eq 0 ]; then
+            echo "Branch found on geoserver. Switching and tracking: $BRANCH_NAME"
+            git switch "$BRANCH_NAME"
+          fi
+          cd ..
+          
+          
           echo "Checking out mapfish-print-v2"
           mkdir mapfish-print-v2
-          git clone https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2
+          git clone -q https://github.com/mapfish/mapfish-print-v2.git mapfish-print-v2
+          cd mapfish-print-v2
+          MF_BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; echo $?)
+          if [ "$MF_BRANCH_EXISTS" -eq 0 ]; then
+            echo "Branch found on mapfish-print-v2. Switching and tracking: $BRANCH_NAME"
+            git switch "$BRANCH_NAME"
+          fi
+          cd ..
       - name: Build Mapfish-print v2 with tests
         run: |
           cd ~

--- a/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/SchemaGenerator.java
+++ b/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/SchemaGenerator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.xsd.XSDAttributeDeclaration;
@@ -370,8 +371,7 @@ public class SchemaGenerator extends AbstractGenerator {
                     try {
                         createType(definition, 0);
                     } catch (Exception e) {
-                        logger.warning("XERRORX generating " + xsdType);
-                        e.printStackTrace();
+                        logger.log(Level.WARNING,"XERRORX generating " + xsdType,e);
                     }
                 }
             }

--- a/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/BindingTestClass.java
+++ b/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/BindingTestClass.java
@@ -30,6 +30,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.eclipse.xsd.XSDNamedComponent;
 import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.XSDTypeDefinition;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Schemas;
 
 public class BindingTestClass
@@ -79,8 +80,7 @@ public class BindingTestClass
     
     StringWriter writer = new StringWriter();
 
-    SAXTransformerFactory txFactory = 
-            (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+    SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
     TransformerHandler xmls;
     try {
         xmls = txFactory.newTransformerHandler();

--- a/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/CLASS.java
+++ b/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/CLASS.java
@@ -36,6 +36,7 @@ import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.XSDSimpleTypeDefinition;
 import org.eclipse.xsd.XSDTypeDefinition;
 import org.geotools.maven.xmlcodegen.BindingConstructorArgument;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Schemas;
 
 public class CLASS
@@ -128,8 +129,7 @@ public class CLASS
 
     StringWriter writer = new StringWriter();
 
-    SAXTransformerFactory txFactory = 
-            (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+    SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
     TransformerHandler xmls;
     try {
         xmls = txFactory.newTransformerHandler();

--- a/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/CycleSchemaClassTemplate.java
+++ b/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/CycleSchemaClassTemplate.java
@@ -39,6 +39,7 @@ import org.geotools.api.feature.type.PropertyDescriptor;
 import org.geotools.api.feature.type.PropertyType;
 import org.geotools.api.feature.type.Schema;
 import org.geotools.maven.xmlcodegen.SchemaGenerator;
+import org.geotools.xml.XMLUtils;
 
 public class CycleSchemaClassTemplate
 {
@@ -152,8 +153,7 @@ public class CycleSchemaClassTemplate
             XSDTypeDefinition xsdType = sg.getXSDType(type);
             StringWriter writer = new StringWriter();
 
-            SAXTransformerFactory txFactory = 
-                    (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+            SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
             TransformerHandler xmls;
             try {
                 xmls = txFactory.newTransformerHandler();

--- a/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/SchemaClassTemplate.java
+++ b/build/maven/xmlcodegen/src/main/java/org/geotools/maven/xmlcodegen/templates/SchemaClassTemplate.java
@@ -39,6 +39,7 @@ import org.geotools.api.feature.type.PropertyDescriptor;
 import org.geotools.api.feature.type.PropertyType;
 import org.geotools.api.feature.type.Schema;
 import org.geotools.maven.xmlcodegen.SchemaGenerator;
+import org.geotools.xml.XMLUtils;
 
 public class SchemaClassTemplate
 {
@@ -161,8 +162,7 @@ public class SchemaClassTemplate
           StringWriter writer = new StringWriter();
 
           XSDTypeDefinition xsdType = sg.getXSDType(type);
-          SAXTransformerFactory txFactory =
-                  (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+          SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
           TransformerHandler xmls;
           try {
               xmls = txFactory.newTransformerHandler();

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -157,24 +157,101 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
       </property>
     </properties>
   </rule>
-  <rule name="AvoidTransform"
+  <rule name="AvoidTransformFactory"
         language="java"
-        message="Do not use TransformerFactory directly; recommend XMLUtils.newTransformer()"
+        message="Do not use TransformerFactory directly; recommend XMLUtils.newInstance()"
         class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
     <description>
       Notice use of TransformerFactory.newInstance() which should be avoided in favor of
-      XMLUtils.newInstance(Hints) to respect GeoTools init configuration.
+      XMLUtils.newTransformerFactory(Hints) to respect GeoTools init configuration.
     </description>
     <priority>3</priority>
     <properties>
       <property name="xpath">
           <value>
               <![CDATA[
-              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newTransformer()")]
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newInstance()")]
               ]]>
           </value>
       </property>
     </properties>
   </rule>
+  <rule name="AvoidTransformer"
+        language="java"
+        message="Do not use TransformerFactory.newTransformer() directly; recommend XMLUtils.newTransformer()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of TransformerFactory.newTransformer() which should be avoided in favor of
+      XMLUtils.newTransformer(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newTransformer()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidTransformerSource"
+        language="java"
+        message="Do not use TransformerFactory.newTransformer(source) directly; recommend XMLUtils.newTransformer(source)"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of TransformerFactory.newTransformer(Source) which should be avoided in favor of
+      XMLUtils.newTransformer(Source,Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newTransformer(javax.xml.transform.Source)")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidSAXParserFactory"
+        language="java"
+        message="Do not use ParserFactory.newInstance() directly; recommend XMLUtils.newSAXParserFactory()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SAXParserFactory.newInstance() which should be avoided in favor of
+      XMLUtils.newSAXParserFactory(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.SAXParserFactory#newInstance()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  <rule name="AvoidSaxParser"
+        language="java"
+        message="Do not use SAXParserFactory.newSAXParser() directly; recommend XMLUtils.newSAXParser()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SAXParserFactory.newSAXParser() which should be avoided in favor of
+      XMLUtils.newSAXParser(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.SAXParserFactory#newInstance()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+
 
 </ruleset>

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -96,7 +96,10 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
   <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector" />
   <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
   <rule ref="category/java/performance.xml/StringInstantiation"/>
-  <rule name="wildcards" language="java" message="No Wildcard Imports" class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+  <rule name="wildcards"
+        language="java"
+        message="No Wildcard Imports"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
     <description>
       Don't use wildcard imports
     </description>
@@ -119,7 +122,7 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
   <rule name="AvoidDocumentBuilder"
         language="java"
         message="Do not use DocumentBuilder directly; recommend XMLUtils.newDocumentBuilder()"
-        class="net.sourceforge.pmd.lang.rule.XPathRule">
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
     <description>
       Notice use of DocumentBuilderFactory.newDocumentBuilder() which should be avoided in favor of
       XMLUtils.newDocumentBuilder(Hints) to respect GeoTools init configuration.
@@ -127,13 +130,11 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
     <priority>3</priority>
     <properties>
       <property name="xpath">
-        <value>
-          //MethodCall[
-          @MethodName='newDocumentBuilder'
-          and
-          ..//Type[@TypeName='DocumentBuilderFactory']
-          ]
-        </value>
+          <value>
+              <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.DocumentBuilderFactory#newDocumentBuilder()")]
+              ]]>
+          </value>
       </property>
     </properties>
   </rule>

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -157,5 +157,24 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
       </property>
     </properties>
   </rule>
+  <rule name="AvoidTransform"
+        language="java"
+        message="Do not use TransformerFactory directly; recommend XMLUtils.newTransformer()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of TransformerFactory.newInstance() which should be avoided in favor of
+      XMLUtils.newInstance(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+          <value>
+              <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.transform.TransformerFactory#newTransformer()")]
+              ]]>
+          </value>
+      </property>
+    </properties>
+  </rule>
 
 </ruleset>

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -273,5 +273,24 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
     </properties>
   </rule>
 
-
+  <rule name="AvoidSchemaFactory"
+        language="java"
+        message="Do not use SchemaFactory.newInstance(String) directly; recommend XMLUtils.newSchemaFactory(String)"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SchemaFactory.newInstance() which should be avoided in favor of
+      XMLUtils.newInstance(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.validation.SchemaFactory#newInstance(java.lang.String)")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
+  
 </ruleset>

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -252,6 +252,26 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
       </property>
     </properties>
   </rule>
+  
+  <rule name="AvoidXMLInputFactory"
+        language="java"
+        message="Do not use XMLInputFactory.newInstance() directly; recommend XMLUtils.newXMLInputFactory()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of SAXParserFactory.newSAXParser() which should be avoided in favor of
+      XMLUtils.newSAXParser(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.stream.XMLInputFactory#newInstance()")]
+              ]]>
+        </value>
+      </property>
+    </properties>
+  </rule>
 
 
 </ruleset>

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -114,5 +114,28 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
     <properties>
       <property name="reportLevel" value="140"/>
     </properties>
-  </rule>	 
+  </rule>
+
+  <rule name="AvoidDocumentBuilder"
+        language="java"
+        message="Do not use DocumentBuilder directly; recommend XMLUtils.newDocumentBuilder()"
+        class="net.sourceforge.pmd.lang.rule.XPathRule">
+    <description>
+      Notice use of DocumentBuilderFactory.newDocumentBuilder() which should be avoided in favor of
+      XMLUtils.newDocumentBuilder(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          //MethodCall[
+          @MethodName='newDocumentBuilder'
+          and
+          ..//Type[@TypeName='DocumentBuilderFactory']
+          ]
+        </value>
+      </property>
+    </properties>
+  </rule>
+
 </ruleset>

--- a/build/qa/pmd-ruleset.xml
+++ b/build/qa/pmd-ruleset.xml
@@ -119,6 +119,25 @@ GeoTools ruleset. See https://pmd.github.io/pmd/pmd_userdocs_making_rulesets.htm
     </properties>
   </rule>
 
+  <rule name="AvoidDocumentBuilderFactory"
+        language="java"
+        message="Do not use DocumentBuildeFactory instance directly; recommend XMLUtils.newDocumentBuilderFactory()"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+    <description>
+      Notice use of DocumentBuilderFactory.newInstance() which should be avoided in favor of
+      XMLUtils.DocumentBuilderFactory(Hints) to respect GeoTools init configuration.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+          <value>
+              <![CDATA[
+              //MethodCall[pmd-java:matchesSig("javax.xml.parsers.DocumentBuilderFactory#newInstance()")]
+              ]]>
+          </value>
+      </property>
+    </properties>
+  </rule>
   <rule name="AvoidDocumentBuilder"
         language="java"
         message="Do not use DocumentBuilder directly; recommend XMLUtils.newDocumentBuilder()"

--- a/docs/src/main/java/org/geotools/render/GenerateSVG.java
+++ b/docs/src/main/java/org/geotools/render/GenerateSVG.java
@@ -19,13 +19,13 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.map.MapContent;
 import org.geotools.renderer.lite.StreamingRenderer;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 
 /**
@@ -59,10 +59,7 @@ public class GenerateSVG {
         if (canvasSize == null) {
             canvasSize = new Dimension(300, 300); // default of 300x300
         }
-
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
-
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         // Create an instance of org.w3c.dom.Document
         Document document = db.getDOMImplementation().createDocument(null, "svg", null);
 

--- a/docs/src/main/java/org/geotools/xml/GMLParsing.java
+++ b/docs/src/main/java/org/geotools/xml/GMLParsing.java
@@ -16,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.IOUtils;
@@ -114,7 +113,7 @@ public class GMLParsing {
                 .setAttribute("xsi:schemaLocation", "http://www.openplans.org/topp " + xsd.getCanonicalPath());
 
         File xml = File.createTempFile("states", "xml");
-        TransformerFactory.newInstance().newTransformer().transform(new DOMSource(d), new StreamResult(xml));
+        XMLUtils.newTransformer().transform(new DOMSource(d), new StreamResult(xml));
         return xml;
     }
 }

--- a/docs/src/main/java/org/geotools/xml/GMLParsing.java
+++ b/docs/src/main/java/org/geotools/xml/GMLParsing.java
@@ -16,7 +16,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
@@ -109,7 +108,7 @@ public class GMLParsing {
         File xsd = File.createTempFile("states", "xsd");
         IOUtils.copy(GMLParsing.class.getResourceAsStream("states.xsd"), new FileOutputStream(xsd));
 
-        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document d = db.parse(GMLParsing.class.getResourceAsStream("states.xml"));
         d.getDocumentElement()
                 .setAttribute("xsi:schemaLocation", "http://www.openplans.org/topp " + xsd.getCanonicalPath());

--- a/docs/user/library/xml/index.rst
+++ b/docs/user/library/xml/index.rst
@@ -34,6 +34,7 @@ you to what is available.
 .. toctree::
    :maxdepth: 1
    
+   xmlutils
    geometry
    filter
    style

--- a/docs/user/library/xml/xmlutils.rst
+++ b/docs/user/library/xml/xmlutils.rst
@@ -1,0 +1,102 @@
+XMLUtils
+--------
+
+GeoTools provides an ``XMLUtils`` utility class to perform common XML factory and instantiation activities.
+By providing these methods the GeoTools library can respect the factory configuration `Hints` including  `GeoTools.getDefaultEntityResolver(Hints)` configuration provided by the surrounding application.
+
+The library is configured to use `DefaultEntityResolver` which allows access to OGC and INSPIRE schemas. It also defaults to locked down settings within the limits of the OGC Standards implemented by the library.
+
+Reference:
+
+* `XML External Entity Prevention Cheat Sheet <https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html>`__ (OWASP)
+
+DocumentBuilderFactory and DocumentBuilder
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use XMLUtils for DocumentBuilder construction:
+
+.. code-block:: java
+
+   DocumentBuilder builder = XMLUtils.newDocumentBuilder();
+   Document document = builder.parse(stream);
+
+For greater control configuration is available using DocumentBuilderFactory and Hints:
+
+.. code-block:: java
+
+   DocumentBuilderFactory documentBuilderFactory = XMLUtils.newDocumentBuilderFactory(hints);
+   documentBuilderFactory.setNamespaceAware(namespaceAware);
+   
+   DocumentBuilder builder = XMLUtils.newDocumentBuilder(documentBuilderFactory);
+   Document document = builder.parse(stream);
+
+GeoTools uses the locked down ``XMLConstants.FEATURE_SECURE_PROCESSING`` when setting up document parsing.
+You may carefully relax settings as needed if working with local files:
+
+.. code-block:: java
+   
+   // Allow http access, with DefaultEntityResolver limiting access to OGC Schemas 
+   Hints hints = GeoTools.getDefaultHints();
+   hints.put(Hints.ENTITY_RESOLVER, DefaultEntityResolver.INSTANCE);
+   
+   DocumentBuilderFactory documentBuilderFactory = XMLUtils.newDocumentBuilderFactory(hints);
+   documentBuilderFactory.setNamespaceAware(namespaceAware);
+   documentBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
+   
+   DocumentBuilder builder = XMLUtils.newDocumentBuilder(documentBuilderFactory);
+   Document document = builder.parse(stream);
+
+TransformerFactory and Transformer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The same approach is taken with TransformerFactory and Transformer.
+
+XMLTransformer:
+
+.. code-block:: java
+
+   InputSource gmlSource = new InputSource(uri.toString());
+
+   DocumentBuilderFactory documentBuilderFactory = XMLUtils.newDocumentBuilderFactory(hints);
+   documentBuilderFactory.setNamespaceAware(true);
+   DocumentBuilder documentBuilder = XMLUtils.newDocumentBuilder(documentBuilderFactory, hints);
+   Document document = documentBuilder.parse(gmlSource);
+   assertNotNull(document);
+
+   TransformerFactory txFactory = XMLUtils.newTransformerFactory(hints);
+   txFactory.setAttribute("indent-number", 3);
+
+   // Transformer
+   Transformer tx = XMLUtils.newTransformer(txFactory, hints);
+   tx.setOutputProperty(OutputKeys.INDENT, "yes");
+
+   StringWriter writer = new StringWriter();
+   tx.transform(XMLUtils.source(document), new StreamResult(writer));
+
+
+SAXParserFactory and SAXParser
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use XMLUtils to create SAXParserFactory and SAXParser:
+
+.. code-block:: java
+
+   SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory(hints);
+   parserFactory.setNamespaceAware(true);
+   
+   SAXParser parser = XMLUtils.newSAXParser(parserFactory);
+   parser.parse(file, contentHandler);
+
+Use Hints to provide factory configuration:
+
+.. code-block:: java
+
+   Hints hints = GeoTools.getDefaultHints();
+   hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+   
+   SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory(hints);
+   parserFactory.setNamespaceAware(true);
+   parserFactory.setValidation(false);
+   
+   SAXParser parser = XMLUtils.newSAXParser(parserFactory);
+   parser.parse(file, contentHandler);

--- a/docs/user/unsupported/gml-geometry-streaming.rst
+++ b/docs/user/unsupported/gml-geometry-streaming.rst
@@ -15,8 +15,7 @@ Efficiently read GML geometry elements using StAX in a streaming manner. No writ
 
 Here is a small example from the test cases::
 
-    XMLInputFactory f = XMLInputFactory.newInstance();
-    f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+    XMLInputFactory f = XMLUtils.newXMLInputFactory();
     XMLStreamReader r = f.createXMLStreamReader(new StringReader(gmlStringSnippet));
     XmlStreamGeometryReader geometryReader = new XmlStreamGeometryReader(r);
     r.nextTag();

--- a/docs/user/welcome/use.rst
+++ b/docs/user/welcome/use.rst
@@ -177,7 +177,6 @@ common class for lookup.
 
 ``CommonFactoryFinder``
 
-
 * ``FilterFactory``
 * ``StyleFactory``
 * ``Function``
@@ -213,6 +212,12 @@ For access to coverage (i.e. raster) information:
 * ``MathTransformFactory``
 * ``CoordinateOperationFactory``
 * ``CoordinateOperationAuthorityFactory``
+
+``XMLUtils`` - used to access XML parsing services
+
+* ``DocumentFactory``
+* ``TransformerFactory``
+* ``SAXParserFactory``
 
 Where to get a Factory
 ----------------------
@@ -289,10 +294,9 @@ factories together.
 Popular techniques:
 
 * reflection - ``picocontainer`` looks the constructors using reflection to see if any of the required parameters are available
-* configuration - Spring uses a big XML file marking how each factory is created
+* configuration - SpringFramework uses annotations (or a big XML file) marking how each factory is created
 
-The other nice thing is the container can put off creating the
-factories until you actually ask for them.::
+Container approach can put off creating the factories until you actually ask for them.::
   
   container.registerImplementationClass( PositionFactory.class, PositionFactoryImpl.class );
   container.registerImplementationClass( CoordinateFactory.class, CoordinateFactoryImpl.class );

--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaValidator.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaValidator.java
@@ -25,15 +25,25 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xml.resolver.SchemaCatalog;
 import org.geotools.xml.resolver.SchemaResolver;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.ext.EntityResolver2;
@@ -44,7 +54,7 @@ import org.xml.sax.ext.EntityResolver2;
  * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
  */
 public class AppSchemaValidator {
-
+    public static Logger LOGGER = Logging.getLogger(AppSchemaValidator.class);
     /**
      * Pattern matching a string that starts with an XML declaration with an encoding, with a single group that contains
      * the encoding.
@@ -109,20 +119,34 @@ public class AppSchemaValidator {
      * @param input stream from which XML instance document is read
      */
     public void parse(InputStream input) {
-        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        // Use Entity Resolver backed by SchemaResolver
+        AppSchemaEntityResolver appSchmeaEntityResolver = new AppSchemaEntityResolver(GeoTools.getDefaultHints());
+
+        Hints hints = GeoTools.addDefaultHints(new Hints(Hints.ENTITY_RESOLVER, appSchmeaEntityResolver));
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory(hints);
         parserFactory.setNamespaceAware(true);
         parserFactory.setValidating(true);
+        try {
+            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+            LOGGER.fine(
+                    "Parser does not support feature " + XMLConstants.ACCESS_EXTERNAL_SCHEMA + ": " + e.getMessage());
+        }
         XMLReader xmlReader;
         try {
-            SAXParser parser = parserFactory.newSAXParser();
+            SAXParser parser = XMLUtils.newSAXParser(parserFactory, hints);
             // Validation is against XML Schema
             parser.setProperty(
                     "http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");
+            if (parser.getXMLReader().getEntityResolver() != null) {
+                // only allow access to external schema when entity resolver in use
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+            }
             xmlReader = parser.getXMLReader();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        xmlReader.setEntityResolver(new AppSchemaEntityResolver());
+        xmlReader.setEntityResolver(appSchmeaEntityResolver);
         // We principally care about the failures themselves, but it is also possible to install a
         // ContentHandler to output annotated XML that identifies the precise location of failures.
         // That can be done with a serializer that implements both ContentHandler and ErrorHandler.
@@ -271,6 +295,11 @@ public class AppSchemaValidator {
      * (that is, XML schemas).
      */
     private class AppSchemaEntityResolver implements EntityResolver2 {
+        EntityResolver entityResolver;
+
+        public AppSchemaEntityResolver(Hints hints) {
+            this.entityResolver = GeoTools.getEntityResolver(hints);
+        }
 
         /**
          * Always throws {@link UnsupportedOperationException}. The {@link EntityResolver2} interface must be used so
@@ -285,12 +314,14 @@ public class AppSchemaValidator {
                     + "so that relative URLs are resolved correctly");
         }
         /**
-         * Always returns null to indicate that there is no external subset.
+         * Delegate to library entity resolver, or {@code null} to indicate that there is no external subset.
          *
          * @see org.xml.sax.ext.EntityResolver2#getExternalSubset(java.lang.String, java.lang.String)
          */
         @Override
-        public InputSource getExternalSubset(String name, String baseURI) {
+        public InputSource getExternalSubset(String name, String baseURI) throws SAXException, IOException {
+            if (entityResolver instanceof EntityResolver2 entityResolver2)
+                return entityResolver2.getExternalSubset(name, baseURI);
             return null;
         }
 
@@ -308,6 +339,15 @@ public class AppSchemaValidator {
         public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId)
                 throws SAXException, IOException {
             return new InputSource(resolver.resolve(systemId, baseURI));
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                    .append("AppSchemaEntityResolver {")
+                    .append(resolver)
+                    .append("}")
+                    .toString();
         }
     }
 

--- a/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/appschema/resolver/xml/AppSchemaConfigurationTest.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/appschema/resolver/xml/AppSchemaConfigurationTest.java
@@ -25,7 +25,9 @@ import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
 import org.eclipse.xsd.XSDSchema;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.resolver.SchemaCache;
 import org.geotools.xml.resolver.SchemaCatalog;
 import org.geotools.xml.resolver.SchemaResolver;
@@ -63,6 +65,7 @@ public class AppSchemaConfigurationTest {
     /** Hack the log level so we can see schemas loading. */
     @Before
     public void before() {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         if (ADJUST_LOGLEVEL) {
             logLevel = LOGGER.getLevel();
             LOGGER.setLevel(LOGLEVEL);
@@ -78,6 +81,7 @@ public class AppSchemaConfigurationTest {
             getRootLogHandler().setLevel(rootLogLevel);
             LOGGER.setLevel(logLevel);
         }
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     /** Return the root log handler, needed to hack the log level. */

--- a/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/appschema/resolver/xml/AppSchemaValidatorTest.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/appschema/resolver/xml/AppSchemaValidatorTest.java
@@ -20,7 +20,12 @@ package org.geotools.appschema.resolver.xml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.geotools.util.DefaultEntityResolver;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -29,6 +34,15 @@ import org.junit.Test;
  * @author Ben Caradoc-Davies (CSIRO Earth Science and Resource Engineering)
  */
 public class AppSchemaValidatorTest {
+    @Before
+    public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, DefaultEntityResolver.INSTANCE);
+    }
 
     /** Test that validation succeeds for a known-valid XML instance document. */
     @Test

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/NestedAttributeMapping.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/complex/NestedAttributeMapping.java
@@ -364,8 +364,7 @@ public class NestedAttributeMapping extends AttributeMapping {
             selectedProperties.add(propertyName);
         }
 
-        final Hints hints = new Hints();
-        hints.put(Query.INCLUDE_MANDATORY_PROPS, includeMandatory);
+        final Hints hints = new Hints(Query.INCLUDE_MANDATORY_PROPS, includeMandatory);
 
         if (resolveDepth > 0) {
             hints.put(Hints.RESOLVE, ResolveValueType.ALL);

--- a/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/joining/JoiningNestedAttributeMapping.java
+++ b/modules/extension/app-schema/app-schema/src/main/java/org/geotools/data/joining/JoiningNestedAttributeMapping.java
@@ -182,8 +182,7 @@ public class JoiningNestedAttributeMapping extends NestedAttributeMapping {
             selectedProperties.add(filterFac.property(this.nestedTargetXPath.toString()));
         }
 
-        final Hints hints = new Hints();
-        hints.put(Query.INCLUDE_MANDATORY_PROPS, includeMandatory);
+        final Hints hints = new Hints(Query.INCLUDE_MANDATORY_PROPS, includeMandatory);
 
         if (resolveDepth > 0) {
             hints.put(Hints.RESOLVE, ResolveValueType.ALL);

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/XlinkMissingNamespaceTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/data/complex/XlinkMissingNamespaceTest.java
@@ -26,6 +26,8 @@ import org.geotools.data.complex.config.AppSchemaDataAccessConfigurator;
 import org.geotools.data.complex.config.AppSchemaDataAccessDTO;
 import org.geotools.data.complex.config.XMLConfigDigester;
 import org.geotools.test.AppSchemaTestSupport;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.junit.Test;
 
 /**
@@ -43,6 +45,7 @@ public class XlinkMissingNamespaceTest extends AppSchemaTestSupport {
     @Test
     public void testGetClientProperties() throws IOException {
         try {
+            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
             XMLConfigDigester reader = new XMLConfigDigester();
 
             URL url = getClass().getResource("/test-data/MappedFeatureMissingNamespaceXlink.xml");
@@ -52,6 +55,8 @@ public class XlinkMissingNamespaceTest extends AppSchemaTestSupport {
 
         } catch (Exception ex) {
             assertSame(java.io.IOException.class, ex.getClass());
+        } finally {
+            Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
         }
     }
 }

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/http/HttpConfigTest.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/http/HttpConfigTest.java
@@ -35,6 +35,8 @@ import org.geotools.api.feature.type.Name;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.complex.AppSchemaDataAccess;
 import org.geotools.feature.NameImpl;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.resolver.SchemaCache;
 import org.junit.AfterClass;
 import org.junit.Assume;
@@ -54,6 +56,9 @@ public final class HttpConfigTest {
 
     @BeforeClass
     public static void setup() {
+        // ALlow access to local files for testing
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+
         // will fail on GitHub linux build, due to TCP port opening. Tests depending on it
         // will have to be skipped with the same variable
         if (LINUX_GITHUB_BUILD) return;
@@ -78,6 +83,7 @@ public final class HttpConfigTest {
             // remove the test schema cache
             FileUtils.deleteQuietly(APP_SCHEMA_CACHE_DIR);
         }
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     @Test

--- a/modules/extension/app-schema/app-schema/src/test/java/org/geotools/test/AppSchemaTestSupport.java
+++ b/modules/extension/app-schema/app-schema/src/test/java/org/geotools/test/AppSchemaTestSupport.java
@@ -20,13 +20,24 @@ package org.geotools.test;
 import org.geotools.appschema.resolver.xml.AppSchemaXSDRegistry;
 import org.geotools.data.complex.AppSchemaDataAccessRegistry;
 import org.geotools.data.complex.DataAccessRegistry;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 /** @author Niels Charlier (Curtin University of Technology) */
 public class AppSchemaTestSupport {
 
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
     @AfterClass
     public static void oneTimeTearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         DataAccessRegistry.unregisterAndDisposeAll();
         AppSchemaDataAccessRegistry.clearAppSchemaProperties();
         AppSchemaXSDRegistry.getInstance().dispose();

--- a/modules/extension/brewer/src/main/java/org/geotools/brewer/color/ColorBrewer.java
+++ b/modules/extension/brewer/src/main/java/org/geotools/brewer/color/ColorBrewer.java
@@ -30,8 +30,8 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -296,8 +296,8 @@ public class ColorBrewer {
 
     private void load(InputStream stream, PaletteType type) {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = XMLUtils.newDocumentBuilder();
+
             Document document = builder.parse(stream);
             this.name = fixToString(document.getElementsByTagName("name")
                     .item(0)

--- a/modules/extension/complex/src/main/java/org/geotools/data/complex/util/EmfComplexFeatureReader.java
+++ b/modules/extension/complex/src/main/java/org/geotools/data/complex/util/EmfComplexFeatureReader.java
@@ -27,6 +27,7 @@ import javax.xml.stream.XMLStreamReader;
 import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.AttributeType;
 import org.geotools.appschema.resolver.xml.AppSchemaConfiguration;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xml.resolver.SchemaCatalog;
 import org.geotools.xml.resolver.SchemaResolver;
 import org.geotools.xsd.Binding;
@@ -125,7 +126,7 @@ public class EmfComplexFeatureReader {
         // create stream parser
 
         try (InputStream input = resolvedLocation.openStream()) {
-            XMLInputFactory factory = XMLInputFactory.newFactory();
+            XMLInputFactory factory = XMLUtils.newXMLInputFactory();
             // disable DTDs
             factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             // disable external entities

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WMTSTestUtils.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/WMTSTestUtils.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import net.opengis.wmts.v_1.CapabilitiesType;
 import org.geotools.ows.wmts.model.WMTSCapabilities;
 import org.geotools.test.TestData;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.wmts.WMTSConfiguration;
 import org.geotools.xsd.Parser;
 
@@ -36,6 +37,7 @@ public class WMTSTestUtils {
         assertNotNull(getCaps);
 
         Parser parser = new Parser(new WMTSConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
 
         Object object = parser.parse(new FileReader(getCaps, StandardCharsets.UTF_8));
         assertTrue("Capabilities failed to parse " + object.getClass(), object instanceof CapabilitiesType);

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/client/WMTSTileFactory4326Test.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/client/WMTSTileFactory4326Test.java
@@ -39,6 +39,7 @@ import org.geotools.tile.Tile.RenderState;
 import org.geotools.tile.TileIdentifier;
 import org.geotools.tile.TileService;
 import org.geotools.tile.impl.WebMercatorZoomLevel;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.wmts.WMTSConfiguration;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -288,6 +289,7 @@ public class WMTSTileFactory4326Test {
 
     public static WMTSCapabilities createCapabilities(File capFile) throws Exception {
         Parser parser = new Parser(new WMTSConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
 
         Object object = parser.parse(new FileReader(capFile, StandardCharsets.UTF_8));
         assertTrue("Capabilities failed to parse " + object.getClass(), object instanceof CapabilitiesType);

--- a/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
+++ b/modules/extension/wmts/src/test/java/org/geotools/ows/wmts/map/WMTSCoverageReaderTest.java
@@ -60,6 +60,7 @@ import org.geotools.parameter.Parameter;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.tile.Tile;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.wmts.WMTSConfiguration;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
@@ -270,7 +271,7 @@ public class WMTSCoverageReaderTest {
         Object object;
         try (InputStream inputStream = new FileInputStream(capa)) {
             Parser parser = new Parser(new WMTSConfiguration());
-
+            parser.setEntityResolver(NullEntityResolver.INSTANCE);
             object = parser.parse(new InputSource(inputStream));
 
         } catch (SAXException | ParserConfigurationException | IOException e) {

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/DOMParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/DOMParser.java
@@ -22,11 +22,15 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXResult;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.impl.ParserHandler;
 import org.w3c.dom.Document;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.SAXException;
 
 /**
@@ -40,6 +44,7 @@ import org.xml.sax.SAXException;
 public class DOMParser {
     Configuration configuration;
     Document document;
+    EntityResolver entityResolver = null;
     ParserHandler handler;
 
     /**
@@ -49,8 +54,21 @@ public class DOMParser {
      * @param document An xml document.
      */
     public DOMParser(Configuration configuration, Document document) {
+        this(configuration, document, null);
+    }
+
+    /**
+     * Creates a new instance of the parser.
+     *
+     * @param configuration Object representing the configuration of the parser.
+     * @param document An xml document.
+     * @param entityResolver An entity resolver to use when parsing the document, or {@code null} to use the default
+     *     one.
+     */
+    public DOMParser(Configuration configuration, Document document, EntityResolver entityResolver) {
         this.configuration = configuration;
         this.document = document;
+        this.entityResolver = entityResolver;
     }
 
     /**
@@ -62,21 +80,27 @@ public class DOMParser {
         // Prepare the DOM source
         Source source = new DOMSource(document);
 
+        // "Parser" traverses Document issuing SAX events (fake as document has already been parsed)
         Parser fake = new Parser(configuration);
+        if (entityResolver != null) {
+            Hints hints = new Hints();
+            hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+
+            fake.setEntityResolver(GeoTools.getEntityResolver(hints));
+        } else {
+            fake.setEntityResolver(GeoTools.getEntityResolver(null));
+        }
 
         // Create the handler to handle the SAX events
         handler = fake.getParserHandler();
-
         try {
             // Prepare the result
             SAXResult result = new SAXResult(handler);
             // add lexical handler to spot CDATA
             result.setLexicalHandler(handler);
 
-            TransformerFactory xformerFactory = TransformerFactory.newInstance();
-
             // Create a transformer
-            Transformer xformer = xformerFactory.newTransformer();
+            Transformer xformer = XMLUtils.newTransformer();
 
             // Traverse the DOM tree
             xformer.transform(source, result);

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/DOMParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/DOMParser.java
@@ -83,8 +83,7 @@ public class DOMParser {
         // "Parser" traverses Document issuing SAX events (fake as document has already been parsed)
         Parser fake = new Parser(configuration);
         if (entityResolver != null) {
-            Hints hints = new Hints();
-            hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+            Hints hints = new Hints(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
 
             fake.setEntityResolver(GeoTools.getEntityResolver(hints));
         } else {

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Encoder.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Encoder.java
@@ -43,7 +43,6 @@ import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
@@ -1103,7 +1102,8 @@ public class Encoder {
 
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
         DOMResult result = new DOMResult();
-        Transformer tx = TransformerFactory.newInstance().newTransformer();
+
+        Transformer tx = XMLUtils.newTransformer(null);
         tx.transform(new StreamSource(in), result);
         return (Document) result.getNode();
     }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Encoder.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Encoder.java
@@ -37,7 +37,6 @@ import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -611,12 +610,10 @@ public class Encoder {
             }
 
             // create the document
-            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-
             try {
-                doc = docFactory.newDocumentBuilder().newDocument();
+                doc = XMLUtils.newDocumentBuilder().newDocument();
             } catch (ParserConfigurationException e) {
-                new IOException().initCause(e);
+                throw new IOException("Unable to create document", e);
             }
 
             encoded = new Stack<>();

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Encoder.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Encoder.java
@@ -521,7 +521,7 @@ public class Encoder {
         }
 
         // create the document serializer
-        SAXTransformerFactory txFactory = (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+        SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
 
         TransformerHandler xmls;
         try {
@@ -1100,7 +1100,7 @@ public class Encoder {
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
         DOMResult result = new DOMResult();
 
-        Transformer tx = XMLUtils.newTransformer(null);
+        Transformer tx = XMLUtils.newTransformer();
         tx.transform(new StreamSource(in), result);
         return (Document) result.getNode();
     }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -31,11 +32,14 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import org.eclipse.emf.ecore.resource.URIHandler;
 import org.eclipse.xsd.XSDSchema;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.impl.ParserHandler;
 import org.geotools.xsd.impl.ParserHandler.ContextCustomizer;
@@ -77,9 +81,6 @@ public class Parser {
 
     /** sax handler which maintains the element stack */
     private ParserHandler handler;
-
-    /** the sax parser driving the handler */
-    private SAXParser parser;
 
     /** Entity expansion limit configuration, set to null by default */
     private Integer entityExpansionLimit;
@@ -152,10 +153,10 @@ public class Parser {
         // TODO: use SAXResult to stream, need to figure out how to enable
         // validation with transformer api
         // SAXResult result = new SAXResult( handler );
-        StreamResult result = new StreamResult(new ByteArrayOutputStream());
 
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Transformer tx = tf.newTransformer();
+        StreamResult result = new StreamResult(new ByteArrayOutputStream());
+        Transformer tx = XMLUtils.newTransformer();
+        SAXSource saxSource = XMLUtils.sourceToInputSource(source, null);
 
         tx.transform(source, result);
 
@@ -171,7 +172,7 @@ public class Parser {
      * @return The object representation of the root element of the document.
      */
     public Object parse(InputSource source) throws IOException, SAXException, ParserConfigurationException {
-        parser = parser();
+        SAXParser parser = parser();
 
         parser.parse(source, handler);
 
@@ -411,7 +412,12 @@ public class Parser {
     protected SAXParser parser(boolean validate) throws ParserConfigurationException, SAXException {
         // JD: we use xerces directly here because jaxp does seem to allow use to
         // override all the namespaces to validate against
-        SAXParserFactory pFactory = SAXParserFactory.newInstance();
+
+        Hints hints = GeoTools.getDefaultHints();
+        if (getEntityResolver() != null) {
+            hints.put(Hints.ENTITY_RESOLVER, getEntityResolver());
+        }
+        SAXParserFactory pFactory = XMLUtils.newSAXParserFactory(hints);
 
         // set the appropriate features
         pFactory.setFeature("http://xml.org/sax/features/namespaces", true);
@@ -421,8 +427,16 @@ public class Parser {
             pFactory.setFeature("http://apache.org/xml/features/validation/schema", true);
             pFactory.setFeature("http://apache.org/xml/features/validation/schema-full-checking", true);
         }
-
         SAXParser parser = pFactory.newSAXParser();
+        if (parser.getXMLReader().getEntityResolver() != getEntityResolver()) {
+            LOGGER.fine("Force entity resolver if required:" + getEntityResolver());
+            parser.getXMLReader().setEntityResolver(getEntityResolver());
+        }
+
+        if (parser.getXMLReader().getEntityResolver() != null) {
+            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+        }
 
         // set the schema sources of this configuration, and all dependent ones
         StringBuffer schemaLocation = new StringBuffer();
@@ -452,8 +466,7 @@ public class Parser {
         // set Entity expansion limit
         setupEntityExpansionLimit(parser);
 
-        //
-        // return builded parser
+        // return built parser
         return parser;
     }
 

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -92,11 +92,20 @@ public class Parser {
      *     </code>.
      */
     public Parser(Configuration configuration) {
+        this(configuration, GeoTools.getEntityResolver(null));
+    }
+    /**
+     * Creates a new instance of the parser.
+     *
+     * @param configuration The parser configuration, bindings and context, must never be {@code }null}
+     * @param entityResolver EntityResolver used to allow access to xsd assets during parsing
+     */
+    public Parser(Configuration configuration, EntityResolver entityResolver) {
         if (configuration == null) {
             throw new NullPointerException("configuration");
         }
-
         handler = new ParserHandler(configuration);
+        handler.setEntityResolver(entityResolver);
 
         configuration.setupParser(this);
     }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -32,7 +32,6 @@ import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.Source;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import org.eclipse.emf.ecore.resource.URIHandler;
 import org.eclipse.xsd.XSDSchema;
@@ -146,28 +145,25 @@ public class Parser {
 
     /**
      * Parses an instance document defined by a transformer source.
-     * <p>
-     * Note: Currently this method reads the entire source into memory in order to validate
-     * it. If large documents must be parsed one of {@link #
-     * </p>
+     *
+     * <p>Note: Currently this method reads the entire source into memory in order to validate it. If large documents
+     * must be parsed one of the other parse methods should be used instead.
+     *
      * @param source THe source of the instance document.
-     *
      * @return @return The object representation of the root element of the document.
-     *
-     *
      * @since 2.6
      */
     public Object parse(Source source)
             throws IOException, SAXException, ParserConfigurationException, TransformerException {
-        // TODO: use SAXResult to stream, need to figure out how to enable
-        // validation with transformer api
+
+        // TODO: use SAXResult to stream, need to figure out how to enable validation with transformer api
         // SAXResult result = new SAXResult( handler );
 
         StreamResult result = new StreamResult(new ByteArrayOutputStream());
         Transformer tx = XMLUtils.newTransformer();
-        SAXSource saxSource = XMLUtils.sourceToInputSource(source, null);
 
-        tx.transform(saxSource, result);
+        Source checkedSource = XMLUtils.source(source, null);
+        tx.transform(checkedSource, result);
 
         return parse(new ByteArrayInputStream(((ByteArrayOutputStream) result.getOutputStream()).toByteArray()));
     }
@@ -443,8 +439,16 @@ public class Parser {
         }
 
         if (parser.getXMLReader().getEntityResolver() != null) {
-            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
-            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+            try {
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+            }
+            try {
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+            }
         }
 
         // set the schema sources of this configuration, and all dependent ones

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -167,7 +167,7 @@ public class Parser {
         Transformer tx = XMLUtils.newTransformer();
         SAXSource saxSource = XMLUtils.sourceToInputSource(source, null);
 
-        tx.transform(source, result);
+        tx.transform(saxSource, result);
 
         return parse(new ByteArrayInputStream(((ByteArrayOutputStream) result.getOutputStream()).toByteArray()));
     }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
@@ -141,7 +141,7 @@ public class PullParser {
     }
 
     XMLStreamReader createPullParser(InputStream input) {
-        XMLInputFactory factory = XMLInputFactory.newInstance();//XMLUtils.newXMLInputFactory();
+        XMLInputFactory factory = XMLUtils.newXMLInputFactory();
         factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
         factory.setProperty(XMLInputFactory.IS_VALIDATING, false);
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
@@ -26,6 +26,8 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import org.eclipse.emf.ecore.resource.URIHandler;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.impl.ElementHandler;
 import org.geotools.xsd.impl.NodeImpl;
 import org.geotools.xsd.impl.ParserHandler;
@@ -60,6 +62,7 @@ public class PullParser {
 
     public PullParser(Configuration config, InputStream input, PullParserHandler handler) {
         this.handler = handler;
+        this.handler.setEntityResolver(GeoTools.getEntityResolver(null));
         pp = createPullParser(input);
     }
 
@@ -138,12 +141,10 @@ public class PullParser {
     }
 
     XMLStreamReader createPullParser(InputStream input) {
-        XMLInputFactory factory = XMLInputFactory.newInstance();
+        XMLInputFactory factory = XMLInputFactory.newInstance();//XMLUtils.newXMLInputFactory();
         factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
         factory.setProperty(XMLInputFactory.IS_VALIDATING, false);
-        // disable DTDs
         factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-        // disable external entities
         factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         try {
             return factory.createXMLStreamReader(input);

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -82,6 +83,9 @@ import org.eclipse.xsd.util.XSDUtil;
 import org.geotools.util.DefaultEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.util.Utilities;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.impl.SchemaIndexImpl;
 import org.geotools.xsd.impl.TypeWalker;
 import org.picocontainer.ComponentAdapter;
@@ -535,25 +539,34 @@ public class Schemas {
         if (resolvers == null) resolvers = Collections.emptyList();
 
         // create a parser
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        Hints hints = GeoTools.getDefaultHints();
+        if (entityResolver != null) {
+            hints.put(Hints.ENTITY_RESOLVER, entityResolver);
+        }
+
+        SAXParserFactory factory;
+        factory = XMLUtils.newSAXParserFactory(hints);
+
         factory.setNamespaceAware(true);
         factory.setValidating(false);
-
         SAXParser parser = null;
         try {
             parser = factory.newSAXParser();
+
         } catch (Exception e) {
             throw (IOException) new IOException("could not create parser").initCause(e);
         }
 
-        if (entityResolver != null) {
-            try {
-                parser.getXMLReader().setEntityResolver(entityResolver);
-            } catch (SAXException e) {
-                throw new IOException(e);
+        try {
+            // XMLUtils has configured parser entity resolver provided by Hints
+            entityResolver = parser.getXMLReader().getEntityResolver();
+            if (entityResolver != null) {
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
             }
+        } catch (SAXException e) {
+            throw new IOException(e);
         }
-
         SchemaImportIncludeValidator validator = new SchemaImportIncludeValidator(locators, resolvers, entityResolver);
 
         // queue of files to parse

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
@@ -97,6 +97,7 @@ import org.xml.sax.Attributes;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -158,21 +159,24 @@ public class Schemas {
 
             String namespaceURI = conf.getNamespaceURI();
             String schemaLocation = null;
-
-            // first check if entity resolver would allow reading the schema location
-            if (entityResolver != null) {
-                try {
-                    entityResolver.resolveEntity(null, conf.getXSD().getSchemaLocation());
-                } catch (IOException | SAXException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-
             try {
                 URL location = new URL(conf.getXSD().getSchemaLocation());
                 schemaLocation = location.toExternalForm();
             } catch (MalformedURLException e) {
                 throw new RuntimeException(e);
+            }
+
+            // first check if entity resolver would allow reading the schema location
+            if (entityResolver != null) {
+                try {
+                    if (entityResolver instanceof EntityResolver2 entityResolver2) {
+                        entityResolver2.resolveEntity(null, null, null, schemaLocation);
+                    } else {
+                        entityResolver.resolveEntity(null, schemaLocation);
+                    }
+                } catch (IOException | SAXException e) {
+                    throw new RuntimeException(e);
+                }
             }
 
             if (LOGGER.isLoggable(Level.FINE)) {

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
@@ -561,8 +561,16 @@ public class Schemas {
             // XMLUtils has configured parser entity resolver provided by Hints
             entityResolver = parser.getXMLReader().getEntityResolver();
             if (entityResolver != null) {
-                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
-                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+                try {
+                    parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+                } catch (IllegalArgumentException notSupported) {
+                    LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+                }
+                try {
+                    parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+                } catch (IllegalArgumentException notSupported) {
+                    LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+                }
             }
         } catch (SAXException e) {
             throw new IOException(e);

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
@@ -128,7 +128,7 @@ public class Schemas {
      * @return a {@link SchemaIndex} holding the schemas related to <code>configuration</code>
      */
     public static final SchemaIndex findSchemas(Configuration configuration) {
-        return findSchemas(configuration, null);
+        return findSchemas(configuration, GeoTools.getEntityResolver(null));
     }
     /**
      * Finds all the XSDSchemas used by the {@link Configuration configuration} by looking at the configuration's schema
@@ -241,7 +241,7 @@ public class Schemas {
     public static final XSDSchema parse(
             String location, List<XSDSchemaLocator> locators, List<XSDSchemaLocationResolver> resolvers)
             throws IOException {
-        return parse(location, locators, resolvers, emptyList(), null);
+        return parse(location, locators, resolvers, emptyList(), GeoTools.getEntityResolver(null));
     }
 
     /**
@@ -337,7 +337,6 @@ public class Schemas {
             } catch (SAXException e) {
                 throw new IOException(e);
             }
-
             options.put(XSDResourceImpl.XSD_JAXP_CONFIG, new DefaultJAXPConfiguration() {
 
                 @Override

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/StreamingParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/StreamingParser.java
@@ -18,10 +18,13 @@ package org.geotools.xsd;
 
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
+import java.util.logging.Logger;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.impl.ElementNameStreamingParserHandler;
 import org.geotools.xsd.impl.StreamingParserHandler;
 import org.geotools.xsd.impl.TypeStreamingParserHandler;
@@ -122,6 +125,8 @@ import org.xml.sax.SAXException;
  * @author Justin Deoliveira, The Open Planning Project
  */
 public class StreamingParser {
+    public static Logger LOGGER = Logging.getLogger(StreamingParser.class.getName());
+
     /** The sax driver / handler. */
     private StreamingParserHandler handler;
 
@@ -190,7 +195,7 @@ public class StreamingParser {
             c = clazz.getConstructor(new Class[] {Configuration.class, String.class});
             return (StreamingParserHandler) c.newInstance(new Object[] {configuration, xpath});
         } catch (Exception e) {
-            // shoudl not happen
+            // should not happen
             throw new RuntimeException(e);
         }
 
@@ -200,9 +205,9 @@ public class StreamingParser {
     /** Internal constructor. */
     protected StreamingParser(Configuration configuration, InputStream input, StreamingParserHandler handler)
             throws ParserConfigurationException, SAXException {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        parser = spf.newSAXParser();
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        this.parser = XMLUtils.newSAXParser(parserFactory);
 
         this.handler = handler;
         this.input = input;
@@ -210,6 +215,11 @@ public class StreamingParser {
 
     public void setEntityResolver(EntityResolver entityResolver) {
         handler.setEntityResolver(entityResolver);
+        try {
+            parser.getXMLReader().setEntityResolver(entityResolver);
+        } catch (SAXException e) {
+            LOGGER.fine("Unable to set entity resolver on parser: " + e.getMessage());
+        }
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/impl/ParserHandler.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/impl/ParserHandler.java
@@ -588,7 +588,7 @@ public class ParserHandler extends DefaultHandler2 {
                         } catch (Exception e) {
                             String msg =
                                     "Error loading schema for namespace: " + namespace + " at location: " + location;
-                            logger.warning(msg);
+                            logger.log(Level.WARNING,msg,e);
 
                             if (isStrict()) {
                                 // strict mode, throw exception

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/impl/ParserHandler.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/impl/ParserHandler.java
@@ -588,7 +588,7 @@ public class ParserHandler extends DefaultHandler2 {
                         } catch (Exception e) {
                             String msg =
                                     "Error loading schema for namespace: " + namespace + " at location: " + location;
-                            logger.log(Level.WARNING,msg,e);
+                            logger.log(Level.WARNING, msg, e);
 
                             if (isStrict()) {
                                 // strict mode, throw exception

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/TestSchema.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/TestSchema.java
@@ -33,7 +33,9 @@ import org.eclipse.xsd.XSDFactory;
 import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.XSDSimpleTypeDefinition;
 import org.eclipse.xsd.util.XSDParser;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.Hints;
 import org.geotools.xsd.Binding;
 import org.geotools.xsd.ElementInstance;
 import org.geotools.xsd.Schemas;
@@ -41,6 +43,7 @@ import org.geotools.xsd.SimpleBinding;
 import org.geotools.xsd.impl.BindingLoader;
 import org.geotools.xsd.impl.ElementImpl;
 import org.geotools.xsd.impl.PicoMap;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,9 +59,12 @@ public abstract class TestSchema {
         url = TestSchema.class.getResource("sample.xsd");
 
         try {
+            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
             schema = Schemas.parse(url.toString());
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
         }
 
         xsd = schema.getSchemaForSchema();
@@ -177,14 +183,18 @@ public abstract class TestSchema {
 
     @Before
     public void setUp() throws Exception {
-        // TODO Auto-generated method stub
-
         qname = getQName();
 
         if (qname != null) {
             typeDef = xsdSimple(qname.getLocalPart());
             strategy = (SimpleBinding) stratagy(qname);
         }
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     @Test

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDateTimeStrategyTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSDateTimeStrategyTest.java
@@ -24,7 +24,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilderFactory;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xs.TestSchema;
 import org.geotools.xs.XS;
 import org.geotools.xs.XSConfiguration;
@@ -196,9 +196,7 @@ public class XSDateTimeStrategyTest extends TestSchema {
 
         encoder.encode(cal, qname, out);
 
-        Document dom = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder()
-                .parse(new ByteArrayInputStream(out.toByteArray()));
+        Document dom = XMLUtils.newDocumentBuilder().parse(new ByteArrayInputStream(out.toByteArray()));
 
         String encodedValue = dom.getDocumentElement().getTextContent();
 

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSUnsignedBindingsTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xs/bindings/XSUnsignedBindingsTest.java
@@ -24,6 +24,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.xs.TestSchema;
 import org.geotools.xs.XSConfiguration;
@@ -40,6 +41,7 @@ public class XSUnsignedBindingsTest {
     public void setUp() throws Exception {
         XSConfiguration xs = new XSConfiguration();
         p = new Parser(xs);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
     }
 
     @Test

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/FacetTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/FacetTest.java
@@ -19,12 +19,14 @@ package org.geotools.xsd;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xs.XSConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
 public class FacetTest {
+
     @Test
     public void testList() throws Exception {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -39,7 +41,7 @@ public class FacetTest {
         doc.getDocumentElement()
                 .setAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation", schemaLocation);
 
-        DOMParser parser = new DOMParser(new XSConfiguration(), doc);
+        DOMParser parser = new DOMParser(new XSConfiguration(), doc, NullEntityResolver.INSTANCE);
         Object o = parser.parse();
         Assert.assertTrue(o instanceof List);
 
@@ -65,7 +67,7 @@ public class FacetTest {
         doc.getDocumentElement()
                 .setAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation", schemaLocation);
 
-        DOMParser parser = new DOMParser(new XSConfiguration(), doc);
+        DOMParser parser = new DOMParser(new XSConfiguration(), doc, NullEntityResolver.INSTANCE);
         String s = (String) parser.parse();
 
         Assert.assertEquals("this is a normal string with some whitespace and some new lines", s);
@@ -85,7 +87,7 @@ public class FacetTest {
         doc.getDocumentElement()
                 .setAttributeNS("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation", schemaLocation);
 
-        DOMParser parser = new DOMParser(new XSConfiguration(), doc);
+        DOMParser parser = new DOMParser(new XSConfiguration(), doc, NullEntityResolver.INSTANCE);
         String s = (String) parser.parse();
 
         Assert.assertEquals(" this is a \n normal string \n with some whitespace and \n some new lines", s);

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/FacetTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/FacetTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xs.XSConfiguration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,7 +33,7 @@ public class FacetTest {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document doc = db.parse(getClass().getResourceAsStream("list.xml"));
 
         String schemaLocation = "http://geotools.org/test "
@@ -58,7 +59,7 @@ public class FacetTest {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document doc = db.parse(getClass().getResourceAsStream("whitespace.xml"));
 
         String schemaLocation = "http://geotools.org/test "
@@ -78,7 +79,7 @@ public class FacetTest {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         dbf.setNamespaceAware(true);
 
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document doc = db.parse(getClass().getResourceAsStream("whitespace-cdata.xml"));
 
         String schemaLocation = "http://geotools.org/test "

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/FacetTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/FacetTest.java
@@ -30,10 +30,10 @@ public class FacetTest {
 
     @Test
     public void testList() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
         dbf.setNamespaceAware(true);
 
-        DocumentBuilder db = XMLUtils.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
         Document doc = db.parse(getClass().getResourceAsStream("list.xml"));
 
         String schemaLocation = "http://geotools.org/test "
@@ -56,10 +56,10 @@ public class FacetTest {
 
     @Test
     public void testWhitespace() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
         dbf.setNamespaceAware(true);
 
-        DocumentBuilder db = XMLUtils.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
         Document doc = db.parse(getClass().getResourceAsStream("whitespace.xml"));
 
         String schemaLocation = "http://geotools.org/test "
@@ -76,10 +76,10 @@ public class FacetTest {
 
     @Test
     public void testCDATAWhitespace() throws Exception {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
         dbf.setNamespaceAware(true);
 
-        DocumentBuilder db = XMLUtils.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
         Document doc = db.parse(getClass().getResourceAsStream("whitespace-cdata.xml"));
 
         String schemaLocation = "http://geotools.org/test "

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/ParserTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/ParserTest.java
@@ -29,6 +29,7 @@ import javax.xml.namespace.QName;
 import org.geotools.ml.MLConfiguration;
 import org.geotools.ml.Mail;
 import org.geotools.ml.bindings.MLSchemaLocationResolver;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.impl.Handler;
 import org.junit.Assert;
 import org.junit.Test;
@@ -85,6 +86,7 @@ public class ParserTest {
     public void testParseValid() throws Exception {
         Parser parser = new Parser(new MLConfiguration());
         parser.setValidating(true);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         parser.parse(MLSchemaLocationResolver.class.getResourceAsStream("mails.xml"));
 
         Assert.assertEquals(0, parser.getValidationErrors().size());
@@ -94,6 +96,7 @@ public class ParserTest {
     public void testParseNull() throws Exception {
         Parser parser = new Parser(new MLConfiguration());
         parser.setValidating(true);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         List mails = (List) parser.parse(MLSchemaLocationResolver.class.getResourceAsStream("null-mail.xml"));
 
         Assert.assertEquals(0, parser.getValidationErrors().size());
@@ -107,6 +110,7 @@ public class ParserTest {
     public void testParseInValid() throws Exception {
         Parser parser = new Parser(new MLConfiguration());
         parser.setValidating(true);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         parser.parse(MLSchemaLocationResolver.class.getResourceAsStream("mails-invalid.xml"));
 
         Assert.assertNotEquals(0, parser.getValidationErrors().size());
@@ -123,6 +127,8 @@ public class ParserTest {
     @Test
     public void testValidate() throws Exception {
         Parser parser = new Parser(new MLConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
+
         parser.validate(MLSchemaLocationResolver.class.getResourceAsStream("mails-invalid.xml"));
 
         Assert.assertNotEquals(0, parser.getValidationErrors().size());
@@ -290,6 +296,7 @@ public class ParserTest {
     public void testParseWithEntityResolver() throws Exception {
         Parser parser = new Parser(new MLConfiguration());
 
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         try {
             parser.parse(MLSchemaLocationResolver.class.getResourceAsStream("mails-external-entities.xml"));
             Assert.fail("parsing should throw an exception since referenced file does not exist");

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/SchemasTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/SchemasTest.java
@@ -49,6 +49,7 @@ import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.util.XSDSchemaLocationResolver;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.PreventLocalEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.xs.XS;
 import org.geotools.xsd.impl.HTTPURIHandler;
 import org.hamcrest.CoreMatchers;
@@ -66,7 +67,7 @@ public class SchemasTest {
 
     @Before
     public void setUp() throws Exception {
-
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         tmp = File.createTempFile("schemas", "xsd");
         tmp.delete();
         tmp.mkdir();
@@ -154,7 +155,7 @@ public class SchemasTest {
         tmp.delete();
 
         System.setProperty(Schemas.FORCE_SCHEMA_IMPORT, "false");
-
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
         executorService.shutdown();
     }
 

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/SchemasTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/SchemasTest.java
@@ -16,6 +16,7 @@
  */
 package org.geotools.xsd;
 
+import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,13 +49,11 @@ import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.util.XSDSchemaLocationResolver;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.PreventLocalEntityResolver;
-import org.geotools.util.factory.Hints;
 import org.geotools.xs.XS;
 import org.geotools.xsd.impl.HTTPURIHandler;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
@@ -64,12 +63,6 @@ public class SchemasTest {
 
     File tmp, sub;
     private ExecutorService executorService = Executors.newSingleThreadExecutor();
-
-    @BeforeClass
-    public static void setupResolver() {
-        // tests need to be able to resolve local entities
-        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
-    }
 
     @Before
     public void setUp() throws Exception {
@@ -168,7 +161,7 @@ public class SchemasTest {
     @Test
     public void testValidateImportsIncludes() throws Exception {
         String location = new File(tmp, "root.xsd").getAbsolutePath();
-        List errors = Schemas.validateImportsIncludes(location);
+        List errors = Schemas.validateImportsIncludes(location, emptyList(), emptyList(), null);
         assertEquals(2, errors.size());
 
         SchemaLocationResolver resolver1 = new SchemaLocationResolver(XS.getInstance()) {

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/StreamingParserTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/StreamingParserTest.java
@@ -37,7 +37,7 @@ public class StreamingParserTest {
         StreamingParser parser = new StreamingParser(new MLConfiguration(), in, new QName(ML.NAMESPACE, "mail"));
         parser.setEntityResolver(PreventLocalEntityResolver.INSTANCE);
         // StreamingParser returns null if the parsing fails
-        assertNull(parser.parse());
+        assertNull("parsing failed", parser.parse());
     }
 
     @Test

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
@@ -33,6 +34,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.eclipse.xsd.XSDSchema;
 import org.geotools.test.xml.XmlTestSupport;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Binding;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.DOMParser;
@@ -150,10 +152,10 @@ public abstract class XMLTestSupport extends XmlTestSupport {
     /** Creates an empty xml document. */
     @Before
     public void setUp() throws Exception {
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
-        document = docFactory.newDocumentBuilder().newDocument();
+        document = docFactory.newDocumentBuilder().newDocument(); // NOPMD: AvoidDocumentBuilder
     }
 
     /**
@@ -266,10 +268,12 @@ public abstract class XMLTestSupport extends XmlTestSupport {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         encoder.encode(object, element, output);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
         dbf.setNamespaceAware(true);
 
-        return dbf.newDocumentBuilder().parse(new ByteArrayInputStream(output.toByteArray()));
+        @SuppressWarnings("PMD.AvoidDocumentBuilder")
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        return db.parse(new ByteArrayInputStream(output.toByteArray()));
     }
 
     /**
@@ -371,8 +375,9 @@ public abstract class XMLTestSupport extends XmlTestSupport {
      *
      * @param xml A string of xml
      */
+    @SuppressWarnings("PMD.AvoidDocumentBuilder")
     public void buildDocument(String xml) throws Exception {
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
         document =

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
@@ -32,6 +32,8 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.stream.StreamResult;
 import org.eclipse.xsd.XSDSchema;
 import org.geotools.test.xml.XmlTestSupport;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Binding;
 import org.geotools.xsd.Configuration;
@@ -44,6 +46,7 @@ import org.geotools.xsd.impl.BindingLoader;
 import org.geotools.xsd.impl.BindingWalkerFactoryImpl;
 import org.geotools.xsd.impl.NamespaceSupportWrapper;
 import org.geotools.xsd.impl.SchemaIndexImpl;
+import org.junit.After;
 import org.junit.Before;
 import org.picocontainer.MutablePicoContainer;
 import org.picocontainer.defaults.DefaultPicoContainer;
@@ -150,10 +153,16 @@ public abstract class XMLTestSupport extends XmlTestSupport {
     /** Creates an empty xml document. */
     @Before
     public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
         document = docFactory.newDocumentBuilder().newDocument(); // NOPMD: AvoidDocumentBuilder
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
@@ -29,7 +29,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.eclipse.xsd.XSDSchema;
@@ -289,8 +288,7 @@ public abstract class XMLTestSupport extends XmlTestSupport {
 
     /** Convenience method to dump the contents of the document to stdout. */
     public static void print(Node dom) throws Exception {
-        TransformerFactory txFactory = TransformerFactory.newInstance();
-        Transformer tx = txFactory.newTransformer();
+        Transformer tx = XMLUtils.newTransformer();
         tx.setOutputProperty(OutputKeys.INDENT, "yes");
 
         tx.transform(new DOMSource(dom), new StreamResult(System.out));

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/test/XMLTestSupport.java
@@ -29,7 +29,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.eclipse.xsd.XSDSchema;
 import org.geotools.test.xml.XmlTestSupport;
@@ -291,7 +290,7 @@ public abstract class XMLTestSupport extends XmlTestSupport {
         Transformer tx = XMLUtils.newTransformer();
         tx.setOutputProperty(OutputKeys.INDENT, "yes");
 
-        tx.transform(new DOMSource(dom), new StreamResult(System.out));
+        tx.transform(XMLUtils.source(dom), new StreamResult(System.out));
     }
 
     /**

--- a/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWCapabilitiesTest.java
+++ b/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWCapabilitiesTest.java
@@ -36,6 +36,7 @@ import org.geotools.api.filter.capability.SpatialOperators;
 import org.geotools.filter.v1_1.OGC;
 import org.geotools.gml2.GML;
 import org.geotools.test.xml.XmlTestSupport;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.EncoderDelegate;
 import org.geotools.xsd.Parser;
@@ -48,7 +49,7 @@ public class CSWCapabilitiesTest extends XmlTestSupport {
 
     private static final String RIM_NAMESPACE = "urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0";
 
-    Parser parser = new Parser(new CSWConfiguration());
+    Parser parser = new Parser(new CSWConfiguration(), NullEntityResolver.INSTANCE);
 
     @Override
     protected Map<String, String> getNamespaces() {

--- a/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWDescribeRecordTest.java
+++ b/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWDescribeRecordTest.java
@@ -4,12 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import javax.xml.namespace.QName;
 import net.opengis.cat.csw20.DescribeRecordType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class CSWDescribeRecordTest {
 
-    Parser parser = new Parser(new CSWConfiguration());
+    Parser parser = new Parser(new CSWConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseDescribeRecord() throws Exception {

--- a/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWGetRecordsTest.java
+++ b/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWGetRecordsTest.java
@@ -23,12 +23,13 @@ import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.sort.SortBy;
 import org.geotools.api.filter.sort.SortOrder;
 import org.geotools.filter.text.cql2.CQL;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class CSWGetRecordsTest {
 
-    Parser parser = new Parser(new CSWConfiguration());
+    Parser parser = new Parser(new CSWConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseGetRecordsEbrimBrief() throws Exception {

--- a/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWRecordTest.java
+++ b/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/CSWRecordTest.java
@@ -12,6 +12,7 @@ import net.opengis.cat.csw20.SimpleLiteral;
 import net.opengis.cat.csw20.SummaryRecordType;
 import net.opengis.ows10.BoundingBoxType;
 import org.eclipse.emf.common.util.EList;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.ows.OWS;
@@ -26,6 +27,7 @@ public class CSWRecordTest {
     @Before
     public void setup() {
         parser = new Parser(new CSWConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         encoder = new Encoder(new CSWConfiguration());
         encoder.getNamespaces().declarePrefix("csw", CSW.NAMESPACE);
         encoder.getNamespaces().declarePrefix("dc", DC.NAMESPACE);

--- a/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/GetDomainTest.java
+++ b/modules/extension/xsd/xsd-csw/src/test/java/org/geotools/csw/GetDomainTest.java
@@ -3,11 +3,12 @@ package org.geotools.csw;
 import static org.junit.Assert.assertEquals;
 
 import net.opengis.cat.csw20.GetDomainType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class GetDomainTest {
-    Parser parser = new Parser(new CSWConfiguration());
+    Parser parser = new Parser(new CSWConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseGetDomainParameter() throws Exception {

--- a/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/FESFilterTest.java
+++ b/modules/extension/xsd/xsd-fes/src/test/java/org/geotools/filter/v2_0/bindings/FESFilterTest.java
@@ -27,10 +27,12 @@ import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.PropertyIsLike;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.v2_0.FESTestSupport;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Encoder;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
+@SuppressWarnings("PMD.AvoidDocumentBuilder")
 public class FESFilterTest extends FESTestSupport {
     @Test
     public void testEncodePropertyIsLike() throws Exception {
@@ -41,9 +43,8 @@ public class FESFilterTest extends FESTestSupport {
         Encoder encoder = new Encoder(configuration);
         encoder.encode(filter, org.geotools.filter.v2_0.FES.Filter, os);
 
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
-
         Document doc = docFactory.newDocumentBuilder().parse(new ByteArrayInputStream(os.toByteArray()));
 
         assertEquals(1, doc.getElementsByTagName("fes:PropertyIsLike").getLength());
@@ -60,7 +61,7 @@ public class FESFilterTest extends FESTestSupport {
         Encoder encoder = new Encoder(configuration);
         encoder.encode(filter, org.geotools.filter.v2_0.FES.Filter, os);
 
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
         Document doc = docFactory.newDocumentBuilder().parse(new ByteArrayInputStream(os.toByteArray()));

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCFilterTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCFilterTest.java
@@ -34,6 +34,7 @@ import org.geotools.api.filter.expression.PropertyName;
 import org.geotools.api.filter.spatial.DWithin;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -57,10 +58,10 @@ public class OGCFilterTest {
             output.flush();
         }
 
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
-        Document doc = docFactory.newDocumentBuilder().parse(file);
+        Document doc = docFactory.newDocumentBuilder().parse(file); // NOPMD: AvoidDocumentBuilder
 
         Assert.assertEquals("ogc:PropertyIsEqualTo", doc.getDocumentElement().getNodeName());
         Assert.assertEquals(1, doc.getElementsByTagName("ogc:PropertyName").getLength());

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCFilterTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCFilterTest.java
@@ -33,6 +33,7 @@ import org.geotools.api.filter.expression.Literal;
 import org.geotools.api.filter.expression.PropertyName;
 import org.geotools.api.filter.spatial.DWithin;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -182,6 +183,7 @@ public class OGCFilterTest {
                 + "</ogc:Filter>";
 
         Parser p = new Parser(new OGCConfiguration());
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         p.validate(new StringReader(xml));
 
         Assert.assertTrue(p.getValidationErrors().isEmpty());

--- a/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCFilterTest.java
+++ b/modules/extension/xsd/xsd-filter/src/test/java/org/geotools/filter/v1_1/OGCFilterTest.java
@@ -77,6 +77,7 @@ public class OGCFilterTest {
     @Test
     public void testParse() throws Exception {
         Parser parser = new Parser(new OGCConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         try (InputStream in = getClass().getResourceAsStream("test1.xml")) {
 
             if (in == null) {
@@ -118,6 +119,7 @@ public class OGCFilterTest {
         OGCConfiguration configuration = new OGCConfiguration();
 
         Parser parser = new Parser(configuration);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         DWithin filter = (DWithin) parser.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         Assert.assertNotNull(filter);
 
@@ -159,6 +161,7 @@ public class OGCFilterTest {
         OGCConfiguration configuration = new OGCConfiguration();
 
         Parser parser = new Parser(configuration);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         DWithin filter = (DWithin) parser.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         Assert.assertNotNull(filter);
 

--- a/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GMLEncodingUtils.java
+++ b/modules/extension/xsd/xsd-gml2/src/main/java/org/geotools/gml2/bindings/GMLEncodingUtils.java
@@ -28,7 +28,6 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.eclipse.xsd.XSDComplexTypeDefinition;
 import org.eclipse.xsd.XSDCompositor;
@@ -57,6 +56,7 @@ import org.geotools.geometry.jts.JTS;
 import org.geotools.gml2.GMLConfiguration;
 import org.geotools.util.logging.Logging;
 import org.geotools.xlink.XLINK;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xs.XS;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.SchemaIndex;
@@ -280,7 +280,7 @@ public class GMLEncodingUtils {
         XSDFactory f = XSDFactory.eINSTANCE;
         Document dom;
         try {
-            dom = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            dom = XMLUtils.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException e) {
             throw new RuntimeException(e);
         }

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLApplicationSchemaParsingTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLApplicationSchemaParsingTest.java
@@ -73,10 +73,10 @@ public class GMLApplicationSchemaParsingTest {
         schemaFile.deleteOnExit();
         try (InputStream in = getClass().getResourceAsStream("feature.xml")) {
 
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
             factory.setNamespaceAware(true);
 
-            Document document = factory.newDocumentBuilder().parse(in);
+            Document document = XMLUtils.newDocumentBuilder(factory).parse(in);
 
             // update hte schema location
             document.getDocumentElement().removeAttribute("xsi:schemaLocation");
@@ -107,10 +107,10 @@ public class GMLApplicationSchemaParsingTest {
         File schemaFile = File.createTempFile("test", "xsd");
         schemaFile.deleteOnExit();
         try (InputStream in = getClass().getResourceAsStream("feature.xml")) {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
             factory.setNamespaceAware(true);
 
-            Document document = factory.newDocumentBuilder().parse(in);
+            Document document = XMLUtils.newDocumentBuilder(factory).parse(in);
 
             // update hte schema location
             String schemaLocation = getClass().getResource("test.xsd").toString();

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLApplicationSchemaParsingTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLApplicationSchemaParsingTest.java
@@ -21,7 +21,6 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.geotools.api.feature.simple.SimpleFeature;
@@ -49,7 +48,7 @@ public class GMLApplicationSchemaParsingTest {
             document.getDocumentElement().removeAttribute("xsi:schemaLocation");
 
             // reserialize the document
-            Transformer tx = TransformerFactory.newInstance().newTransformer();
+            Transformer tx = XMLUtils.newTransformer();
             tx.transform(new DOMSource(document), new StreamResult(schemaFile));
         }
         try (FileInputStream in = new FileInputStream(schemaFile)) {
@@ -82,7 +81,7 @@ public class GMLApplicationSchemaParsingTest {
             document.getDocumentElement().removeAttribute("xsi:schemaLocation");
 
             // reserialize the document
-            Transformer tx = TransformerFactory.newInstance().newTransformer();
+            Transformer tx = XMLUtils.newTransformer();
             tx.transform(new DOMSource(document), new StreamResult(schemaFile));
         }
         try (InputStream in = new FileInputStream(schemaFile)) {
@@ -117,7 +116,7 @@ public class GMLApplicationSchemaParsingTest {
             document.getDocumentElement().setAttribute("xsi:schemaLocation", TEST.NAMESPACE + " " + schemaLocation);
 
             // reserialize the document
-            Transformer tx = TransformerFactory.newInstance().newTransformer();
+            Transformer tx = XMLUtils.newTransformer();
             tx.transform(new DOMSource(document), new StreamResult(schemaFile));
         }
         try (InputStream in = new FileInputStream(schemaFile)) {

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLApplicationSchemaParsingTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLApplicationSchemaParsingTest.java
@@ -25,12 +25,14 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.StreamingParser;
 import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.jts.geom.Point;
 import org.w3c.dom.Document;
 
+@SuppressWarnings("PMD.AvoidDocumentBuilder")
 public class GMLApplicationSchemaParsingTest {
     @Test
     public void testStreamFeatureWithIncorrectSchemaLocation() throws Exception {
@@ -39,9 +41,8 @@ public class GMLApplicationSchemaParsingTest {
 
         try (InputStream in = getClass().getResourceAsStream("feature.xml")) {
 
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
             factory.setNamespaceAware(true);
-
             Document document = factory.newDocumentBuilder().parse(in);
 
             // update hte schema location

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLGeometryTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLGeometryTest.java
@@ -17,6 +17,7 @@
 package org.geotools.gml2;
 
 import javax.xml.parsers.SAXParserFactory;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -39,6 +40,7 @@ public class GMLGeometryTest {
         Configuration configuration = new GMLConfiguration();
 
         parser = new Parser(configuration);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
     }
 
     @Test

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLGeometryTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/GMLGeometryTest.java
@@ -16,7 +16,6 @@
  */
 package org.geotools.gml2;
 
-import javax.xml.parsers.SAXParserFactory;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
@@ -33,10 +32,6 @@ public class GMLGeometryTest {
 
     @Before
     public void setUp() throws Exception {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-
-        spf.setNamespaceAware(true);
-
         Configuration configuration = new GMLConfiguration();
 
         parser = new Parser(configuration);

--- a/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/simple/GMLWriterTest.java
+++ b/modules/extension/xsd/xsd-gml2/src/test/java/org/geotools/gml2/simple/GMLWriterTest.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
@@ -38,6 +37,7 @@ import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.gml2.GML;
 import org.geotools.gml2.GMLConfiguration;
 import org.geotools.gml2.bindings.GMLTestSupport;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Encoder;
 import org.junit.Before;
@@ -138,8 +138,7 @@ public class GMLWriterTest extends GMLTestSupport {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         // create the document serializer
-        SAXTransformerFactory txFactory = (SAXTransformerFactory) SAXTransformerFactory.newInstance();
-
+        SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
         TransformerHandler xmls;
         try {
             xmls = txFactory.newTransformerHandler();
@@ -163,7 +162,7 @@ public class GMLWriterTest extends GMLTestSupport {
 
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
         DOMResult result = new DOMResult();
-        Transformer tx = TransformerFactory.newInstance().newTransformer();
+        Transformer tx = XMLUtils.newTransformer();
         tx.transform(new StreamSource(in), result);
         Document d = (Document) result.getNode();
         return d;

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3CompositeCurveParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3CompositeCurveParsingTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -19,6 +20,7 @@ public class GML3CompositeCurveParsingTest extends GML3TestSupport {
     public void testCompositeCurve() throws Exception {
         GMLConfiguration gml = new GMLConfiguration(true);
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object compositeCurve = p.parse(getClass().getResourceAsStream("v3_2/gml_compositecurve_1.xml"));
         assertFalse(compositeCurve instanceof String);
         // System.out.println(compositeCurve);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3CurveParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3CurveParsingTest.java
@@ -31,6 +31,7 @@ import org.geotools.geometry.jts.CurvePolygon;
 import org.geotools.geometry.jts.CurvedGeometries;
 import org.geotools.geometry.jts.CurvedGeometryFactory;
 import org.geotools.geometry.jts.MultiCurve;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.junit.Before;
@@ -55,6 +56,7 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testSingleArc() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object arc = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/singleArc.xml"));
         assertThat(arc, instanceOf(CircularString.class));
         CircularString cs = (CircularString) arc;
@@ -65,6 +67,7 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testArcString() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object arc = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/arcString.xml"));
         assertThat(arc, instanceOf(CircularString.class));
         CircularString cs = (CircularString) arc;
@@ -75,6 +78,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testCompoundOpen() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/compoundOpen.xml"));
         assertThat(g, instanceOf(CompoundCurvedGeometry.class));
 
@@ -100,6 +105,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testCompoundClosed() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/compoundClosed.xml"));
         assertThat(g, instanceOf(CompoundCurvedGeometry.class));
 
@@ -122,6 +129,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testCirclePolygon() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/circlePolygon.xml"));
         assertThat(g, instanceOf(CurvePolygon.class));
 
@@ -141,6 +150,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testCompoundPolygon() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/compoundPolygon.xml"));
         assertThat(g, instanceOf(CurvePolygon.class));
 
@@ -165,6 +176,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testCompoundPolygonWithHole() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/compoundPolygonWithHole.xml"));
         assertThat(g, instanceOf(CurvePolygon.class));
 
@@ -204,6 +217,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testMultiSurface() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/multiSurface2.xml"));
         assertThat(g, instanceOf(org.geotools.geometry.jts.MultiSurface.class));
 
@@ -238,6 +253,8 @@ public class GML3CurveParsingTest extends GML3TestSupport {
     @Test
     public void testMultiCurve() throws Exception {
         Parser p = new Parser(gml);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3CurveParsingTest.class.getResourceAsStream("v3_2/multiCurve.xml"));
         assertThat(g, instanceOf(MultiCurve.class));
 

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3EncodingOnlineTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3EncodingOnlineTest.java
@@ -32,6 +32,7 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.gml3.bindings.TEST;
 import org.geotools.gml3.bindings.TestConfiguration;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
@@ -112,7 +113,7 @@ public class GML3EncodingOnlineTest {
     }
 
     void validate(byte[] data, Configuration configuration) throws Exception {
-        SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        SchemaFactory sf = XMLUtils.newSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
         Schema s = sf.newSchema(new URI(configuration.getXSD().getSchemaLocation()).toURL());
 

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3EncodingOnlineTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3EncodingOnlineTest.java
@@ -31,6 +31,7 @@ import org.eclipse.xsd.XSDSchema;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.gml3.bindings.TEST;
 import org.geotools.gml3.bindings.TestConfiguration;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
@@ -66,7 +67,7 @@ public class GML3EncodingOnlineTest {
         TestConfiguration configuration = new TestConfiguration();
 
         // first parse in test data
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         SimpleFeatureCollection fc =
                 (SimpleFeatureCollection) parser.parse(TestConfiguration.class.getResourceAsStream("test.xml"));
         Assert.assertNotNull(fc);
@@ -94,7 +95,7 @@ public class GML3EncodingOnlineTest {
                 new ApplicationSchemaConfiguration(TEST.NAMESPACE, schemaLocation);
 
         // first parse in test data
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         SimpleFeatureCollection fc =
                 (SimpleFeatureCollection) parser.parse(TestConfiguration.class.getResourceAsStream("test.xml"));
         Assert.assertNotNull(fc);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3ParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3ParsingTest.java
@@ -16,6 +16,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.temporal.Period;
 import org.geotools.geometry.jts.coordinatesequence.CoordinateSequences;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.StreamingParser;
 import org.junit.Assert;
@@ -84,7 +85,7 @@ public class GML3ParsingTest {
 
     @Test
     public void testParse3D() throws Exception {
-        Parser p = new Parser(new GMLConfiguration());
+        Parser p = new Parser(new GMLConfiguration(), NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3ParsingTest.class.getResourceAsStream("polygon3d.xml"));
         assertThat(g, instanceOf(Polygon.class));
 
@@ -97,7 +98,7 @@ public class GML3ParsingTest {
 
     @Test
     public void testParseTimePeriodByPosition() throws Exception {
-        Parser p = new Parser(new GMLConfiguration());
+        Parser p = new Parser(new GMLConfiguration(), NullEntityResolver.INSTANCE);
         Object g = p.parse(GML3ParsingTest.class.getResourceAsStream("timePeriodByPosition.xml"));
         assertThat(g, instanceOf(Period.class));
 

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3ParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/GML3ParsingTest.java
@@ -8,15 +8,14 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.TimeZone;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.temporal.Period;
 import org.geotools.geometry.jts.coordinatesequence.CoordinateSequences;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.StreamingParser;
 import org.junit.Assert;
@@ -48,14 +47,14 @@ public class GML3ParsingTest {
 
     @Test
     public void testWithSchema() throws Exception {
-        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
         // copy the schema to a temporary file
         File xsd = new File("target/states.xsd");
         // xsd.deleteOnExit();
 
         Document schema = db.parse(getClass().getResourceAsStream("states.xsd"));
-        Transformer tx = TransformerFactory.newInstance().newTransformer();
+        Transformer tx = XMLUtils.newTransformer();
         tx.transform(new DOMSource(schema), new StreamResult(xsd));
 
         // update the schemaLocation to point at the schema

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/SchemasTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/SchemasTest.java
@@ -10,10 +10,24 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.util.XSDSchemaLocator;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.xsd.Schemas;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class SchemasTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+    }
 
     @Test
     public void testConcurrentParse() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/GML3EncodingUtilsTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/bindings/GML3EncodingUtilsTest.java
@@ -33,13 +33,27 @@ import org.geotools.data.DataUtilities;
 import org.geotools.gml2.bindings.GMLEncodingUtils;
 import org.geotools.gml3.GML;
 import org.geotools.gml3.GMLConfiguration;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.SchemaIndex;
 import org.geotools.xsd.Schemas;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Test GML 3.1 encoding utilities. Most of the work is delegate on {@link GMLEncodingUtils}. */
 public class GML3EncodingUtilsTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+    }
 
     @Test
     public void testGeometriesGML3FeatureEncoding() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryEncoderTestSupport.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/simple/GeometryEncoderTestSupport.java
@@ -24,7 +24,6 @@ import java.util.Properties;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
@@ -34,6 +33,7 @@ import org.geotools.gml2.simple.GMLWriter;
 import org.geotools.gml2.simple.GeometryEncoder;
 import org.geotools.gml3.GML;
 import org.geotools.gml3.GML3TestSupport;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Encoder;
 import org.junit.Before;
 import org.locationtech.jts.geom.Geometry;
@@ -79,7 +79,7 @@ public abstract class GeometryEncoderTestSupport extends GML3TestSupport {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
         // create the document serializer
-        SAXTransformerFactory txFactory = (SAXTransformerFactory) SAXTransformerFactory.newInstance();
+        SAXTransformerFactory txFactory = XMLUtils.newSaxTransformerFactory();
 
         TransformerHandler xmls;
         try {
@@ -104,7 +104,7 @@ public abstract class GeometryEncoderTestSupport extends GML3TestSupport {
 
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
         DOMResult result = new DOMResult();
-        Transformer tx = TransformerFactory.newInstance().newTransformer();
+        Transformer tx = XMLUtils.newTransformer();
         tx.transform(new StreamSource(in), result);
         Document d = (Document) result.getNode();
         return d;

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/ChildElementTypeTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/ChildElementTypeTest.java
@@ -21,10 +21,14 @@ import java.util.List;
 import javax.xml.namespace.QName;
 import org.eclipse.xsd.XSDElementDeclaration;
 import org.eclipse.xsd.XSDTypeDefinition;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.SchemaIndex;
 import org.geotools.xsd.Schemas;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -33,6 +37,16 @@ import org.junit.Test;
  * @author Ben Caradoc-Davies, CSIRO Earth Science and Resource Engineering
  */
 public class ChildElementTypeTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+    }
 
     /** Test that gml:AbstractGMLType child elements have types. */
     @Test

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GML32CompositeCurveParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GML32CompositeCurveParsingTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
@@ -12,7 +13,7 @@ public class GML32CompositeCurveParsingTest extends GML32TestSupport {
     @Test
     public void testCompositeCurve() throws Exception {
         GMLConfiguration gml = new GMLConfiguration(true);
-        Parser p = new Parser(gml);
+        Parser p = new Parser(gml, NullEntityResolver.INSTANCE);
         Object compositeCurve = p.parse(getClass().getResourceAsStream("gml_compositecurve_1.xml"));
         assertFalse(compositeCurve instanceof String);
         // System.out.println(compositeCurve);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GML32SurfaceParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GML32SurfaceParsingTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.geotools.geometry.jts.CompoundRing;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -13,7 +14,7 @@ public class GML32SurfaceParsingTest extends GML32TestSupport {
     @Test
     public void testMultiSurface() throws Exception {
         GMLConfiguration gml = new GMLConfiguration(true);
-        Parser p = new Parser(gml);
+        Parser p = new Parser(gml, NullEntityResolver.INSTANCE);
         Object multiSurface = p.parse(getClass().getResourceAsStream("multisurface.xml"));
         assertTrue(multiSurface instanceof MultiPolygon);
         MultiPolygon mp = (MultiPolygon) multiSurface;

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GML32TestSupport.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GML32TestSupport.java
@@ -35,6 +35,7 @@ public abstract class GML32TestSupport extends XMLTestSupport {
         GML3MockData.setGML(GML.getInstance());
     }
 
+    @Override
     @After
     public void tearDown() throws Exception {
         GML3MockData.setGML(null);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.FileUtils;
@@ -63,7 +62,7 @@ public class GMLParsingTest {
         dom.getDocumentElement()
                 .setAttribute("xsi:schemaLocation", "http://www.geotools.org/test " + schemaURL.getFile());
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        TransformerFactory.newInstance().newTransformer().transform(new DOMSource(dom), new StreamResult(out));
+        XMLUtils.newTransformer().transform(new DOMSource(dom), new StreamResult(out));
 
         GMLConfiguration config = new GMLConfiguration();
         Parser p = new Parser(config);

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
@@ -34,9 +34,12 @@ import org.geotools.feature.FeatureIterator;
 import org.geotools.referencing.CRS;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Parser;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
@@ -44,6 +47,15 @@ import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 public class GMLParsingTest {
+    @Before
+    public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+    }
 
     @Test
     public void testGML() throws Exception {

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
@@ -34,6 +34,7 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.referencing.CRS;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -68,6 +69,7 @@ public class GMLParsingTest {
 
         GMLConfiguration config = new GMLConfiguration();
         Parser p = new Parser(config);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object o = p.parse(new ByteArrayInputStream(out.toByteArray()));
         Assert.assertTrue(o instanceof FeatureCollection);
 

--- a/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
+++ b/modules/extension/xsd/xsd-gml3/src/test/java/org/geotools/gml3/v3_2/GMLParsingTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -36,6 +35,7 @@ import org.geotools.feature.FeatureIterator;
 import org.geotools.referencing.CRS;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -58,9 +58,7 @@ public class GMLParsingTest {
         schema.deleteOnExit();
         FileUtils.copyURLToFile(getClass().getResource("test.xsd"), schema);
 
-        Document dom = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder()
-                .parse(getClass().getResourceAsStream("test.xml"));
+        Document dom = XMLUtils.newDocumentBuilder().parse(getClass().getResourceAsStream("test.xml"));
         URL schemaURL = URLs.fileToUrl(schema.getAbsoluteFile());
         dom.getDocumentElement()
                 .setAttribute("xsi:schemaLocation", "http://www.geotools.org/test " + schemaURL.getFile());

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/KMLParsingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/KMLParsingTest.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.style.FeatureTypeStyle;
 import org.geotools.feature.DefaultFeatureCollection;
@@ -30,6 +29,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.kml.bindings.DocumentTypeBinding;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.StreamingParser;
@@ -103,7 +103,7 @@ public class KMLParsingTest {
         encoder.encode(features, KML.kml, out);
         // System.out.println(new String(out.toByteArray()));
 
-        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document d = db.parse(new ByteArrayInputStream(out.toByteArray()));
         Assert.assertEquals("kml:kml", d.getDocumentElement().getNodeName());
         Assert.assertEquals(2, d.getElementsByTagName("kml:Placemark").getLength());
@@ -141,7 +141,7 @@ public class KMLParsingTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         encoder.encode(f, KML.kml, out);
 
-        DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document d = db.parse(new ByteArrayInputStream(out.toByteArray()));
         Assert.assertEquals("kml:kml", d.getDocumentElement().getNodeName());
         Assert.assertEquals(2, d.getElementsByTagName("kml:Placemark").getLength());

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/KMLParsingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/KMLParsingTest.java
@@ -29,6 +29,7 @@ import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.kml.bindings.DocumentTypeBinding;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.StreamingParser;
@@ -45,6 +46,7 @@ public class KMLParsingTest {
     @Test
     public void testParse() throws Exception {
         Parser parser = new Parser(new KMLConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         SimpleFeature f = (SimpleFeature) parser.parse(getClass().getResourceAsStream("states.kml"));
         Assert.assertNotNull(f);
 

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLParsingTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLParsingTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.PullParser;
 import org.geotools.xsd.StreamingParser;
@@ -215,6 +216,7 @@ public class KMLParsingTest extends KMLTestSupport {
 
     SimpleFeature parseSamples(String sampleName) throws Exception {
         Parser p = new Parser(createConfiguration());
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         SimpleFeature doc = (SimpleFeature) p.parse(getClass().getResourceAsStream(sampleName));
         return doc;
     }

--- a/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLPlacemarkLookAtTest.java
+++ b/modules/extension/xsd/xsd-kml/src/test/java/org/geotools/kml/v22/KMLPlacemarkLookAtTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
 import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 import org.locationtech.jts.geom.Point;
@@ -29,6 +30,7 @@ public class KMLPlacemarkLookAtTest extends KMLTestSupport {
     @Test
     public void testParseDocument() throws Exception {
         Parser parser = new Parser(createConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         SimpleFeature doc = (SimpleFeature) parser.parse(getClass().getResourceAsStream("geot5666.kml"));
         assertNotNull(doc);
         assertEquals("document", doc.getType().getTypeName());

--- a/modules/extension/xsd/xsd-ows/src/test/java/org/geotools/ows/v1_1/CapabilitiesParseTest.java
+++ b/modules/extension/xsd/xsd-ows/src/test/java/org/geotools/ows/v1_1/CapabilitiesParseTest.java
@@ -10,6 +10,7 @@ import net.opengis.ows11.DomainType;
 import net.opengis.ows11.OperationType;
 import net.opengis.ows11.OperationsMetadataType;
 import net.opengis.ows11.ValueType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
@@ -17,6 +18,7 @@ public class CapabilitiesParseTest extends OWSTestSupport_1_1 {
     @Test
     public void testParseCapabilities() throws Exception {
         Parser p = new Parser(createConfiguration());
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object o = p.parse(getClass().getResourceAsStream("exampleCapabilities1.xml"));
 
         // the core ows schema is abstract, and meant to be extended, so the root caps document
@@ -46,6 +48,7 @@ public class CapabilitiesParseTest extends OWSTestSupport_1_1 {
     @Test
     public void testConstraints() throws Exception {
         Parser p = new Parser(createConfiguration());
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object o = p.parse(getClass().getResourceAsStream("exampleCapabilities1.xml"));
 
         // the core ows schema is abstract, and meant to be extended, so the

--- a/modules/extension/xsd/xsd-ows/src/test/java/org/geotools/ows/v1_1/RangeTest.java
+++ b/modules/extension/xsd/xsd-ows/src/test/java/org/geotools/ows/v1_1/RangeTest.java
@@ -8,6 +8,7 @@ import net.opengis.ows11.Ows11Factory;
 import net.opengis.ows11.RangeClosureType;
 import net.opengis.ows11.RangeType;
 import net.opengis.ows11.ValueType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
@@ -17,6 +18,7 @@ public class RangeTest extends OWSTestSupport_1_1 {
     @Test
     public void testParseRange() throws Exception {
         Parser p = new Parser(createConfiguration());
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object o = p.parse(getClass().getResourceAsStream("range.xml"));
         RangeType rt = (RangeType) o;
         assertEquals(RangeClosureType.CLOSED_LITERAL, rt.getRangeClosure());
@@ -27,6 +29,7 @@ public class RangeTest extends OWSTestSupport_1_1 {
     @Test
     public void testParseOpenClosed() throws Exception {
         Parser p = new Parser(createConfiguration());
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         Object o = p.parse(getClass().getResourceAsStream("range-open-closed.xml"));
         RangeType rt = (RangeType) o;
         assertEquals(RangeClosureType.OPEN_CLOSED_LITERAL, rt.getRangeClosure());

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/se/v1_1/SEExampleTest.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/se/v1_1/SEExampleTest.java
@@ -62,6 +62,7 @@ import org.geotools.filter.function.EnvFunction;
 import org.geotools.styling.DefaultResourceLocator;
 import org.geotools.styling.SLD;
 import org.geotools.styling.UomOgcMapping;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Before;
 import org.junit.Test;
@@ -270,6 +271,7 @@ public class SEExampleTest extends SETestSupport {
             }
         };
         Parser p = new Parser(se);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         PointSymbolizer sym = (PointSymbolizer) p.parse(getClass().getResourceAsStream("example-pointsymbolizer6.xml"));
         assertEquals("MyPointSymbolizer", sym.getName());
         assertEquals("Example Pointsymbolizer", sym.getDescription().getTitle().toString());

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/se/v1_1/SETestSupport.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/se/v1_1/SETestSupport.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.List;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.test.XMLTestSupport;
@@ -67,12 +68,14 @@ public abstract class SETestSupport extends XMLTestSupport {
     protected Object parse(String filename) throws Exception {
         SEConfiguration se = new SEConfiguration();
         Parser p = new Parser(se);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         return p.parse(getClass().getResourceAsStream(filename));
     }
 
     protected List validate(String filename) throws Exception {
         SEConfiguration se = new SEConfiguration();
         Parser p = new Parser(se);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         p.validate(getClass().getResourceAsStream(filename));
         return p.getValidationErrors();
     }

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/SLDTest.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/SLDTest.java
@@ -39,6 +39,7 @@ import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.api.style.TextSymbolizer;
 import org.geotools.api.style.UserLayer;
 import org.geotools.styling.SLD;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.junit.Ignore;
@@ -50,7 +51,7 @@ public class SLDTest {
     @Test
     public void test() throws Exception {
         Parser parser = new Parser(new SLDConfiguration());
-
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         StyledLayerDescriptor sld =
                 (StyledLayerDescriptor) parser.parse(getClass().getResourceAsStream("example-sld.xml"));
 
@@ -84,7 +85,7 @@ public class SLDTest {
     @Test
     public void testValidateTransformation() throws Exception {
         Parser parser = new Parser(new SLDConfiguration());
-
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         // if a validation error occurs it will blow up with an exception
         parser.validate(getClass().getResourceAsStream("gcontours.sld"));
     }
@@ -92,7 +93,7 @@ public class SLDTest {
     @Test
     public void testValidatePerpendicularOffset() throws Exception {
         Parser parser = new Parser(new SLDConfiguration());
-
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         // if a validation error occurs it will blow up with an exception
         parser.validate(getClass().getResourceAsStream("linePerpendicularOffset.sld"));
     }
@@ -100,7 +101,7 @@ public class SLDTest {
     @Test
     public void testValidateGammaValueExpression() throws Exception {
         Parser parser = new Parser(new SLDConfiguration());
-
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         // if a validation error occurs it will blow up with an exception
         parser.validate(getClass().getResourceAsStream("gammaValueExpression.sld"));
     }
@@ -155,7 +156,7 @@ public class SLDTest {
     @Test
     public void testBackgroundSolid() throws ParserConfigurationException, SAXException, IOException {
         Parser parser = new Parser(new SLDConfiguration());
-
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         // if a validation error occurs it will blow up with an exception
         parser.validate(getClass().getResourceAsStream("backgroundSolid.sld"));
 
@@ -171,6 +172,7 @@ public class SLDTest {
     @Test
     public void testBackgroundGraphicFill() throws ParserConfigurationException, SAXException, IOException {
         Parser parser = new Parser(new SLDConfiguration());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
 
         // if a validation error occurs it will blow up with an exception
         parser.validate(getClass().getResourceAsStream("backgroundGraphicFill.sld"));

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/v1_1/SLDExampleTest.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/v1_1/SLDExampleTest.java
@@ -42,6 +42,7 @@ import org.geotools.api.style.Rule;
 import org.geotools.api.style.Style;
 import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.api.style.TextSymbolizer;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -131,7 +132,7 @@ public class SLDExampleTest {
     Object parse(String filename) throws Exception {
         SLDConfiguration sld = new SLDConfiguration();
         try (InputStream location = getClass().getResourceAsStream(filename)) {
-            return new Parser(sld).parse(location);
+            return new Parser(sld, NullEntityResolver.INSTANCE).parse(location);
         }
     }
 
@@ -139,6 +140,7 @@ public class SLDExampleTest {
         SLDConfiguration sld = new SLDConfiguration();
         try (InputStream location = getClass().getResourceAsStream(filename)) {
             Parser p = new Parser(sld);
+            p.setEntityResolver(NullEntityResolver.INSTANCE);
             p.validate(location);
             return p.getValidationErrors();
         }
@@ -150,7 +152,7 @@ public class SLDExampleTest {
         String file = "../example-textsymbolizer-externalentities.xml";
 
         Parser parser = new Parser(new SLDConfiguration());
-
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         try (InputStream location = getClass().getResourceAsStream(file)) {
             parser.parse(location);
             Assert.fail("parsing should fail with a FileNotFoundException because the parser try to "

--- a/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v1_1/DescribeCoverageTest.java
+++ b/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v1_1/DescribeCoverageTest.java
@@ -3,12 +3,13 @@ package org.geotools.wcs.v1_1;
 import static org.junit.Assert.assertEquals;
 
 import net.opengis.wcs11.DescribeCoverageType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class DescribeCoverageTest {
 
-    Parser parser = new Parser(new WCSConfiguration());
+    Parser parser = new Parser(new WCSConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseDescribeCoverage() throws Exception {

--- a/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v1_1/GetCapabilitiesTest.java
+++ b/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v1_1/GetCapabilitiesTest.java
@@ -4,12 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.List;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class GetCapabilitiesTest {
 
-    Parser parser = new Parser(new WCSConfiguration());
+    Parser parser = new Parser(new WCSConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseCapabilitiesRequest() throws Exception {

--- a/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/DescribeCoverageTest.java
+++ b/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/DescribeCoverageTest.java
@@ -4,12 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import net.opengis.wcs20.DescribeCoverageType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class DescribeCoverageTest {
 
-    Parser parser = new Parser(new WCSConfiguration());
+    Parser parser = new Parser(new WCSConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseDescribeCoverage() throws Exception {

--- a/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/DescribeEOCoverageSetTest.java
+++ b/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/DescribeEOCoverageSetTest.java
@@ -7,12 +7,13 @@ import net.opengis.wcs20.DescribeEOCoverageSetType;
 import net.opengis.wcs20.DimensionTrimType;
 import net.opengis.wcs20.Section;
 import org.eclipse.emf.common.util.EList;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class DescribeEOCoverageSetTest {
 
-    Parser parser = new Parser(new WCSEOConfiguration());
+    Parser parser = new Parser(new WCSEOConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseDescribeCoverage() throws Exception {

--- a/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/GetCapabilitiesTest.java
+++ b/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/GetCapabilitiesTest.java
@@ -4,12 +4,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 import net.opengis.wcs20.GetCapabilitiesType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class GetCapabilitiesTest {
 
-    Parser parser = new Parser(new WCSConfiguration());
+    Parser parser = new Parser(new WCSConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseCapabilitiesRequest() throws Exception {

--- a/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/GetCoverageTest.java
+++ b/modules/extension/xsd/xsd-wcs/src/test/java/org/geotools/wcs/v2_0/GetCoverageTest.java
@@ -24,12 +24,13 @@ import net.opengis.wcs20.ScalingType;
 import net.opengis.wcs20.TargetAxisExtentType;
 import net.opengis.wcs20.TargetAxisSizeType;
 import org.eclipse.emf.common.util.EList;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
 
 public class GetCoverageTest {
 
-    Parser parser = new Parser(new WCSConfiguration());
+    Parser parser = new Parser(new WCSConfiguration(), NullEntityResolver.INSTANCE);
 
     @Test
     public void testParseGetCoverageSlicing() throws Exception {

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/bindings/QueryExpressionTextTypeBinding.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/bindings/QueryExpressionTextTypeBinding.java
@@ -20,10 +20,10 @@ import java.io.StringReader;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import net.opengis.wfs20.QueryExpressionTextType;
 import net.opengis.wfs20.Wfs20Factory;
 import org.geotools.wfs.v2_0.WFS;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.AbstractComplexEMFBinding;
 import org.geotools.xsd.ElementInstance;
 import org.geotools.xsd.Node;
@@ -101,7 +101,7 @@ public class QueryExpressionTextTypeBinding extends AbstractComplexEMFBinding {
             ConvertToDomHandler h =
                     new ConvertToDomHandler(dbf.newDocumentBuilder().newDocument(), namespaceContext);
 
-            SAXParser saxp = SAXParserFactory.newInstance().newSAXParser();
+            SAXParser saxp = XMLUtils.newSAXParserFactory(null).newSAXParser();
             saxp.parse(new InputSource(new StringReader(qe.getValue())), h);
 
             Document d = h.getDocument();

--- a/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/bindings/QueryExpressionTextTypeBinding.java
+++ b/modules/extension/xsd/xsd-wfs/src/main/java/org/geotools/wfs/v2_0/bindings/QueryExpressionTextTypeBinding.java
@@ -95,11 +95,10 @@ public class QueryExpressionTextTypeBinding extends AbstractComplexEMFBinding {
             // having them declared by the expression text, so we first parse the query
             // expression with a sax handler that can transform to a namespace aware dom
             // using the current namespace context
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
             dbf.setNamespaceAware(true);
-
             ConvertToDomHandler h =
-                    new ConvertToDomHandler(dbf.newDocumentBuilder().newDocument(), namespaceContext);
+                    new ConvertToDomHandler(XMLUtils.newDocumentBuilder(dbf).newDocument(), namespaceContext);
 
             SAXParser saxp = XMLUtils.newSAXParserFactory(null).newSAXParser();
             saxp.parse(new InputSource(new StringReader(qe.getValue())), h);

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/GMLTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/GMLTest.java
@@ -49,6 +49,8 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.WKTReader2;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.test.TestData;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.wfs.GML.Version;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -211,44 +213,54 @@ public class GMLTest {
     // WFS 1.1
     @Test
     public void testGML3ParseSimpleFeatureType() throws IOException {
-        URL schemaLocation = TestData.getResource(this, "states.xsd");
+        try {
+            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+            URL schemaLocation = TestData.getResource(this, "states.xsd");
 
-        GML gml = new GML(Version.WFS1_1);
-        gml.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84);
+            GML gml = new GML(Version.WFS1_1);
+            gml.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84);
 
-        SimpleFeatureType featureType =
-                gml.decodeSimpleFeatureType(schemaLocation, new NameImpl("http://www.openplans.org/topp", "states"));
+            SimpleFeatureType featureType = gml.decodeSimpleFeatureType(
+                    schemaLocation, new NameImpl("http://www.openplans.org/topp", "states"));
 
-        assertNotNull(featureType);
-        assertSame(DefaultGeographicCRS.WGS84, featureType.getCoordinateReferenceSystem());
+            assertNotNull(featureType);
+            assertSame(DefaultGeographicCRS.WGS84, featureType.getCoordinateReferenceSystem());
 
-        List<AttributeDescriptor> attributes = featureType.getAttributeDescriptors();
-        List<String> names = new ArrayList<>(attributes.size());
-        for (AttributeDescriptor desc : attributes) {
-            names.add(desc.getLocalName());
+            List<AttributeDescriptor> attributes = featureType.getAttributeDescriptors();
+            List<String> names = new ArrayList<>(attributes.size());
+            for (AttributeDescriptor desc : attributes) {
+                names.add(desc.getLocalName());
+            }
+            assertEquals("Expected number of Attributes", 23, names.size());
+        } finally {
+            Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
         }
-        assertEquals("Expected number of Attributes", 23, names.size());
     }
 
     @Test
     public void testGML2ParseSimpleFeatureType() throws IOException {
-        URL schemaLocation = TestData.getResource(this, "states_gml2.xsd");
+        try {
+            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+            URL schemaLocation = TestData.getResource(this, "states_gml2.xsd");
 
-        GML gml = new GML(Version.WFS1_0);
-        gml.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84);
+            GML gml = new GML(Version.WFS1_0);
+            gml.setCoordinateReferenceSystem(DefaultGeographicCRS.WGS84);
 
-        SimpleFeatureType featureType =
-                gml.decodeSimpleFeatureType(schemaLocation, new NameImpl("http://www.openplans.org/topp", "states"));
+            SimpleFeatureType featureType = gml.decodeSimpleFeatureType(
+                    schemaLocation, new NameImpl("http://www.openplans.org/topp", "states"));
 
-        assertNotNull(featureType);
-        assertSame(DefaultGeographicCRS.WGS84, featureType.getCoordinateReferenceSystem());
+            assertNotNull(featureType);
+            assertSame(DefaultGeographicCRS.WGS84, featureType.getCoordinateReferenceSystem());
 
-        List<AttributeDescriptor> attributes = featureType.getAttributeDescriptors();
-        List<String> names = new ArrayList<>(attributes.size());
-        for (AttributeDescriptor desc : attributes) {
-            names.add(desc.getLocalName());
+            List<AttributeDescriptor> attributes = featureType.getAttributeDescriptors();
+            List<String> names = new ArrayList<>(attributes.size());
+            for (AttributeDescriptor desc : attributes) {
+                names.add(desc.getLocalName());
+            }
+            assertEquals("Expected number of Attributes", 23, names.size());
+        } finally {
+            Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
         }
-        assertEquals("Expected number of Attributes", 23, names.size());
     }
 
     @Test

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFSTestSupport.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFSTestSupport.java
@@ -30,6 +30,7 @@ import net.opengis.wfs.WfsFactory;
 import org.eclipse.emf.ecore.EObject;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Binding;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.test.XMLTestSupport;
@@ -159,13 +160,13 @@ public abstract class WFSTestSupport extends XMLTestSupport {
      * @param xml An URL for the xml resource to build the document from
      */
     protected void buildDocument(URL resource) throws Exception {
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
         try (InputStream in = resource.openStream();
                 InputStreamReader reader = new InputStreamReader(in, StandardCharsets.UTF_8)) {
             InputSource source = new InputSource(new BufferedReader(reader));
-            document = docFactory.newDocumentBuilder().parse(source);
+            document = XMLUtils.newDocumentBuilder(docFactory).parse(source);
         }
     }
 }

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
@@ -59,6 +59,7 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.Schemas;
@@ -326,7 +327,7 @@ public class WFS_2_0_0_ParsingTest {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
 
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder();
             Document doc = db.parse(in);
 
             // http://cite.opengeospatial.org/gmlsf

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
@@ -57,6 +57,7 @@ import org.geotools.api.filter.capability.FilterCapabilities;
 import org.geotools.api.filter.capability.Operator;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
@@ -89,7 +90,7 @@ public class WFS_2_0_0_ParsingTest {
 
         configuration = new org.geotools.wfs.v2_0.WFSCapabilitiesConfiguration();
 
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         Assert.assertNotNull(parsed);
         Assert.assertTrue(parsed.getClass().getName(), parsed instanceof WFSCapabilitiesType);
@@ -103,7 +104,7 @@ public class WFS_2_0_0_ParsingTest {
     public void testParseGetCapabilities() throws Exception {
         configuration = new org.geotools.wfs.v2_0.WFSCapabilitiesConfiguration();
 
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(getClass().getResourceAsStream("geoserver-GetCapabilities_2_0_0.xml"));
 
         Assert.assertNotNull(parsed);
@@ -124,7 +125,7 @@ public class WFS_2_0_0_ParsingTest {
     public void testParseGetCapabilitiesFMI() throws Exception {
         configuration = new org.geotools.wfs.v2_0.WFSCapabilitiesConfiguration();
 
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(getClass().getResourceAsStream("fmi-GetCapabilities_2_0_0.xml"));
 
         Assert.assertNotNull(parsed);
@@ -142,7 +143,7 @@ public class WFS_2_0_0_ParsingTest {
     public void testParseGetCapabilitiesCuzk() throws Exception {
         configuration = new org.geotools.wfs.v2_0.WFSCapabilitiesConfiguration();
 
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(getClass().getResourceAsStream("cuzk-GetCapabilities_2_0_0.xml"));
 
         Assert.assertNotNull(parsed);
@@ -348,7 +349,7 @@ public class WFS_2_0_0_ParsingTest {
 
         try (InputStream in = new FileInputStream(tmp)) {
 
-            Parser parser = new Parser(configuration);
+            Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
             FeatureCollectionType fc = (FeatureCollectionType) parser.parse(in);
             Assert.assertNotNull(fc);
 

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
@@ -324,10 +324,10 @@ public class WFS_2_0_0_ParsingTest {
 
         try (InputStream in = getClass().getResourceAsStream("geoserver-GetFeature.xml")) {
 
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
             dbf.setNamespaceAware(true);
 
-            DocumentBuilder db = XMLUtils.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
             Document doc = db.parse(in);
 
             // http://cite.opengeospatial.org/gmlsf

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/WFS_2_0_0_ParsingTest.java
@@ -33,7 +33,6 @@ import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import net.opengis.fes20.FilterCapabilitiesType;
@@ -344,7 +343,7 @@ public class WFS_2_0_0_ParsingTest {
             tmp = File.createTempFile("geoserver-GetFeature", "xml");
             tmp.deleteOnExit();
 
-            Transformer tx = TransformerFactory.newInstance().newTransformer();
+            Transformer tx = XMLUtils.newTransformer();
             tx.transform(new DOMSource(doc), new StreamResult(tmp));
         }
 

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
@@ -69,6 +69,7 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.Schemas;
@@ -347,7 +348,7 @@ public class WFSParsingTest {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
 
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder();
             Document doc = db.parse(in);
 
             // http://cite.opengeospatial.org/gmlsf

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
@@ -345,10 +345,10 @@ public class WFSParsingTest {
 
         try (InputStream in = getClass().getResourceAsStream("geoserver-GetFeature.xml")) {
 
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
             dbf.setNamespaceAware(true);
 
-            DocumentBuilder db = XMLUtils.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
             Document doc = db.parse(in);
 
             // http://cite.opengeospatial.org/gmlsf

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
@@ -67,6 +67,7 @@ import org.geotools.api.filter.capability.FilterCapabilities;
 import org.geotools.api.filter.capability.Operator;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
@@ -101,7 +102,7 @@ public class WFSParsingTest {
 
         configuration = new org.geotools.wfs.v1_0.WFSCapabilitiesConfiguration();
 
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
         assertNotNull(parsed);
         assertTrue(parsed.getClass().getName(), parsed instanceof WFSCapabilitiesType);
@@ -115,7 +116,7 @@ public class WFSParsingTest {
     public void testParseGetCapabilities() throws Exception {
         configuration = new org.geotools.wfs.v1_0.WFSCapabilitiesConfiguration();
 
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(getClass().getResourceAsStream("geoserver-GetCapabilities.xml"));
 
         assertNotNull(parsed);
@@ -136,7 +137,7 @@ public class WFSParsingTest {
     @Test
     @Ignore
     public void testParseGetCapabilitiesDeegree() throws Exception {
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         WFSCapabilitiesType caps =
                 (WFSCapabilitiesType) parser.parse(getClass().getResourceAsStream("deegree-GetCapabilities.xml"));
 
@@ -368,7 +369,7 @@ public class WFSParsingTest {
         }
         try (InputStream in = new FileInputStream(tmp)) {
 
-            Parser parser = new Parser(configuration);
+            Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
             FeatureCollectionType fc = (FeatureCollectionType) parser.parse(in);
             assertNotNull(fc);
 
@@ -435,7 +436,7 @@ public class WFSParsingTest {
 
     @Test
     public void testParseTransactionResponse() throws IOException, SAXException, ParserConfigurationException {
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(getClass().getResourceAsStream("transactionResponse.xml"));
 
         assertNotNull(parsed);

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_0/WFSParsingTest.java
@@ -42,7 +42,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import net.opengis.ows10.DCPType;
@@ -365,7 +364,7 @@ public class WFSParsingTest {
             tmp = File.createTempFile("geoserver-GetFeature", "xml");
             tmp.deleteOnExit();
 
-            Transformer tx = TransformerFactory.newInstance().newTransformer();
+            Transformer tx = XMLUtils.newTransformer();
             tx.transform(new DOMSource(doc), new StreamResult(tmp));
         }
         try (InputStream in = new FileInputStream(tmp)) {

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSEncodingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSEncodingTest.java
@@ -29,6 +29,7 @@ import org.geotools.feature.NameImpl;
 import org.geotools.feature.type.FeatureTypeFactoryImpl;
 import org.geotools.gml3.GMLConfiguration;
 import org.geotools.test.xml.XmlTestSupport;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xs.XSSchema;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
@@ -247,7 +248,7 @@ public class WFSEncodingTest extends XmlTestSupport {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             encoder.encode(update, WFS.Update, out);
 
-            Parser parser = new Parser(new WFSConfiguration());
+            Parser parser = new Parser(new WFSConfiguration(), NullEntityResolver.INSTANCE);
             try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray())) {
                 UpdateElementType updateElementType = (UpdateElementType) parser.parse(in);
 

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
@@ -67,6 +67,7 @@ import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.wfs.WFSConfiguration;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.Schemas;
 import org.geotools.xsd.StreamingParser;
@@ -274,7 +275,7 @@ public class WFSParsingTest {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
 
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder();
             Document doc = db.parse(in);
 
             // http://cite.opengeospatial.org/gmlsf

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import javax.xml.namespace.QName;
@@ -245,7 +246,12 @@ public class WFSParsingTest {
     @Test
     public void testParseDescribeFeatureType() throws Exception {
         String loc = getClass().getResource("geoserver-DescribeFeatureType.xml").getFile();
-        XSDSchema schema = Schemas.parse(loc);
+        XSDSchema schema = Schemas.parse(
+                loc,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                NullEntityResolver.INSTANCE);
 
         assertNotNull(schema);
         final String targetNs = "http://cite.opengeospatial.org/gmlsf";

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
@@ -272,10 +272,10 @@ public class WFSParsingTest {
 
         try (InputStream in = getClass().getResourceAsStream("geoserver-GetFeature.xml")) {
 
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
             dbf.setNamespaceAware(true);
 
-            DocumentBuilder db = XMLUtils.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
             Document doc = db.parse(in);
 
             // http://cite.opengeospatial.org/gmlsf

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
@@ -40,7 +40,6 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import net.opengis.ows10.DCPType;
@@ -292,7 +291,7 @@ public class WFSParsingTest {
             tmp = File.createTempFile("geoserver-GetFeature", "xml");
             tmp.deleteOnExit();
 
-            Transformer tx = TransformerFactory.newInstance().newTransformer();
+            Transformer tx = XMLUtils.newTransformer();
             tx.transform(new DOMSource(doc), new StreamResult(tmp));
         }
 

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v1_1/WFSParsingTest.java
@@ -64,6 +64,7 @@ import org.geotools.api.filter.capability.FilterCapabilities;
 import org.geotools.api.filter.capability.SpatialOperators;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.wfs.WFSConfiguration;
 import org.geotools.xsd.Parser;
@@ -87,7 +88,7 @@ public class WFSParsingTest {
 
     @Test
     public void testParseGetCapabilities() throws Exception {
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         WFSCapabilitiesType caps =
                 (WFSCapabilitiesType) parser.parse(getClass().getResourceAsStream("geoserver-GetCapabilities.xml"));
 
@@ -105,7 +106,7 @@ public class WFSParsingTest {
     @Test
     @Ignore
     public void testParseGetCapabilitiesDeegree() throws Exception {
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         WFSCapabilitiesType caps =
                 (WFSCapabilitiesType) parser.parse(getClass().getResourceAsStream("deegree-GetCapabilities.xml"));
 
@@ -296,7 +297,7 @@ public class WFSParsingTest {
 
         try (InputStream in = new FileInputStream(tmp)) {
 
-            Parser parser = new Parser(configuration);
+            Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
             FeatureCollectionType fc = (FeatureCollectionType) parser.parse(in);
             assertNotNull(fc);
 
@@ -363,7 +364,7 @@ public class WFSParsingTest {
 
     @Test
     public void testParseTransactionResponse() throws IOException, SAXException, ParserConfigurationException {
-        Parser parser = new Parser(configuration);
+        Parser parser = new Parser(configuration, NullEntityResolver.INSTANCE);
         Object parsed = parser.parse(getClass().getResourceAsStream("transactionResponse.xml"));
 
         assertNotNull(parsed);

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/DescribeStoredQueriesTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/DescribeStoredQueriesTypeBindingTest.java
@@ -30,16 +30,17 @@ import net.opengis.wfs20.QueryExpressionTextType;
 import net.opengis.wfs20.StoredQueryDescriptionType;
 import org.geotools.wfs.WFS_2_0_0_ParsingTest;
 import org.geotools.wfs.v2_0.WFSTestSupport;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 
 public class DescribeStoredQueriesTypeBindingTest extends WFSTestSupport {
     @Test
     public void testParse() throws Exception {
-        DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
         docFactory.setNamespaceAware(true);
 
         try (InputStream is = WFS_2_0_0_ParsingTest.class.getResourceAsStream("fmi-DescribeStoredQueries_2_0_0.xml")) {
-            document = docFactory.newDocumentBuilder().parse(is);
+            document = XMLUtils.newDocumentBuilder(docFactory).parse(is);
         }
 
         Object o = parse();

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/GetFeatureStoredQueryBindingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/GetFeatureStoredQueryBindingTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.StringWriter;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import net.opengis.wfs20.GetFeatureType;
@@ -30,6 +29,7 @@ import net.opengis.wfs20.StoredQueryType;
 import net.opengis.wfs20.Wfs20Factory;
 import org.geotools.wfs.v2_0.WFS;
 import org.geotools.wfs.v2_0.WFSTestSupport;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
@@ -58,8 +58,7 @@ public class GetFeatureStoredQueryBindingTest extends WFSTestSupport {
 
         StringWriter writer = new StringWriter();
         StreamResult result = new StreamResult(writer);
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Transformer transformer = tf.newTransformer();
+        Transformer transformer = XMLUtils.newTransformer();
         transformer.transform(domSource, result);
 
         String asString = writer.toString();

--- a/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/LockFeatureTypeBindingTest.java
+++ b/modules/extension/xsd/xsd-wfs/src/test/java/org/geotools/wfs/v2_0/bindings/LockFeatureTypeBindingTest.java
@@ -9,6 +9,7 @@ import javax.xml.namespace.QName;
 import net.opengis.wfs20.LockFeatureType;
 import net.opengis.wfs20.QueryType;
 import org.geotools.api.filter.Id;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.wfs.v2_0.WFSConfiguration;
 import org.geotools.wfs.v2_0.WFSTestSupport;
 import org.geotools.xsd.Parser;
@@ -59,7 +60,7 @@ public class LockFeatureTypeBindingTest extends WFSTestSupport {
                 + "lockId=\"GeoServer_eb5fd6b6b6024d5\" service=\"WFS\" version=\"2.0.0\"> "
                 + "</wfs:LockFeature>";
 
-        Parser p = new Parser(new WFSConfiguration());
+        Parser p = new Parser(new WFSConfiguration(), NullEntityResolver.INSTANCE);
         p.validate(new StringReader(xml));
 
         assertTrue(p.getValidationErrors().isEmpty());

--- a/modules/extension/xsd/xsd-wms/src/test/java/org/geotools/wms/v1_3/WMSConfigurationTest.java
+++ b/modules/extension/xsd/xsd-wms/src/test/java/org/geotools/wms/v1_3/WMSConfigurationTest.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.logging.Logging;
 import org.geotools.xsd.Parser;
 import org.junit.Test;
@@ -19,7 +20,8 @@ public class WMSConfigurationTest {
 
     @Test
     public void testValidate() throws IOException, SAXException, ParserConfigurationException {
-        Parser p = new Parser(new WMSConfiguration());
+        Parser p = new Parser(new WMSConfiguration(), NullEntityResolver.INSTANCE);
+        p.setEntityResolver(NullEntityResolver.INSTANCE);
         p.setValidating(true);
         try (InputStream is = getClass().getResourceAsStream("./caps130.xml")) {
             p.parse(is);

--- a/modules/extension/xsd/xsd-wmts/src/test/java/org/geotools/wmts/v1/WMTSConfigurationTest.java
+++ b/modules/extension/xsd/xsd-wmts/src/test/java/org/geotools/wmts/v1/WMTSConfigurationTest.java
@@ -49,6 +49,7 @@ import org.geotools.util.logging.Logging;
 import org.geotools.wmts.WMTS;
 import org.geotools.wmts.WMTSConfiguration;
 import org.geotools.xlink.XLINK;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.geotools.xsd.ows.OWS;
@@ -474,14 +475,14 @@ public class WMTSConfigurationTest extends XmlTestSupport {
 
     /** Utility method to print out a dom. */
     protected void print(Document dom) throws Exception {
-        TransformerFactory txFactory = TransformerFactory.newInstance();
+        TransformerFactory txFactory = XMLUtils.newTransformerFactory();
         try {
             txFactory.setAttribute("{http://xml.apache.org/xalan}indent-number", Integer.valueOf(4));
         } catch (Exception e) {
             // some
         }
 
-        Transformer tx = txFactory.newTransformer();
+        Transformer tx = XMLUtils.newTransformer(txFactory);
         tx.setOutputProperty(OutputKeys.METHOD, "xml");
         tx.setOutputProperty(OutputKeys.INDENT, "yes");
 

--- a/modules/extension/xsd/xsd-wmts/src/test/java/org/geotools/wmts/v1/WMTSConfigurationTest.java
+++ b/modules/extension/xsd/xsd-wmts/src/test/java/org/geotools/wmts/v1/WMTSConfigurationTest.java
@@ -44,6 +44,7 @@ import net.opengis.wmts.v_1.LayerType;
 import org.geotools.filter.v1_1.OGC;
 import org.geotools.gml2.GML;
 import org.geotools.test.xml.XmlTestSupport;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.logging.Logging;
 import org.geotools.wmts.WMTS;
 import org.geotools.wmts.WMTSConfiguration;
@@ -74,7 +75,7 @@ public class WMTSConfigurationTest extends XmlTestSupport {
     @Test
     /** Test GEOT-6004 GetCapabilities fails for ows:Profile */
     public void testGEOT6004() throws IOException, SAXException, ParserConfigurationException {
-        Parser p = new Parser(new WMTSConfiguration());
+        Parser p = new Parser(new WMTSConfiguration(), NullEntityResolver.INSTANCE);
         // p.setValidating(false);
         Object parsed;
         try (InputStream is = getClass().getResourceAsStream("./wmtsGetCapabilities_6004.xml")) {
@@ -105,7 +106,7 @@ public class WMTSConfigurationTest extends XmlTestSupport {
     /** */
     private Map<String, LayerType> parseCaps(String capDoc)
             throws IOException, SAXException, ParserConfigurationException {
-        Parser p = new Parser(new WMTSConfiguration());
+        Parser p = new Parser(new WMTSConfiguration(), NullEntityResolver.INSTANCE);
         p.setValidating(false);
         Object parsed;
         try (InputStream is = getClass().getResourceAsStream(capDoc)) {
@@ -146,7 +147,7 @@ public class WMTSConfigurationTest extends XmlTestSupport {
     @Ignore
     @Test
     public void testValidate() throws IOException, SAXException, ParserConfigurationException {
-        Parser p = new Parser(new WMTSConfiguration());
+        Parser p = new Parser(new WMTSConfiguration(), NullEntityResolver.INSTANCE);
         p.setValidating(true);
         try (InputStream is = getClass().getResourceAsStream("./nasa.getcapa.xml")) {
             p.parse(is);
@@ -166,7 +167,7 @@ public class WMTSConfigurationTest extends XmlTestSupport {
     // been encoded correctly
     public void testEncode() throws Exception {
 
-        Parser myParser = new Parser(new WMTSConfiguration());
+        Parser myParser = new Parser(new WMTSConfiguration(), NullEntityResolver.INSTANCE);
 
         CapabilitiesType caps = (CapabilitiesType) myParser.parse(getClass().getResourceAsStream("nasa.getcapa.xml"));
 

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/ExecuteOnlineTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/ExecuteOnlineTest.java
@@ -24,6 +24,7 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.logging.Logger;
 import javax.xml.parsers.ParserConfigurationException;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.logging.Logging;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -41,7 +42,7 @@ public class ExecuteOnlineTest {
     public void testExecute() throws IOException, SAXException, ParserConfigurationException {
         URL url = new URL("http://schemas.opengis.net/wps/1.0.0/examples/51_wpsExecute_request_ResponseDocument.xml");
         try (BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
-            Parser parser = new Parser(new WPSConfiguration());
+            Parser parser = new Parser(new WPSConfiguration(), NullEntityResolver.INSTANCE);
             Object obj = parser.parse(in);
             Assert.assertNotNull(obj);
         } catch (UnknownHostException notFound) {

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/ExecuteTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/ExecuteTest.java
@@ -42,6 +42,7 @@ import net.opengis.wps10.Wps10Factory;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
@@ -131,7 +132,7 @@ public class ExecuteTest extends XMLTestSupport {
 
     @Test
     public void testParserDelegateNamespaces() throws Exception {
-        Parser p = new Parser(new WPSConfiguration());
+        Parser p = new Parser(new WPSConfiguration(), NullEntityResolver.INSTANCE);
         ExecuteType exec =
                 (ExecuteType) p.parse(getClass().getResourceAsStream("wpsExecute_inlineGetFeature_request.xml"));
         assertNotNull(exec);
@@ -152,7 +153,7 @@ public class ExecuteTest extends XMLTestSupport {
 
     @Test
     public void testFilterParserDelegate() throws Exception {
-        Parser p = new Parser(new WPSConfiguration());
+        Parser p = new Parser(new WPSConfiguration(), NullEntityResolver.INSTANCE);
         ExecuteType exec = (ExecuteType) p.parse(getClass().getResourceAsStream("wpsExecuteFilterInline.xml"));
         assertNotNull(exec);
         assertEquals(1, exec.getDataInputs().getInput().size());

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/GetCapabilitiesTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/GetCapabilitiesTest.java
@@ -33,6 +33,7 @@ import net.opengis.wps10.LanguagesType1;
 import net.opengis.wps10.ProcessBriefType;
 import net.opengis.wps10.ProcessOfferingsType;
 import net.opengis.wps10.WPSCapabilitiesType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class GetCapabilitiesTest {
     @Test
     public void testParse() throws Exception {
         WPSConfiguration wps = new WPSConfiguration();
-        Parser parser = new Parser(wps);
+        Parser parser = new Parser(wps, NullEntityResolver.INSTANCE);
 
         Object o = parser.parse(getClass().getResourceAsStream("20_wpsGetCapabilities_response.xml"));
         Assert.assertTrue(o instanceof WPSCapabilitiesType);

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/DescribeProcessTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/DescribeProcessTest.java
@@ -12,6 +12,7 @@ import net.opengis.wps20.ProcessDescriptionType;
 import net.opengis.wps20.ProcessOfferingType;
 import net.opengis.wps20.ProcessOfferingsType;
 import org.eclipse.emf.common.util.EList;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -20,7 +21,7 @@ public class DescribeProcessTest extends WPSTestSupport {
 
     @Test
     public void testParse() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
 
         Object o = parser.parse(getClass().getResourceAsStream("wpsProcessOfferingsExample.xml"));
         Assert.assertTrue(o instanceof ProcessOfferingsType);

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/GetCapabilitiesTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/GetCapabilitiesTest.java
@@ -13,6 +13,7 @@ import net.opengis.ows20.ServiceIdentificationType;
 import net.opengis.ows20.ServiceProviderType;
 import net.opengis.wps20.ProcessSummaryType;
 import net.opengis.wps20.WPSCapabilitiesType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -21,7 +22,7 @@ public class GetCapabilitiesTest extends WPSTestSupport {
 
     @Test
     public void testParse() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
 
         Object o = parser.parse(getClass().getResourceAsStream("wpsCapabilitiesDocumentExample.xml"));
         Assert.assertTrue(o instanceof WPSCapabilitiesType);

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/WPSExecuteTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/WPSExecuteTest.java
@@ -3,6 +3,7 @@ package org.geotools.wps.v2_0;
 import net.opengis.wps20.DataInputType;
 import net.opengis.wps20.ExecuteRequestType;
 import net.opengis.wps20.OutputDefinitionType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
 import org.junit.Test;
@@ -11,7 +12,7 @@ public class WPSExecuteTest extends WPSTestSupport {
 
     @Test
     public void testParse() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
 
         Object o = parser.parse(getClass().getResourceAsStream("wpsExecuteRequestExample.xml"));
         Assert.assertTrue(o instanceof ExecuteRequestType);

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/WPSResultTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/WPSResultTest.java
@@ -3,6 +3,7 @@ package org.geotools.wps.v2_0;
 import net.opengis.wps20.DataOutputType;
 import net.opengis.wps20.GetResultType;
 import net.opengis.wps20.ResultType;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -12,7 +13,7 @@ public class WPSResultTest extends WPSTestSupport {
 
     @Test
     public void testParseResultRequest() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
 
         Object o = parser.parse(getClass().getResourceAsStream("wpsResultRequestExample.xml"));
         Assert.assertTrue(o instanceof GetResultType);
@@ -28,7 +29,7 @@ public class WPSResultTest extends WPSTestSupport {
 
     @Test
     public void testParseResultResponse() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
         Object o = parser.parse(getClass().getResourceAsStream("wpsResultResponseExample.xml"));
         Assert.assertTrue(o instanceof ResultType);
 

--- a/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/WPSStatusTest.java
+++ b/modules/extension/xsd/xsd-wps/src/test/java/org/geotools/wps/v2_0/WPSStatusTest.java
@@ -3,6 +3,7 @@ package org.geotools.wps.v2_0;
 import net.opengis.wps20.GetStatusType;
 import net.opengis.wps20.StatusInfoType;
 import net.opengis.wps20.StatusTypeMember0;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.Encoder;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -12,7 +13,7 @@ public class WPSStatusTest extends WPSTestSupport {
 
     @Test
     public void testParseStatusRequest() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
         Object o = parser.parse(getClass().getResourceAsStream("wpsStatusRequestExample.xml"));
         Assert.assertTrue(o instanceof GetStatusType);
 
@@ -26,7 +27,7 @@ public class WPSStatusTest extends WPSTestSupport {
 
     @Test
     public void testParseStatusInfo() throws Exception {
-        Parser parser = new Parser(createConfiguration());
+        Parser parser = new Parser(createConfiguration(), NullEntityResolver.INSTANCE);
 
         Object o = parser.parse(getClass().getResourceAsStream("wpsStatusResponseExample.xml"));
         Assert.assertTrue(o instanceof StatusInfoType);

--- a/modules/extension/ysld/src/main/java/org/geotools/ysld/Ysld.java
+++ b/modules/extension/ysld/src/main/java/org/geotools/ysld/Ysld.java
@@ -41,6 +41,7 @@ import org.geotools.api.style.ResourceLocator;
 import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.styling.zoom.ZoomContextFinder;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xml.styling.SLDParser;
 import org.geotools.ysld.encode.YsldEncoder;
 import org.geotools.ysld.parse.YsldParser;
@@ -115,7 +116,7 @@ public class Ysld {
     public static XMLStreamReader xmlReader(Object input) throws IOException {
         YsldInput in = reader(input);
         try {
-            XMLInputFactory xmlFactory = XMLInputFactory.newFactory();
+            XMLInputFactory xmlFactory = XMLUtils.newXMLInputFactory();
             try {
                 return xmlFactory.createXMLStreamReader(in.reader);
             } catch (XMLStreamException e) {

--- a/modules/extension/ysld/src/test/java/org/geotools/ysld/transform/sld/SldTransformerTest.java
+++ b/modules/extension/ysld/src/test/java/org/geotools/ysld/transform/sld/SldTransformerTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.StringWriter;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
+import org.geotools.xml.XMLUtils;
 import org.geotools.ysld.YamlMap;
 import org.geotools.ysld.YamlUtil;
 import org.geotools.ysld.Ysld;
@@ -1952,7 +1953,7 @@ public class SldTransformerTest {
 
     SldTransformer transformer(String dirname, String filename) throws Exception {
         StringWriter yaml = new StringWriter();
-        XMLInputFactory factory = XMLInputFactory.newFactory();
+        XMLInputFactory factory = XMLUtils.newXMLInputFactory();
         XMLStreamReader xml = factory.createXMLStreamReader(YsldTests.sld(dirname, filename));
         return new SldTransformer(xml, yaml);
     }

--- a/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGeneric3DOnlineTest.java
+++ b/modules/library/jdbc/src/test/java/org/geotools/jdbc/JDBCGeneric3DOnlineTest.java
@@ -275,8 +275,7 @@ public abstract class JDBCGeneric3DOnlineTest extends JDBCTestSupport {
          * Use a LiteCoordinateSequence, since this mimics GeoServer behaviour better, and it exposes bugs in
          * CoordinateSequence handling.
          */
-        final Hints hints = new Hints();
-        hints.put(Hints.JTS_COORDINATE_SEQUENCE_FACTORY, new LiteCoordinateSequenceFactory());
+        final Hints hints = new Hints(Hints.JTS_COORDINATE_SEQUENCE_FACTORY, new LiteCoordinateSequenceFactory());
         Query query = new Query(tname(getPoly3d()));
         query.setHints(hints);
 

--- a/modules/library/main/src/main/java/org/geotools/data/DataTestCase.java
+++ b/modules/library/main/src/main/java/org/geotools/data/DataTestCase.java
@@ -36,6 +36,7 @@ import org.geotools.api.filter.Id;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.factory.Hints;
 import org.junit.After;
 import org.junit.Before;
 import org.locationtech.jts.geom.Coordinate;
@@ -291,6 +292,8 @@ public abstract class DataTestCase {
         buildingType = null;
         buildingFeatures = null;
         buildingBounds = null;
+
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     /**

--- a/modules/library/main/src/main/java/org/geotools/data/ows/ServiceExceptionParser.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/ServiceExceptionParser.java
@@ -50,6 +50,7 @@ public class ServiceExceptionParser {
         List<ServiceException> exceptions = new ArrayList<>();
         try {
             XMLInputFactory inputFactory = XMLInputFactory.newInstance(); // NOPMD AvoidXMLInputFactory
+
             // disable resolving of external DTD entities (coalescing needs to be false)
             inputFactory.setProperty(IS_COALESCING, false);
             inputFactory.setProperty(IS_REPLACING_ENTITY_REFERENCES, false);

--- a/modules/library/main/src/main/java/org/geotools/data/ows/ServiceExceptionParser.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/ServiceExceptionParser.java
@@ -49,7 +49,7 @@ public class ServiceExceptionParser {
     public static ServiceException parse(InputStream inputStream) throws IOException {
         List<ServiceException> exceptions = new ArrayList<>();
         try {
-            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            XMLInputFactory inputFactory = XMLInputFactory.newInstance(); // NOPMD AvoidXMLInputFactory
             // disable resolving of external DTD entities (coalescing needs to be false)
             inputFactory.setProperty(IS_COALESCING, false);
             inputFactory.setProperty(IS_REPLACING_ENTITY_REFERENCES, false);

--- a/modules/library/main/src/main/java/org/geotools/filter/IllegalFilterException.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/IllegalFilterException.java
@@ -21,7 +21,7 @@ import java.io.Serial;
 /**
  * Defines an exception for illegal filters.
  *
- * <p>TODO: JD: Changed this exception to runtime exception. Go through all methods that throw this expception and
+ * <p>TODO: JD: Changed this exception to runtime exception. Go through all methods that throw this exception and
  * reflect the new geoapi method throws it with a javadoc.
  */
 public class IllegalFilterException extends RuntimeException {

--- a/modules/library/main/src/test/java/org/geotools/data/util/NumericConverterFactoryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/data/util/NumericConverterFactoryTest.java
@@ -181,8 +181,7 @@ public class NumericConverterFactoryTest {
     }
 
     Object convertSafe(Object source, Class<?> target) throws Exception {
-        Hints hints = new Hints();
-        hints.put(ConverterFactory.SAFE_CONVERSION, Boolean.TRUE);
+        Hints hints = new Hints(ConverterFactory.SAFE_CONVERSION, Boolean.TRUE);
         return factory.createConverter(source.getClass(), target, hints).convert(source, target);
     }
 

--- a/modules/library/main/src/test/java/org/geotools/filter/ExpressionDomParserTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/ExpressionDomParserTest.java
@@ -86,6 +86,7 @@ public class ExpressionDomParserTest {
 
     Node getDocumentNode() throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        @SuppressWarnings("PMD.AvoidDocumentBuilder")
         DocumentBuilder builder = factory.newDocumentBuilder();
         StringBuilder xmlStringBuilder = new StringBuilder();
         xmlStringBuilder.append("<?xml version=\"1.0\"?> <Literal>3</Literal>");

--- a/modules/library/main/src/test/java/org/geotools/filter/ExpressionDomParserTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/ExpressionDomParserTest.java
@@ -85,9 +85,8 @@ public class ExpressionDomParserTest {
     }
 
     Node getDocumentNode() throws ParserConfigurationException, SAXException, IOException {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        @SuppressWarnings("PMD.AvoidDocumentBuilder")
-        DocumentBuilder builder = factory.newDocumentBuilder();
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance(); // NOPMD AvoidDocumentBuilderFactory
+        DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD AvoidDocumentBuilder
         StringBuilder xmlStringBuilder = new StringBuilder();
         xmlStringBuilder.append("<?xml version=\"1.0\"?> <Literal>3</Literal>");
         ByteArrayInputStream input =

--- a/modules/library/main/src/test/java/org/geotools/filter/function/ParseTimeFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/ParseTimeFunctionTest.java
@@ -72,12 +72,18 @@ public class ParseTimeFunctionTest {
 
     private static void assertionForParsedInstance(String expression, TemporalAmount timeInThePast) {
         Function parseTime = FF.function("parseTime", FF.literal(expression));
+
+        Instant generatedDate = Instant.now().minus(timeInThePast);
         Date date = (Date) parseTime.evaluate(null);
-
-        Instant generatedDate = Instant.now().minus(timeInThePast).truncatedTo(ChronoUnit.SECONDS);
-
         Instant evaluatedTime = date.toInstant().truncatedTo(ChronoUnit.SECONDS);
-        assertEquals(generatedDate, evaluatedTime);
+
+        // round to nearest second (add 0.5 second and truncate)
+        Instant generatedDateRounded =
+                generatedDate.plus(500, ChronoUnit.MICROS).truncatedTo(ChronoUnit.SECONDS);
+        Instant evaluatedTimeRounded =
+                evaluatedTime.plus(500, ChronoUnit.MICROS).truncatedTo(ChronoUnit.SECONDS);
+
+        assertEquals(timeInThePast.toString(), generatedDateRounded, evaluatedTimeRounded);
     }
 
     private static void assertionForParseLocalDateTIme(

--- a/modules/library/main/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
+++ b/modules/library/main/src/test/java/org/geotools/geometry/jts/ReferencedEnvelopeTest.java
@@ -19,7 +19,6 @@ import org.geotools.referencing.CRS;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.referencing.crs.DefaultProjectedCRS;
-import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.junit.After;
 import org.junit.Before;
@@ -34,7 +33,6 @@ public class ReferencedEnvelopeTest {
         // its configuration, necessary when tests are run by Maven, one JVM for all
         // the tests in this module
         Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, Boolean.FALSE);
-        GeoTools.fireConfigurationChanged();
     }
 
     @Test
@@ -351,6 +349,5 @@ public class ReferencedEnvelopeTest {
     @After
     public void tearDown() throws Exception {
         Hints.putSystemDefault(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, Boolean.TRUE);
-        GeoTools.fireConfigurationChanged();
     }
 }

--- a/modules/library/metadata/src/main/java/org/geotools/util/DefaultEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/DefaultEntityResolver.java
@@ -32,7 +32,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.ext.EntityResolver2;
 
 /**
  * Entity Resolver which allows to resolve on OGC & INSPIRE schemas, roughly inspired from the `AllowListEntityResolver`
@@ -42,7 +41,7 @@ import org.xml.sax.ext.EntityResolver2;
  *
  * @author Pierre Mauduit (Camptocamp)
  */
-public class DefaultEntityResolver implements EntityResolver2, Serializable {
+public class DefaultEntityResolver implements EntityResolver3, Serializable {
 
     @Serial
     private static final long serialVersionUID = -793816026668809854L;
@@ -100,6 +99,17 @@ public class DefaultEntityResolver implements EntityResolver2, Serializable {
                 + "|"
                 + Pattern.quote(INSPIRE)
                 + ")/[^?#;]*\\.(xsd|dtd)");
+    }
+
+    /**
+     * DefaultEntityResolver allows access to {@code "http"} protocol, and select internal content
+     * {@code "jar:file,jar:nested,vfs"}.
+     *
+     * @return {@code "http,jar:file,jar:nested,vfs"}
+     */
+    @Override
+    public String getAccess() {
+        return "http,jar:file,jar:nested,vfs";
     }
 
     @Override

--- a/modules/library/metadata/src/main/java/org/geotools/util/DefaultEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/DefaultEntityResolver.java
@@ -63,15 +63,16 @@ public class DefaultEntityResolver implements EntityResolver2, Serializable {
     private static final String ERROR_MESSAGE_BASE = "Entity resolution disallowed for {0}";
 
     /**
-     * Internal uri references.
+     * Internal uri schema references.
      *
      * <ul>
-     *   <li>allow schema parsing for validation.
-     *   <li>jar - internal schema reference
-     *   <li>vfs - internal schema reference (JBoss/WildFly)
+     *   <li>allow {@code xsd} schema parsing for validation
+     *   <li>{@code jar:file} - internal schema reference
+     *   <li>{@code jar:nested} - internal schema reference (SpringBoot)
+     *   <li>{@code vfs} - internal schema reference (JBoss/WildFly)
      * </ul>
      */
-    private static final Pattern INTERNAL_URIS = Pattern.compile("(?i)(jar:file|vfs)[^?#;]*\\.(xsd|dtd)$");
+    private static final Pattern INTERNAL_URIS = Pattern.compile("(?i)(jar:file|jar:nested|vfs)[^?#;]*\\.(xsd|dtd)$");
 
     /** Only allow XSD or DTD URIs that do not contain a URI query or fragment */
     private static final Pattern XSD_OR_DTD_URIS = Pattern.compile("(?i)^[^?#;]*\\.(xsd|dtd)$");

--- a/modules/library/metadata/src/main/java/org/geotools/util/EntityResolver3.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/EntityResolver3.java
@@ -1,0 +1,44 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.util;
+
+import javax.xml.XMLConstants;
+import org.xml.sax.ext.EntityResolver2;
+
+/**
+ * Extends EntityResolver2 to provide additional information on protocols supported.
+ *
+ * <p>This information is used proactively limit EntityResolution by configuring {@code DocumentFactory},
+ * {@code SchemaFactory}, etc to only use the supported protocols.
+ *
+ * <p>For more information see {@code gt-xml} module {@code XMLUtils}.
+ *
+ * @see XMLConstants#ACCESS_EXTERNAL_DTD
+ * @see XMLConstants#ACCESS_EXTERNAL_SCHEMA
+ */
+public interface EntityResolver3 extends EntityResolver2 {
+    /**
+     * Comma seperated list of entity resolution protocols required for EntityResolver to function.
+     *
+     * <p>Common examples: {@code "http"},{@code "file"}, or combined {@code "file,http"}.
+     *
+     * <p>To allow all access {@code "all"}, or to suppress all access {@code ""} supported.
+     *
+     * @return Comma seperated list of protocols, allow all {@code "all"}, or none {@code ""}.
+     */
+    public String getAccess();
+}

--- a/modules/library/metadata/src/main/java/org/geotools/util/NullEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/NullEntityResolver.java
@@ -67,4 +67,9 @@ public class NullEntityResolver implements EntityResolver2, Serializable {
             throws SAXException, IOException {
         return null;
     }
+
+    @Override
+    public String toString() {
+        return "NullEntityResolver";
+    }
 }

--- a/modules/library/metadata/src/main/java/org/geotools/util/NullEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/NullEntityResolver.java
@@ -31,7 +31,7 @@ import org.xml.sax.ext.EntityResolver2;
  *
  * @author Jody Garnett (Boundless)
  */
-public class NullEntityResolver implements EntityResolver2, Serializable {
+public class NullEntityResolver implements EntityResolver3, Serializable {
 
     /** serialVersionUID */
     @Serial
@@ -42,6 +42,16 @@ public class NullEntityResolver implements EntityResolver2, Serializable {
 
     protected NullEntityResolver() {
         // singleton
+    }
+
+    /**
+     * NullEntityResolver allows access to {@code "all"} protocols.
+     *
+     * @return {@code "all"}
+     */
+    @Override
+    public String getAccess() {
+        return "all";
     }
 
     /** @return {@code null} to request that the parser open a regular URI connection to the system identifier. */

--- a/modules/library/metadata/src/main/java/org/geotools/util/PreventLocalEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/PreventLocalEntityResolver.java
@@ -24,7 +24,6 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -36,7 +35,7 @@ import org.xml.sax.helpers.DefaultHandler;
  *
  * <p>When parsing an XML entity reference to a local file a SAXException is thrown, which can be handled appropriately.
  *
- * <p>This implementation is both recommended and the default returned by {@link GeoTools#getEntityResolver()}.
+ * <p>For a more restrictive EntityResolver {@link DefaultEntityResolver} is recommended.
  *
  * @author Davide Savazzi - geo-solutions.it
  */

--- a/modules/library/metadata/src/main/java/org/geotools/util/PreventLocalEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/PreventLocalEntityResolver.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
 import org.geotools.util.logging.Logging;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.ext.EntityResolver2;
 import org.xml.sax.helpers.DefaultHandler;
 
 /**
@@ -39,7 +38,7 @@ import org.xml.sax.helpers.DefaultHandler;
  *
  * @author Davide Savazzi - geo-solutions.it
  */
-public class PreventLocalEntityResolver implements EntityResolver2, Serializable {
+public class PreventLocalEntityResolver implements EntityResolver3, Serializable {
 
     /** serialVersionUID */
     @Serial
@@ -68,6 +67,17 @@ public class PreventLocalEntityResolver implements EntityResolver2, Serializable
 
     protected PreventLocalEntityResolver() {
         // singleton
+    }
+
+    /**
+     * PreventLocalEntityResolver provides access {@code "http"} and internal {@code "jar:file,jar:nested,vfs"}
+     * protocols.
+     *
+     * @return {@code "http,jar:file,jar:nested,vfs"}
+     */
+    @Override
+    public String getAccess() {
+        return "http,jar:file,jar:nested,vfs";
     }
 
     @Override

--- a/modules/library/metadata/src/main/java/org/geotools/util/PreventLocalEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/PreventLocalEntityResolver.java
@@ -51,11 +51,17 @@ public class PreventLocalEntityResolver implements EntityResolver2, Serializable
 
     protected static final Logger LOGGER = Logging.getLogger(PreventLocalEntityResolver.class);
 
-    // allow schema parsing for validation.
-    // http(s) - external schema reference
-    // jar - internal schema reference
-    // vfs - internal schema reference (JBoss/WildFly)
-    // jar:nested - internal schema reference (Spring Boot)
+    /**
+     * Allow uri references schema parsing for validation.
+     *
+     * <ul>
+     *   <li>allow {@code xsd} schema parsing for validation
+     *   <li>{@code http(s)} - external schema reference
+     *   <li>{@code jar} - internal schema reference
+     *   <li>{@code jar:nested} - internal schema reference (SpringBoot)
+     *   <li>{@code vfs} - internal schema reference (JBoss/WildFly)
+     * </ul>
+     */
     private static final Pattern ALLOWED_URIS = Pattern.compile("(?i)(jar:file|jar:nested|http|vfs)[^?#;]*\\.xsd");
 
     /** Singleton instance of PreventLocalEntityResolver */

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/FactoryChangeListener.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/FactoryChangeListener.java
@@ -1,0 +1,29 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.util.factory;
+
+import java.util.EventListener;
+
+public interface FactoryChangeListener extends EventListener {
+
+    /**
+     * Invoked on factory configuration change.
+     *
+     * @param e a ChangeEvent object
+     */
+    void configurationChanged(FactoryConfigurationEvent e);
+}

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/FactoryConfigurationEvent.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/FactoryConfigurationEvent.java
@@ -1,0 +1,48 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.util.factory;
+
+import java.awt.RenderingHints;
+import java.io.Serial;
+import java.util.EventObject;
+import java.util.Map;
+
+/** FactoryConfigurationEvent is used to notify that GeoTools library configuration has changed. */
+public class FactoryConfigurationEvent extends EventObject {
+    @Serial
+    private static final long serialVersionUID = 3154238322369916489L;
+
+    private final Map<RenderingHints.Key, Object> hints;
+
+    public FactoryConfigurationEvent(Object source) {
+        this(source, null);
+    }
+
+    public FactoryConfigurationEvent(Object source, Map<RenderingHints.Key, Object> hints) {
+        super(source);
+        this.hints = hints;
+    }
+
+    /**
+     * Indications of changes that have occurred, or {@code null} for a system-wide change.
+     *
+     * @return factory configuration changes
+     */
+    public Map<RenderingHints.Key, Object> getHints() {
+        return hints;
+    }
+}

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
@@ -747,6 +747,7 @@ public final class GeoTools {
      * @see #getDefaultHints
      */
     public static void init() {
+        Hints.scanSystemProperties();
         if (Logging.ALL.getLoggerFactory() == null) {
             final String[] CANDIDATES = {
                 "org.geotools.util.logging.LogbackLoggerFactory",
@@ -1183,10 +1184,34 @@ public final class GeoTools {
      * Adds the specified listener to the list of objects to inform when system-wide configuration changed.
      *
      * @param listener The listener to add.
+     * @deprecated Use {@link #addConfigurationListener(FactoryChangeListener)} instead, which provdes details of
+     *     configuration change to listeners.
      */
+    @Deprecated
     public static void addChangeListener(final ChangeListener listener) {
         removeChangeListener(listener); // Ensure singleton.
         LISTENERS.add(ChangeListener.class, listener);
+    }
+    /**
+     * Adds the specified listener to the list of objects to inform when system-wide configuration changed.
+     *
+     * @param listener The listener to add.
+     */
+    public static void addConfigurationListener(final FactoryChangeListener listener) {
+        removeChangeListener(listener); // Ensure singleton.
+        LISTENERS.add(FactoryChangeListener.class, listener);
+    }
+
+    /**
+     * Removes the specified listener from the list of objects to inform when system-wide configuration changed.
+     *
+     * @param listener The listener to remove.
+     * @deprecated Use {@link #removeConfigurationListener(FactoryChangeListener)} instead, which provdes details of
+     *     configuration change to listeners.
+     */
+    @Deprecated
+    public static void removeChangeListener(final ChangeListener listener) {
+        LISTENERS.remove(ChangeListener.class, listener);
     }
 
     /**
@@ -1194,18 +1219,37 @@ public final class GeoTools {
      *
      * @param listener The listener to remove.
      */
-    public static void removeChangeListener(final ChangeListener listener) {
-        LISTENERS.remove(ChangeListener.class, listener);
+    public static void removeChangeListener(final FactoryChangeListener listener) {
+        LISTENERS.remove(FactoryChangeListener.class, listener);
     }
 
-    /** Informs every listeners that system-wide configuration changed. */
+    /** Informs every listener of a system-wide configuration changed. */
     public static void fireConfigurationChanged() {
-        final ChangeEvent event = new ChangeEvent(GeoTools.class);
+        fireConfigurationChanged(null);
+    }
+
+    /** Informs every listener of a system-wide configuration changed. */
+    public static void fireConfigurationChanged(Map<RenderingHints.Key, Object> hints) {
+        final ChangeEvent changeEvent = new javax.swing.event.ChangeEvent(GeoTools.class);
+        final FactoryConfigurationEvent configEvent = new FactoryConfigurationEvent(GeoTools.class, hints);
+
         final Object[] listeners = LISTENERS.getListenerList();
+        RuntimeException problem = null;
         for (int i = 0; i < listeners.length; i += 2) {
-            if (listeners[i] == ChangeListener.class) {
-                ((ChangeListener) listeners[i + 1]).stateChanged(event);
+            try {
+                if (listeners[i] == ChangeListener.class) {
+                    ((ChangeListener) listeners[i + 1]).stateChanged(changeEvent);
+                } else if (listeners[i] == FactoryChangeListener.class) {
+                    ((FactoryChangeListener) listeners[i + 1]).configurationChanged(configEvent);
+                }
+            } catch (RuntimeException unexpected) {
+                if (problem == null) problem = unexpected;
+            } catch (Throwable e) {
+                if (problem == null) problem = new RuntimeException(e);
             }
+        }
+        if (problem != null) {
+            throw problem;
         }
     }
 

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
@@ -883,7 +883,11 @@ public final class GeoTools {
         return Hints.getDefaults(false);
     }
 
-    /** Used to combine provided hints with global GeoTools defaults. */
+    /**
+     * Used to combine provided hints with global GeoTools defaults.
+     *
+     * @return A copy of the GeoTools default hints, with provided Hints added.
+     */
     public static Hints addDefaultHints(final Hints hints) {
         final Hints completed = getDefaultHints();
         if (hints != null) {

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1078,8 +1079,10 @@ public class Hints extends RenderingHints {
     }
 
     /**
-     * Invokes {@link GeoTools#scanSystemProperties} when first needed. The caller is responsible for invoking
-     * {@link GeoTools#fireConfigurationChanged} if this method returns {@code true}.
+     * Invokes {@link GeoTools#scanForSystemHints(Map)} when first needed. The caller is responsible for invoking
+     * {@link GeoTools#fireConfigurationChanged(RenderingHints)} if this method returns {@code true}.
+     *
+     * <p>See {@link #changedHints(boolean, Map)} for code example.
      *
      * @return {@code true} if at least one hint changed as a result of this scan, or {@code false} otherwise.
      */
@@ -1095,27 +1098,76 @@ public class Hints extends RenderingHints {
         }
     }
 
+    /**
+     * Create a diff of what has changed in {@link #GLOBAL} after a chage, such as whenb
+     * {@code ensureSystemDefaultLoaded()} is called. This is used so we can fire a configuration change event with only
+     * the hints that have changed.
+     *
+     * <pre>{@literal
+     * Map<RenderingHints.Key, Object> previous = new ConcurrentHashMap<>(GLOBAL);
+     * final boolean changed = ensureSystemDefaultLoaded();
+     * final Object value = GLOBAL.get(key);
+     * Hints changedHints = changedHints(changed, previous);
+     * if (changedHints != null) {
+     *     GeoTools.fireConfigurationChanged(changedHints);
+     * }}</pre>
+     *
+     * @param changed The result of {@code ensureSystemDefaultLoaded()}
+     * @param previous The previous GLOBAL
+     * @return Hints capturing any change, or {@code null} for no change.
+     */
+    private static Map<RenderingHints.Key, Object> changedHints(
+            boolean changed, Map<RenderingHints.Key, Object> previous) {
+        if (changed) {
+            Map<RenderingHints.Key, Object> changes = new HashMap<>();
+            if (previous != null) {
+                changes.putAll(previous);
+            }
+            for (Map.Entry<RenderingHints.Key, Object> entry : GLOBAL.entrySet()) {
+                if (Objects.equals(entry.getValue(), changes.get(entry.getKey()))) {
+                    changes.remove(entry.getKey()); // unchanged
+                }
+                changes.put(entry.getKey(), entry.getValue()); // changed or added
+            }
+            for (Map.Entry<RenderingHints.Key, Object> entry : changes.entrySet()) {
+                if (!GLOBAL.containsKey(entry.getKey())) {
+                    entry.setValue(null);
+                }
+            }
+            return changes;
+        }
+        return null;
+    }
+
     /** Returns a copy of the system hints. This is for {@link GeoTools#getDefaultHints} implementation only. */
     static Hints getDefaults(final boolean strict) {
         final Hints hints;
+
+        Map<RenderingHints.Key, Object> previous = new HashMap<>(GLOBAL);
         final boolean changed = ensureSystemDefaultLoaded();
+        Map<RenderingHints.Key, Object> changes = changedHints(changed, previous);
+
         if (strict) {
             hints = new StrictHints(GLOBAL);
         } else {
             hints = new Hints(GLOBAL);
         }
         if (changed) {
-            GeoTools.fireConfigurationChanged();
+            GeoTools.fireConfigurationChanged(changes);
         }
         return hints;
     }
 
     /** Adds all specified hints to the system hints. This is for {@link GeoTools#init} implementation only. */
     static void putSystemDefault(final RenderingHints hints) {
+        Map<RenderingHints.Key, Object> previous = new HashMap<>(GLOBAL);
+
         ensureSystemDefaultLoaded();
         Map<RenderingHints.Key, Object> map = toMap(hints);
         GLOBAL.putAll(map);
-        GeoTools.fireConfigurationChanged();
+
+        Map<RenderingHints.Key, Object> changedHints = changedHints(true, previous);
+        GeoTools.fireConfigurationChanged(changedHints);
     }
 
     /**
@@ -1141,10 +1193,13 @@ public class Hints extends RenderingHints {
      * @since 2.4
      */
     public static Object getSystemDefault(final RenderingHints.Key key) {
+        Map<RenderingHints.Key, Object> previous = new ConcurrentHashMap<>(GLOBAL);
+
         final boolean changed = ensureSystemDefaultLoaded();
         final Object value = GLOBAL.get(key);
-        if (changed) {
-            GeoTools.fireConfigurationChanged();
+        Map<RenderingHints.Key, Object> changedHints = changedHints(changed, previous);
+        if (changedHints != null) {
+            GeoTools.fireConfigurationChanged(changedHints);
         }
         return value;
     }
@@ -1166,7 +1221,9 @@ public class Hints extends RenderingHints {
         final boolean changed = ensureSystemDefaultLoaded();
         final Object old = GLOBAL.put(key, value);
         if (changed || !Utilities.equals(value, old)) {
-            GeoTools.fireConfigurationChanged();
+            Map<RenderingHints.Key, Object> changes = new HashMap<>();
+            changes.put(key, value);
+            GeoTools.fireConfigurationChanged(changes);
         }
         return old;
     }
@@ -1182,7 +1239,9 @@ public class Hints extends RenderingHints {
         final boolean changed = ensureSystemDefaultLoaded();
         final Object old = GLOBAL.remove(key);
         if (changed || old != null) {
-            GeoTools.fireConfigurationChanged();
+            Map<RenderingHints.Key, Object> changes = new HashMap<>();
+            changes.put(key, null);
+            GeoTools.fireConfigurationChanged(changes);
         }
         return old;
     }
@@ -1196,22 +1255,20 @@ public class Hints extends RenderingHints {
     @Override
     public String toString() {
         final String lineSeparator = System.getProperty("line.separator", "\n");
-        final StringBuilder buffer = new StringBuilder("Hints:"); // TODO: localize
+        final StringBuilder buffer = new StringBuilder("Hints:");
         buffer.append(lineSeparator).append(AbstractFactory.toString(this));
         Map<?, ?> extra = null;
-        final boolean changed = ensureSystemDefaultLoaded();
-        if (!GLOBAL.isEmpty()) {
-            extra = new HashMap<>(GLOBAL);
-        }
-        if (changed) {
-            GeoTools.fireConfigurationChanged();
-        }
-        if (extra != null) {
-            extra.keySet().removeAll(keySet());
-            if (!extra.isEmpty()) {
-                buffer.append("System defaults:") // TODO: localize
-                        .append(lineSeparator)
-                        .append(AbstractFactory.toString(extra));
+        if (needScan.get()) {
+            buffer.append("System defaults: not loaded");
+        } else {
+            if (!GLOBAL.isEmpty()) {
+                extra = new HashMap<>(GLOBAL);
+            }
+            if (extra != null) {
+                extra.keySet().removeAll(keySet());
+                if (!extra.isEmpty()) {
+                    buffer.append("System defaults:").append(lineSeparator).append(AbstractFactory.toString(extra));
+                }
             }
         }
         return buffer.toString();

--- a/modules/library/metadata/src/test/java/org/geotools/util/factory/PlaceholderEntityResolver.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/factory/PlaceholderEntityResolver.java
@@ -23,11 +23,16 @@ import org.xml.sax.SAXException;
 
 /** Placeholder EntityResolver used to test {@link SVGGraphicFactory#defaultResolver()}. */
 public class PlaceholderEntityResolver implements EntityResolver {
-    /** No argumentgs constructor */
+    /** No arguments constructor */
     public PlaceholderEntityResolver() {}
 
     @Override
     public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
         return null;
+    }
+
+    @Override
+    public String toString() {
+        return "PlaceholderEntityResolver";
     }
 }

--- a/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
+++ b/modules/library/referencing/src/main/java/org/geotools/referencing/CRS.java
@@ -19,6 +19,7 @@ package org.geotools.referencing;
 import static org.geotools.referencing.cs.DefaultCoordinateSystemAxis.EASTING;
 import static org.geotools.referencing.cs.DefaultCoordinateSystemAxis.NORTHING;
 
+import java.awt.RenderingHints;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.text.MessageFormat;
@@ -32,8 +33,6 @@ import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.swing.event.ChangeEvent;
-import javax.swing.event.ChangeListener;
 import org.geotools.api.geometry.Bounds;
 import org.geotools.api.geometry.MismatchedDimensionException;
 import org.geotools.api.metadata.citation.Citation;
@@ -97,6 +96,8 @@ import org.geotools.util.SoftValueHashMap;
 import org.geotools.util.UnsupportedImplementationException;
 import org.geotools.util.Version;
 import org.geotools.util.factory.Factory;
+import org.geotools.util.factory.FactoryChangeListener;
+import org.geotools.util.factory.FactoryConfigurationEvent;
 import org.geotools.util.factory.FactoryNotFoundException;
 import org.geotools.util.factory.FactoryRegistryException;
 import org.geotools.util.factory.GeoTools;
@@ -178,17 +179,29 @@ public final class CRS {
 
     /* Registers a listener automatically invoked when the system-wide configuration changed. */
     static {
-        GeoTools.addChangeListener(new ChangeListener() {
+        GeoTools.addConfigurationListener(new FactoryChangeListener() {
             @Override
-            public void stateChanged(ChangeEvent e) {
-                synchronized (CRS.class) {
-                    defaultFactory = null;
-                    xyFactory = null;
-                    strictFactory = null;
-                    lenientFactory = null;
-                    xyCache.clear();
-                    wktCache.clear();
-                    defaultCache.clear();
+            public void configurationChanged(FactoryConfigurationEvent e) {
+                Map<RenderingHints.Key, Object> changes = e.getHints();
+                if (changes == null
+                        || changes.containsKey(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER)
+                        || changes.containsKey(Hints.FORCE_STANDARD_AXIS_UNITS)
+                        || changes.containsKey(Hints.FORCE_STANDARD_AXIS_DIRECTIONS)
+                        || changes.containsKey(Hints.FORCE_AXIS_ORDER_HONORING)
+                        || changes.containsKey(Hints.CRS_AUTHORITY_FACTORY)
+                        || changes.containsKey(Hints.CRS_FACTORY)
+                        || changes.containsKey(Hints.CRS_AUTHORITY_EXTRA_DIRECTORY)
+                        || changes.containsKey(Hints.COORDINATE_OPERATION_FACTORY)
+                        || changes.containsKey(Hints.COORDINATE_OPERATION_AUTHORITY_FACTORY)) {
+                    synchronized (CRS.class) {
+                        defaultFactory = null;
+                        xyFactory = null;
+                        strictFactory = null;
+                        lenientFactory = null;
+                        xyCache.clear();
+                        wktCache.clear();
+                        defaultCache.clear();
+                    }
                 }
             }
         });

--- a/modules/library/render/pom.xml
+++ b/modules/library/render/pom.xml
@@ -91,6 +91,10 @@
     </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
       <artifactId>gt-cql</artifactId>
     </dependency>
     <dependency>

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/BatikXMLReader.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/BatikXMLReader.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.geotools.xml.XMLUtils;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.DTDHandler;
 import org.xml.sax.EntityResolver;
@@ -46,9 +47,9 @@ public class BatikXMLReader implements XMLReader {
     XMLReader reader;
 
     public BatikXMLReader() throws ParserConfigurationException, SAXException {
-        SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
         parserFactory.setNamespaceAware(true);
-        SAXParser parser = parserFactory.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
         reader = parser.getXMLReader();
     }
 

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GradientColorMapGenerator.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/gridcoverage2d/GradientColorMapGenerator.java
@@ -20,7 +20,6 @@ import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.style.ColorMap;
@@ -32,6 +31,7 @@ import org.geotools.styling.ColorMapImpl;
 import org.geotools.util.Converter;
 import org.geotools.util.SoftValueHashMap;
 import org.geotools.util.Utilities;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -246,8 +246,7 @@ public class GradientColorMapGenerator {
     private static GradientColorMapGenerator parseSVG(final File xmlFile)
             throws SAXException, IOException, ParserConfigurationException {
         Utilities.ensureNonNull("xmlFile", xmlFile);
-        final DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-        final DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        final DocumentBuilder dBuilder = XMLUtils.newDocumentBuilder();
         final Document doc = dBuilder.parse(xmlFile);
         doc.getDocumentElement().normalize();
         final NodeList nList = doc.getElementsByTagName("stop");

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/RendererBaseTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/RendererBaseTest.java
@@ -48,6 +48,7 @@ import org.geotools.renderer.style.FontCache;
 import org.geotools.sld.v1_1.SLDConfiguration;
 import org.geotools.styling.DefaultResourceLocator;
 import org.geotools.test.TestData;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xml.styling.SLDParser;
 import org.geotools.xsd.Parser;
 import org.junit.Assert;
@@ -252,7 +253,7 @@ public abstract class RendererBaseTest {
                 }
             };
             Parser parser = new Parser(configuration);
-
+            parser.setEntityResolver(NullEntityResolver.INSTANCE);
             StyledLayerDescriptor sld = (StyledLayerDescriptor) parser.parse(surl.openStream());
 
             for (int i = 0; i < sld.getStyledLayers().length; i++) {

--- a/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
@@ -24,6 +24,8 @@ import java.util.logging.Level;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.handlers.DocumentHandler;
 import org.geotools.xml.schema.Schema;
 import org.xml.sax.SAXException;
@@ -64,7 +66,7 @@ public class DocumentFactory {
 
     /**
      * When this hint is contained and set to Boolean.TRUE, external entities will be disabled. This setting is used to
-     * alivate XXE attacks, preventing both {@link #VALIDATION_HINT} and {@link XMLHandlerHints#ENTITY_RESOLVER} from
+     * alleviate XXE attacks, preventing both {@link #VALIDATION_HINT} and {@link XMLHandlerHints#ENTITY_RESOLVER} from
      * being effective.
      */
     public static final String DISABLE_EXTERNAL_ENTITIES = "DocumentFactory_DISABLE_EXTERNAL_ENTITIES";
@@ -131,14 +133,21 @@ public class DocumentFactory {
      * Convenience method to create an instance of a SAXParser if it is null.
      */
     private static SAXParser getParser(Map<String, Object> hints) throws SAXException {
-        SAXParserFactory spf = null;
-        if (hints != null && hints.containsKey(XMLHandlerHints.SAX_PARSER_FACTORY)) {
-            spf = (SAXParserFactory) hints.get(XMLHandlerHints.SAX_PARSER_FACTORY);
-        } else {
-            spf = SAXParserFactory.newInstance();
+
+        Hints factoryConfig = GeoTools.getDefaultHints();
+        if (hints != null && hints.containsKey(XMLHandlerHints.ENTITY_RESOLVER)) {
+            factoryConfig.put(Hints.ENTITY_RESOLVER, hints.get(XMLHandlerHints.ENTITY_RESOLVER));
         }
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+
+        SAXParserFactory saxParserFactory;
+        if (hints != null && hints.containsKey(XMLHandlerHints.SAX_PARSER_FACTORY)) {
+            SAXParserFactory provided = (SAXParserFactory) hints.get(XMLHandlerHints.SAX_PARSER_FACTORY);
+            saxParserFactory = XMLUtils.toSAXParserFactory(provided, factoryConfig);
+        } else {
+            saxParserFactory = XMLUtils.newSAXParserFactory(factoryConfig);
+        }
+        saxParserFactory.setNamespaceAware(true);
+        saxParserFactory.setValidating(false);
 
         try {
             // Extra precaution to reduce/prevent XXE attacks
@@ -150,17 +159,17 @@ public class DocumentFactory {
             //
             // Note: XMLSaxHandler will reject all DTD references - but we may as well avoid early
             // spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 
             // Step 2 optionally disable external entities
             //
             if (hints != null
                     && hints.containsKey(DISABLE_EXTERNAL_ENTITIES)
                     && Boolean.TRUE.equals(hints.get(DISABLE_EXTERNAL_ENTITIES))) {
-                spf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             }
-            SAXParser sp = spf.newSAXParser();
+            SAXParser sp = XMLUtils.newSAXParser(saxParserFactory, factoryConfig);
             return sp;
         } catch (ParserConfigurationException e) {
             throw new SAXException(e);

--- a/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
@@ -34,10 +34,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import org.geotools.referencing.ReferencingFactoryFinder;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.xml.resolver.SchemaCache;
 import org.geotools.xml.resolver.SchemaResolver;
 import org.geotools.xml.schema.Attribute;
@@ -76,14 +78,15 @@ public class SchemaFactory {
      */
     private Map<URI, Schema> schemas = loadSchemas();
 
-    /** Schema Resolver: uses local versions of schemas or cached ones if available. */
     File cacheDir;
 
+    /** Schema Resolver: uses local versions of schemas or cached ones if available. */
     private SchemaResolver resolver;
 
-    /*
-     * The SAX parser to use if one is required ... isn't loaded until first
-     * use.
+    /**
+     * The SAX parser to use if one is required ... isn't loaded until first use.
+     *
+     * <p>See {@link #setParser()}
      */
     private SAXParser parser;
 
@@ -111,12 +114,12 @@ public class SchemaFactory {
         }
     }
 
+    /** SchemaFactory instance */
     protected static SchemaFactory getInstance() {
         return is;
     }
 
-    /*
-     */
+    /** Load schemas from ClassLoaders. */
     private Map<URI, Schema> loadSchemas() {
         schemas = new HashMap<>();
 
@@ -402,16 +405,18 @@ public class SchemaFactory {
     }
 
     /*
-     * convinience method to create an instance of a SAXParser if it is null.
+     * Convenience method to create an instance of a SAXParser for Schema processing, if it is {@code null}.
      */
     private void setParser() throws SAXException {
         if (parser == null) {
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setNamespaceAware(true);
-            spf.setValidating(false);
-
+            SAXParserFactory saxParserFactory = XMLUtils.newSAXParserFactory();
+            saxParserFactory.setNamespaceAware(true);
+            saxParserFactory.setValidating(false);
             try {
-                parser = spf.newSAXParser();
+                parser = XMLUtils.newSAXParser(saxParserFactory);
+                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(null));
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
             } catch (ParserConfigurationException | SAXException e) {
                 throw new SAXException(e);
             }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLHandlerHints.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLHandlerHints.java
@@ -45,10 +45,10 @@ public class XMLHandlerHints implements Map<String, Object> {
     public static final String FILTER_COMPLIANCE_STRICTNESS = "org.geotools.xml.filter.FILTER_COMPLIANCE_STRICTNESS";
     /** Supplied {@link EntityResolver} for Schema and/or DTD validation */
     public static final String ENTITY_RESOLVER = GeoTools.ENTITY_RESOLVER;
-    /** Supplied {@link SaxParserFactory} */
+    /** Supplied {@code SaxParserFactory} */
     public static final String SAX_PARSER_FACTORY = "javax.xml.parsers.SAXParserFactory";
 
-    /** The value so that the parser will encode all Geotools filters with no modifications. */
+    /** The value so that the parser will encode all GeoTools filters with no modifications. */
     public static final Integer VALUE_FILTER_COMPLIANCE_LOW = Integer.valueOf(0);
     /**
      * The value so the parser will be slightly more compliant to the Filter 1.0.0 spec. It will encode:

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -19,6 +19,7 @@ package org.geotools.xml;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -68,6 +69,19 @@ import org.xml.sax.helpers.NamespaceSupport;
  */
 public class XMLUtils {
     static final Logger LOGGER = Logging.getLogger(XMLUtils.class);
+
+    //
+    // SAXParser and SAXParserFactory utility methods
+    //
+    /**
+     * Create a new SAXParserFactory that respects library configuration.
+     *
+     * @return SAX Parser Factory
+     */
+    public static SAXParserFactory newSAXParserFactory() {
+        return newSAXParserFactory(null);
+    }
+
     /**
      * Create a new SAXParserFactory that respects library configuration.
      *
@@ -76,8 +90,81 @@ public class XMLUtils {
      */
     public static SAXParserFactory newSAXParserFactory(final Hints hints) {
         // Factory applying GeoTools configuration to SAXParserFactory
-        return new GTSAXParserFactory(hints);
+        return newSAXParserFactory(null, hints);
     }
+
+    /**
+     * Create a new SAXParser that respects library configuration.
+     *
+     * @param hints Factory hints
+     * @return SAX Parser Factory
+     */
+    public static SAXParserFactory newSAXParserFactory(final SAXParserFactory factory, final Hints hints) {
+        // Factory applying GeoTools configuration to SAXParserFactory
+        return new GTSAXParserFactory(factory, hints);
+    }
+
+    /**
+     * Cast / wraps to GTSAXParserFactory respecting GeoTools configuration.
+     *
+     * @param factory SAXParserFactory factory, or {@code null}
+     * @param hints Factory configuration
+     * @return GTSAXParserFactory respecting GeoTools configuration.
+     */
+    public static GTSAXParserFactory toSAXParserFactory(SAXParserFactory factory, Hints hints) {
+        if (factory == null) {
+            return new GTSAXParserFactory(hints);
+        } else if (factory instanceof GTSAXParserFactory gtSaxParserFactory) {
+            if (Objects.equals(gtSaxParserFactory.hints, hints)) {
+                return gtSaxParserFactory;
+            } else {
+                // Wrap original factory with modified hints
+                return new GTSAXParserFactory(gtSaxParserFactory.factory, hints);
+            }
+        }
+        return new GTSAXParserFactory(factory, hints);
+    }
+
+    /**
+     * Creates a new instance of a SAXParser using GeoTools configuration.
+     *
+     * @return SAXParser setup with library configuration
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     */
+    public static SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+        return toSAXParserFactory(null, null).newSAXParser();
+    }
+
+    /**
+     * Creates a new instance of a SAXParser provided factory, applying GeoTools configuration.
+     *
+     * @return SAXParser
+     * @param factory SAXParserFactory factory, or {@code null}
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     */
+    public static SAXParser newSAXParser(SAXParserFactory factory) throws ParserConfigurationException, SAXException {
+        return toSAXParserFactory(factory, null).newSAXParser();
+    }
+
+    /**
+     * Creates a new instance of a SAXParser provided factory, applying GeoTools configuration.
+     *
+     * @return SAXParser
+     * @param factory SAXParserFactory factory, or {@code null}
+     * @param hints Factory configuration
+     * @throws ParserConfigurationException
+     * @throws SAXException
+     */
+    public static SAXParser newSAXParser(SAXParserFactory factory, Hints hints)
+            throws ParserConfigurationException, SAXException {
+        return toSAXParserFactory(factory, hints).newSAXParser();
+    }
+
+    //
+    // TransformerFactory and Transformer utility methods
+    //
 
     /**
      * Create a new TransformerFactory that respects library configuration.
@@ -113,7 +200,7 @@ public class XMLUtils {
 
     /** Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}. */
     public static Transformer newTransformer(Hints hints) throws TransformerConfigurationException {
-        return newTransformerFactory(hints).newTransformer(); // NOPMD AvoidTransform
+        return newTransformerFactory(hints).newTransformer(); // NOPMD
     }
 
     /**
@@ -144,7 +231,7 @@ public class XMLUtils {
     }
 
     /**
-     * Cast to GTTransformerFactory or GTSAXTransformFactory respecting GeoTools configuration.
+     * Cast /wraps to GTTransformerFactory or GTSAXTransformFactory respecting GeoTools configuration.
      *
      * @param factory Transformer factory, or {@code null}
      * @param hints Factory configuration
@@ -153,11 +240,19 @@ public class XMLUtils {
     protected static TransformerFactory toTransformerFactory(TransformerFactory factory, Hints hints) {
         if (factory == null) {
             return new GTTransformerFactory(hints);
-        } else if (factory instanceof GTSAXTransformerFactory saxFactory) {
-            if (saxFactory.hints == hints) {
+        } else if (factory instanceof GTTransformerFactory gtTransformerFactory) {
+            if (Objects.equals(gtTransformerFactory.hints, hints)) {
+                return gtTransformerFactory;
+            } else {
+                // Wrap original factory with modified hints
+                return new GTTransformerFactory(gtTransformerFactory.factory, hints);
+            }
+        } else if (factory instanceof GTSAXTransformerFactory gtSaxFactory) {
+            if (Objects.equals(gtSaxFactory.hints, hints)) {
                 return factory;
             } else {
-                return new GTSAXTransformerFactory(saxFactory, hints);
+                // Wrap original factory with modified hints
+                return new GTSAXTransformerFactory(gtSaxFactory.factory, hints);
             }
         } else if (factory instanceof SAXTransformerFactory saxFactory) {
             return new GTSAXTransformerFactory(saxFactory, hints);
@@ -172,7 +267,7 @@ public class XMLUtils {
      * @return XML transformer
      */
     public static Transformer newTransformer(Source source) throws TransformerConfigurationException {
-        return newTransformerFactory().newTransformer(source);
+        return newTransformer(source, null);
     }
 
     /**
@@ -183,7 +278,7 @@ public class XMLUtils {
      * @return XML transformer
      */
     public static Transformer newTransformer(Source source, Hints hints) throws TransformerConfigurationException {
-        return newTransformerFactory(hints).newTransformer(source);
+        return newTransformer(null, source, null);
     }
 
     /**
@@ -195,7 +290,7 @@ public class XMLUtils {
      */
     public static Transformer newTransformer(TransformerFactory factory, Source source)
             throws TransformerConfigurationException {
-        return toTransformerFactory(factory, GeoTools.getDefaultHints()).newTransformer(source);
+        return newTransformer(factory, source, null);
     }
 
     /**
@@ -208,7 +303,7 @@ public class XMLUtils {
      */
     public static Transformer newTransformer(TransformerFactory factory, Source source, Hints hints)
             throws TransformerConfigurationException {
-        return toTransformerFactory(factory, hints).newTransformer(source);
+        return toTransformerFactory(factory, hints).newTransformer(source); // NOPMD AvoidTransformer
     }
 
     /**
@@ -394,7 +489,7 @@ public class XMLUtils {
     public static void checkSupportForJAXP15Properties() {
         List<String> classes = new ArrayList<>();
         try {
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            TransformerFactory transformerFactory = TransformerFactory.newInstance(); // NOPMD AvoidTransformerFactory
             try {
                 transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
                 transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
@@ -475,18 +570,62 @@ public class XMLUtils {
         // || ((c >= 0x10000) && (c <= 0x10FFFF));
     }
 
+    /**
+     * Apply GeoTools configuration to the transformer, including {@code GeoTools.getEntityResolver(hints)}.
+     *
+     * @param transformer XML Transformer
+     * @return transformer
+     */
+    static Transformer config(Transformer transformer, Hints hints) {
+        URIResolver uriResolver = transformer.getURIResolver();
+        if (uriResolver != null && !(uriResolver instanceof GTURIResolver)) {
+            final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+            transformer.setURIResolver(new GTURIResolver(entityResolver, uriResolver, hints));
+        } else {
+            transformer.setURIResolver(new GTURIResolver(GeoTools.getEntityResolver(hints), null, hints));
+        }
+        return transformer;
+    }
+
+    /**
+     * Apply GeoTools configuration to TransformHandler.
+     *
+     * @param handler Transform handler
+     * @return Transform handler
+     */
+    static TransformerHandler config(TransformerHandler handler, Hints hints) {
+        XMLUtils.config(handler.getTransformer(), hints);
+        return handler;
+    }
+
+    /**
+     * Apply GeoTools configuration to XMLFilter.
+     *
+     * @param filter XML Fitler
+     * @return XML Filter
+     */
+    static XMLFilter config(XMLFilter filter, Hints hints) {
+        filter.setEntityResolver(GeoTools.getEntityResolver(hints));
+        return filter;
+    }
+
     /** Wrapper ensuring system SAXParserFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
     private static class GTSAXParserFactory extends SAXParserFactory {
-        private final SAXParserFactory factory;
-        private final Hints hints;
+        protected final SAXParserFactory factory;
+        protected final Hints hints;
 
         public GTSAXParserFactory(Hints hints) {
+            this(SAXParserFactory.newInstance(), hints); // NOPMD AvoidParserzfactory
+        }
+
+        public GTSAXParserFactory(SAXParserFactory factory, Hints hints) {
             this.hints = hints;
-            this.factory = SAXParserFactory.newInstance();
+            this.factory = factory != null ? factory : SAXParserFactory.newInstance(); // NOPMD AvoidParserFactory
             try {
-                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-                // feature secure processing recommended, but not supported
+                LOGGER.finer("Parser does not support secure processing feature: "
+                        + this.factory.getClass().getName());
             }
         }
 
@@ -545,7 +684,9 @@ public class XMLUtils {
         @Override
         public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
             SAXParser parser = factory.newSAXParser();
-            parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(hints));
+            if (parser.getXMLReader() != null) {
+                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(hints));
+            }
             return parser;
         }
 
@@ -630,39 +771,22 @@ public class XMLUtils {
         protected final TransformerFactory factory;
 
         public GTTransformerFactory(Hints hints) {
-            this(TransformerFactory.newInstance(), hints);
+            this(null, hints);
         }
 
         public GTTransformerFactory(TransformerFactory factory, Hints hints) {
             this.hints = hints != null ? hints : GeoTools.getDefaultHints();
-            this.factory = factory;
+            this.factory = factory != null ? factory : TransformerFactory.newInstance(); // NOPMD AvoidTransformer
         }
 
         @Override
         public Transformer newTransformer(Source source) throws TransformerConfigurationException {
-            return config(factory.newTransformer(source));
+            return XMLUtils.config(factory.newTransformer(source), hints); // NOPMD AvoidTransformerSource
         }
 
         @Override
         public Transformer newTransformer() throws TransformerConfigurationException {
-            return config(factory.newTransformer()); // NOPMD AvoidTransform
-        }
-
-        /**
-         * Apply GeoTools configuration to the transformer, including {@code GeoTools.getEntityResolver(hints)}.
-         *
-         * @param transformer XML Transformer
-         * @return transformer
-         */
-        protected Transformer config(Transformer transformer) {
-            URIResolver uriResolver = transformer.getURIResolver();
-            if (uriResolver != null && !(uriResolver instanceof GTURIResolver)) {
-                final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-                transformer.setURIResolver(new GTURIResolver(entityResolver, uriResolver));
-            } else {
-                transformer.setURIResolver(new GTURIResolver(GeoTools.getEntityResolver(hints)));
-            }
-            return transformer;
+            return XMLUtils.config(factory.newTransformer(), hints); // NOPMD AvoidTransform
         }
 
         @Override
@@ -770,56 +894,17 @@ public class XMLUtils {
             this.factory = factory;
             this.hints = hints != null ? hints : GeoTools.getDefaultHints();
         }
-        // apply configuration
-        /**
-         * Apply GeoTools configuration to the transformer, including {@code GeoTools.getEntityResolver(hints)}.
-         *
-         * @param transformer XML Transformer
-         * @return transformer
-         */
-        protected Transformer config(Transformer transformer) {
-            URIResolver uriResolver = transformer.getURIResolver();
-            if (uriResolver != null && !(uriResolver instanceof GTURIResolver)) {
-                final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-                transformer.setURIResolver(new GTURIResolver(entityResolver, uriResolver));
-            } else {
-                transformer.setURIResolver(new GTURIResolver(GeoTools.getEntityResolver(hints)));
-            }
-            return transformer;
-        }
-
-        /**
-         * Apply GeoTools configuration to TransformHandler.
-         *
-         * @param handler Transform handler
-         * @return Transform handler
-         */
-        protected TransformerHandler config(TransformerHandler handler) {
-            config(handler.getTransformer());
-            return handler;
-        }
-
-        /**
-         * Apply GeoTools configuration to XMLFilter.
-         *
-         * @param filter XML Fitler
-         * @return XML Filter
-         */
-        protected XMLFilter config(XMLFilter filter) {
-            filter.setEntityResolver(GeoTools.getEntityResolver(hints));
-            return filter;
-        }
 
         // overrides
 
         @Override
         public Transformer newTransformer(Source source) throws TransformerConfigurationException {
-            return config(factory.newTransformer(source));
+            return XMLUtils.config(factory.newTransformer(source), hints); // NOPMD AvoidTransform
         }
 
         @Override
         public Transformer newTransformer() throws TransformerConfigurationException {
-            return config(factory.newTransformer()); // NOPMD AvoidTransform
+            return XMLUtils.config(factory.newTransformer(), null); // NOPMD AvoidTransform
         }
 
         @Override
@@ -876,17 +961,17 @@ public class XMLUtils {
 
         @Override
         public TransformerHandler newTransformerHandler(Source src) throws TransformerConfigurationException {
-            return config(factory.newTransformerHandler(src));
+            return XMLUtils.config(factory.newTransformerHandler(src), hints);
         }
 
         @Override
         public TransformerHandler newTransformerHandler(Templates templates) throws TransformerConfigurationException {
-            return config(factory.newTransformerHandler(templates));
+            return XMLUtils.config(factory.newTransformerHandler(templates), hints);
         }
 
         @Override
         public TransformerHandler newTransformerHandler() throws TransformerConfigurationException {
-            return config(factory.newTransformerHandler());
+            return XMLUtils.config(factory.newTransformerHandler(), hints);
         }
 
         @Override
@@ -896,12 +981,12 @@ public class XMLUtils {
 
         @Override
         public XMLFilter newXMLFilter(Source src) throws TransformerConfigurationException {
-            return config(factory.newXMLFilter(src));
+            return XMLUtils.config(factory.newXMLFilter(src), null);
         }
 
         @Override
         public XMLFilter newXMLFilter(Templates templates) throws TransformerConfigurationException {
-            return config(factory.newXMLFilter(templates));
+            return XMLUtils.config(factory.newXMLFilter(templates), hints);
         }
 
         @Override
@@ -914,14 +999,20 @@ public class XMLUtils {
     private static class GTURIResolver implements URIResolver {
         private final EntityResolver entityResolver;
         private final URIResolver uriResolver;
+        private final Hints hints;
 
         public GTURIResolver(EntityResolver entityResolver) {
             this(entityResolver, null);
         }
 
         public GTURIResolver(EntityResolver entityResolver, URIResolver uriResolver) {
+            this(entityResolver, uriResolver, null);
+        }
+
+        public GTURIResolver(EntityResolver entityResolver, URIResolver uriResolver, Hints hints) {
             this.entityResolver = entityResolver;
             this.uriResolver = uriResolver;
+            this.hints = hints;
         }
 
         @Override
@@ -929,7 +1020,12 @@ public class XMLUtils {
             try {
                 // step 1: check with entity resolver, will return null (external), source (internal), or exception
                 // (forbidden)
-                entityResolver.resolveEntity(href, base);
+                InputSource source = entityResolver.resolveEntity(href, base);
+                if (source != null) {
+                    // resolved internally, wrap and apply GeoTools configuration
+                    return XMLUtils.sax(source, hints);
+                }
+
                 // step 2: check with uri resolver
                 if (uriResolver != null) {
                     return uriResolver.resolve(href, base);

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -90,11 +90,20 @@ public class XMLUtils {
     /**
      * Creates an XMLInputFactory configured with GeoTools library defaults.
      *
+     * <p>The XMLInputFactory provided will be configured to be more forgiving when {@code NullEntityResolver} is used
+     * as this indicates the library is configured to work with local files.
+     *
+     * <p>When working with EntityResolvers allowing `http` access, such as {@code `DefaultEntityResolver`} more
+     * restrictions are enforced.
+     *
      * @param hints Factory hints
      * @return XMLInputFactory
      */
     public static XMLInputFactory newXMLInputFactory(Hints hints) {
         XMLInputFactory factory = XMLInputFactory.newInstance(); // NOPMD AvoidXMLInputFactory
+
+        // Used to determine sensible defaults based on entity resolver selected
+        EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
 
         // Disable DTD: few of our protocols / formats are old enough to require DTD
         if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
@@ -104,7 +113,13 @@ public class XMLUtils {
                 factory.setProperty(XMLInputFactory.IS_COALESCING, false);
             }
             if (factory.isPropertySupported(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES)) {
-                factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+                if (entityResolver == NullEntityResolver.INSTANCE) {
+                    factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, true);
+                } else if (entityResolver == DefaultEntityResolver.INSTANCE) {
+                    factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+                } else {
+                    factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+                }
             }
         }
 

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -159,23 +159,23 @@ public class XMLUtils {
      */
     public static DocumentBuilder newDocumentBuilder(Hints hints) throws ParserConfigurationException {
         DocumentBuilderFactory factory = newDocumentBuilderFactory(hints);
-
+        @SuppressWarnings("PMD.AvoidDocumentBuilder")
         DocumentBuilder builder = factory.newDocumentBuilder();
         builder.setEntityResolver(GeoTools.getEntityResolver(hints));
         return builder;
     }
 
     /** Create a new DocumentBuilderFactory that respects library configuration. */
-    public static DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+    public static DocumentBuilderFactory newDocumentBuilderFactory() {
         return newDocumentBuilderFactory(GeoTools.getDefaultHints());
     }
 
     /**
      * Create a new DocumentBuilderFactory that respects library configuration.
      *
-     * @param Hints Factory hints
+     * @param hints Factory hints
      */
-    public static DocumentBuilderFactory newDocumentBuilderFactory(Hints hints) throws ParserConfigurationException {
+    public static DocumentBuilderFactory newDocumentBuilderFactory(Hints hints) {
         return new GTDocumentBuilderFactory(hints);
     }
 
@@ -399,7 +399,7 @@ public class XMLUtils {
 
         @Override
         public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
-            // @SuppressWarnings("PMD.AvoidDocumentBuilder")
+            @SuppressWarnings("PMD.AvoidDocumentBuilder")
             DocumentBuilder builder = factory.newDocumentBuilder();
             builder.setEntityResolver(GeoTools.getEntityResolver(hints));
 

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -19,6 +19,7 @@ package org.geotools.xml;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -26,14 +27,19 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Source;
 import javax.xml.transform.SourceLocator;
+import javax.xml.transform.Templates;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
 import javax.xml.transform.sax.SAXSource;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TemplatesHandler;
+import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import org.geotools.util.factory.GeoTools;
@@ -44,6 +50,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLFilter;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.NamespaceSupport;
 
@@ -58,10 +65,38 @@ public class XMLUtils {
      * Create a new SAXParserFactory that respects library configuration.
      *
      * @param hints Factory hints
+     * @return SAX Parser Factory
      */
     public static SAXParserFactory newSAXParserFactory(final Hints hints) {
         // Factory applying GeoTools configuration to SAXParserFactory
         return new GTSAXParserFactory(hints);
+    }
+
+    /**
+     * Create a new TransformerFactory that respects library configuration.
+     *
+     * @return Transformer Factory
+     */
+    public static TransformerFactory newTransformerFactory() {
+        return newTransformerFactory(GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Create a new TransformerFactory that respects library configuration.
+     *
+     * @param hints Factory hints
+     * @return Transformer Factory
+     */
+    public static TransformerFactory newTransformerFactory(final Hints hints) {
+        return new GTTransformerFactory(hints);
+    }
+
+    public static SAXTransformerFactory newSaxTransformerFactory() {
+        return newSaxTransformerFactory(GeoTools.getDefaultHints());
+    }
+
+    public static SAXTransformerFactory newSaxTransformerFactory(final Hints hints) {
+        return new GTSAXTransformerFactory(hints);
     }
 
     /** Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}. */
@@ -71,25 +106,101 @@ public class XMLUtils {
 
     /** Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}. */
     public static Transformer newTransformer(Hints hints) throws TransformerConfigurationException {
-        TransformerFactory xformerFactory = TransformerFactory.newInstance();
-        URIResolver uriResolver = xformerFactory.getURIResolver();
-        if (uriResolver != null) {
-            final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-            xformerFactory.setURIResolver((href, base) -> {
-                try {
-                    entityResolver.resolveEntity(href, base);
-                    return uriResolver.resolve(href, base);
-                } catch (SAXParseException e) {
-                    TransformerException transformerException = new TransformerException(e);
-                    SourceLocator sourceLocator = new SaxParseExceptionSourceLocator(e);
-                    transformerException.setLocator(sourceLocator);
-                    throw transformerException;
-                } catch (SAXException | IOException e) {
-                    throw new TransformerException(e);
-                }
-            });
+        return newTransformerFactory(hints).newTransformer(); // NOPMD AvoidTransform
+    }
+
+    /**
+     * Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}.
+     *
+     * @param factory
+     */
+    public static Transformer newTransformer(TransformerFactory factory) throws TransformerConfigurationException {
+        if (factory == null) {
+            throw new NullPointerException("TransformerFactory required");
         }
-        return xformerFactory.newTransformer();
+        return newTransformer(factory, GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}.
+     *
+     * @param factory Factory pre-configured with information such as indenting
+     * @param hints Factory configuration
+     * @return XML transformer
+     */
+    public static Transformer newTransformer(TransformerFactory factory, Hints hints)
+            throws TransformerConfigurationException {
+        if (factory == null) {
+            throw new NullPointerException("TransformerFactory required");
+        }
+        return toTransformerFactory(factory, hints).newTransformer(); // NOPMD AvoidTransform
+    }
+
+    /**
+     * Cast to GTTransformerFactory or GTSAXTransformFactory respecting GeoTools configuration.
+     *
+     * @param factory Transformer factory, or {@code null}
+     * @param hints Factory configuration
+     * @return GTTransformerFactory or GTSAXTransformFactory respecting GeoTools configuration.
+     */
+    protected static TransformerFactory toTransformerFactory(TransformerFactory factory, Hints hints) {
+        if (factory == null) {
+            return new GTTransformerFactory(hints);
+        } else if (factory instanceof GTSAXTransformerFactory saxFactory) {
+            if (saxFactory.hints == hints) {
+                return factory;
+            } else {
+                return new GTSAXTransformerFactory(saxFactory, hints);
+            }
+        } else if (factory instanceof SAXTransformerFactory saxFactory) {
+            return new GTSAXTransformerFactory(saxFactory, hints);
+        }
+        return new GTTransformerFactory(factory, hints);
+    }
+
+    /**
+     * Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}.
+     *
+     * @param source Source input
+     * @return XML transformer
+     */
+    public static Transformer newTransformer(Source source) throws TransformerConfigurationException {
+        return newTransformerFactory().newTransformer(source);
+    }
+
+    /**
+     * Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}.
+     *
+     * @param source Source input
+     * @param hints Factory configuration
+     * @return XML transformer
+     */    public static Transformer newTransformer(Source source, Hints hints) throws TransformerConfigurationException {
+        return newTransformerFactory(hints).newTransformer(source);
+    }
+
+    /**
+     * Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}.
+     *
+     * @param source Source input
+     * @param factory Factory pre-configured with information such as indenting
+     * @return XML transformer
+     */
+    public static Transformer newTransformer(TransformerFactory factory, Source source)
+            throws TransformerConfigurationException {
+        return toTransformerFactory(factory, GeoTools.getDefaultHints()).newTransformer(source);
+    }
+
+    /**
+     * Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}.
+     *
+     * @param source Source input
+     * @param factory Factory pre-configured with information such as indenting
+     * @param hints Factory configuration
+     * @return XML transformer
+     */
+    public static Transformer newTransformer(TransformerFactory factory, Source source, Hints hints)
+            throws TransformerConfigurationException {
+        return toTransformerFactory(factory, hints).newTransformer(source);
     }
 
     /**
@@ -204,7 +315,7 @@ public class XMLUtils {
     public static DocumentBuilder newDocumentBuilder(DocumentBuilderFactory factory, Hints hints)
             throws ParserConfigurationException {
 
-        DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD.AvoidDocumentBuilder
+        DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD AvoidDocumentBuilder
         builder.setEntityResolver(GeoTools.getEntityResolver(hints));
         return builder;
     }
@@ -317,35 +428,6 @@ public class XMLUtils {
         // || ((c >= 0x10000) && (c <= 0x10FFFF));
     }
 
-    /** Wrapper providing SourceLocator from SAXParseException information */
-    private static class SaxParseExceptionSourceLocator implements SourceLocator {
-        private final SAXParseException e;
-
-        public SaxParseExceptionSourceLocator(SAXParseException saxException) {
-            this.e = saxException;
-        }
-
-        @Override
-        public String getPublicId() {
-            return e.getPublicId();
-        }
-
-        @Override
-        public String getSystemId() {
-            return e.getSystemId();
-        }
-
-        @Override
-        public int getLineNumber() {
-            return e.getLineNumber();
-        }
-
-        @Override
-        public int getColumnNumber() {
-            return e.getColumnNumber();
-        }
-    }
-
     /** Wrapper ensuring system SAXParserFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
     private static class GTSAXParserFactory extends SAXParserFactory {
         private final SAXParserFactory factory;
@@ -422,7 +504,7 @@ public class XMLUtils {
 
         @Override
         public String toString() {
-            return "GeoToolsSAXParserFactoryWrapper {" + factory + "}";
+            return "GTSAXParserFactory {" + factory + "}";
         }
     }
 
@@ -487,6 +569,387 @@ public class XMLUtils {
         @Override
         public boolean getFeature(String name) throws ParserConfigurationException {
             return this.factory.getFeature(name);
+        }
+
+        @Override
+        public String toString() {
+            return "GTDocumentBuilderFactory {" + factory + "}";
+        }
+    }
+
+    /** Wrapper ensuring TransformerFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
+    private static class GTTransformerFactory extends TransformerFactory {
+        protected final Hints hints;
+        protected final TransformerFactory factory;
+
+        public GTTransformerFactory(Hints hints) {
+            this(TransformerFactory.newInstance(), hints);
+        }
+
+        public GTTransformerFactory(TransformerFactory factory, Hints hints) {
+            this.hints = hints != null ? hints : GeoTools.getDefaultHints();
+            this.factory = factory;
+        }
+
+        @Override
+        public Transformer newTransformer(Source source) throws TransformerConfigurationException {
+            return config(factory.newTransformer(source));
+        }
+
+        @Override
+        public Transformer newTransformer() throws TransformerConfigurationException {
+            return config(factory.newTransformer()); // NOPMD AvoidTransform
+        }
+
+        /**
+         * Apply GeoTools configuration to the transformer, including {@code GeoTools.getEntityResolver(hints)}.
+         *
+         * @param transformer XML Transformer
+         * @return transformer
+         */
+        protected Transformer config(Transformer transformer) {
+            URIResolver uriResolver = transformer.getURIResolver();
+            if (uriResolver != null && !(uriResolver instanceof GTURIResolver)) {
+                final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+                transformer.setURIResolver(new GTURIResolver(entityResolver, uriResolver));
+            } else {
+                transformer.setURIResolver(new GTURIResolver(GeoTools.getEntityResolver(hints)));
+            }
+            return transformer;
+        }
+
+        @Override
+        public Templates newTemplates(Source source) throws TransformerConfigurationException {
+            final Templates templates = factory.newTemplates(source);
+            return new GTTemplates(templates, hints);
+        }
+
+        @Override
+        public Source getAssociatedStylesheet(Source source, String media, String title, String charset)
+                throws TransformerConfigurationException {
+            return factory.getAssociatedStylesheet(source, media, title, charset);
+        }
+
+        @Override
+        public void setURIResolver(URIResolver resolver) {
+            this.factory.setURIResolver(resolver);
+        }
+
+        @Override
+        public URIResolver getURIResolver() {
+            return factory.getURIResolver();
+        }
+
+        @Override
+        public void setFeature(String name, boolean value) throws TransformerConfigurationException {
+            this.factory.setFeature(name, value);
+        }
+
+        @Override
+        public boolean getFeature(String name) {
+            return this.factory.getFeature(name);
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+            this.factory.setAttribute(name, value);
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return this.factory.getAttribute(name);
+        }
+
+        @Override
+        public void setErrorListener(ErrorListener listener) {
+            this.factory.setErrorListener(listener);
+        }
+
+        @Override
+        public ErrorListener getErrorListener() {
+            return this.factory.getErrorListener();
+        }
+
+        @Override
+        public String toString() {
+            return "GTTransformerFactory {" + factory + "}";
+        }
+    }
+
+    /** Templates that delegates to EntityResolver. */
+    private static class GTTemplates implements Templates {
+        private final Templates templates;
+        private final Hints hints;
+
+        public GTTemplates(Templates templates, Hints hints) {
+            this.templates = templates;
+            this.hints = hints;
+        }
+
+        @Override
+        public Transformer newTransformer() throws TransformerConfigurationException {
+            Transformer transformer = templates.newTransformer();
+            URIResolver uriResolver = transformer.getURIResolver();
+            if (uriResolver != null && !(uriResolver instanceof GTURIResolver)) {
+                final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+                transformer.setURIResolver(new GTURIResolver(entityResolver, uriResolver));
+            } else {
+                transformer.setURIResolver(new GTURIResolver(GeoTools.getEntityResolver(hints)));
+            }
+            return transformer;
+        }
+
+        @Override
+        public Properties getOutputProperties() {
+            return templates.getOutputProperties();
+        }
+
+        @Override
+        public String toString() {
+            return "GTTemplates {" + templates + "}";
+        }
+    }
+
+    /** Wrapper ensuring SAXTransformerFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
+    private static class GTSAXTransformerFactory extends SAXTransformerFactory {
+        protected final Hints hints;
+        protected final SAXTransformerFactory factory;
+
+        public GTSAXTransformerFactory(Hints hints) {
+            this((SAXTransformerFactory) SAXTransformerFactory.newInstance(), hints);
+        }
+
+        public GTSAXTransformerFactory(SAXTransformerFactory factory, Hints hints) {
+            this.factory = factory;
+            this.hints = hints != null ? hints : GeoTools.getDefaultHints();
+        }
+        // apply configuration
+        /**
+         * Apply GeoTools configuration to the transformer, including {@code GeoTools.getEntityResolver(hints)}.
+         *
+         * @param transformer XML Transformer
+         * @return transformer
+         */
+        protected Transformer config(Transformer transformer) {
+            URIResolver uriResolver = transformer.getURIResolver();
+            if (uriResolver != null && !(uriResolver instanceof GTURIResolver)) {
+                final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+                transformer.setURIResolver(new GTURIResolver(entityResolver, uriResolver));
+            } else {
+                transformer.setURIResolver(new GTURIResolver(GeoTools.getEntityResolver(hints)));
+            }
+            return transformer;
+        }
+
+        /**
+         * Apply GeoTools configuration to TransformHandler.
+         *
+         * @param handler Transform handler
+         * @return Transform handler
+         */
+        protected TransformerHandler config(TransformerHandler handler) {
+            config(handler.getTransformer());
+            return handler;
+        }
+
+        /**
+         * Apply GeoTools configuration to XMLFilter.
+         *
+         * @param filter XML Fitler
+         * @return XML Filter
+         */
+        protected XMLFilter config(XMLFilter filter) {
+            filter.setEntityResolver(GeoTools.getEntityResolver(hints));
+            return filter;
+        }
+
+        // overrides
+
+        @Override
+        public Transformer newTransformer(Source source) throws TransformerConfigurationException {
+            return config(factory.newTransformer(source));
+        }
+
+        @Override
+        public Transformer newTransformer() throws TransformerConfigurationException {
+            return config(factory.newTransformer()); // NOPMD AvoidTransform
+        }
+
+        @Override
+        public Templates newTemplates(Source source) throws TransformerConfigurationException {
+            final Templates templates = factory.newTemplates(source);
+            return new GTTemplates(templates, hints);
+        }
+
+        @Override
+        public Source getAssociatedStylesheet(Source source, String media, String title, String charset)
+                throws TransformerConfigurationException {
+            return factory.getAssociatedStylesheet(source, media, title, charset);
+        }
+
+        @Override
+        public void setURIResolver(URIResolver resolver) {
+            this.factory.setURIResolver(resolver);
+        }
+
+        @Override
+        public URIResolver getURIResolver() {
+            return factory.getURIResolver();
+        }
+
+        @Override
+        public void setFeature(String name, boolean value) throws TransformerConfigurationException {
+            this.factory.setFeature(name, value);
+        }
+
+        @Override
+        public boolean getFeature(String name) {
+            return this.factory.getFeature(name);
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) {
+            this.factory.setAttribute(name, value);
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return this.factory.getAttribute(name);
+        }
+
+        @Override
+        public void setErrorListener(ErrorListener listener) {
+            this.factory.setErrorListener(listener);
+        }
+
+        @Override
+        public ErrorListener getErrorListener() {
+            return this.factory.getErrorListener();
+        }
+
+        @Override
+        public TransformerHandler newTransformerHandler(Source src) throws TransformerConfigurationException {
+            return config(factory.newTransformerHandler(src));
+        }
+
+        @Override
+        public TransformerHandler newTransformerHandler(Templates templates) throws TransformerConfigurationException {
+            return config(factory.newTransformerHandler(templates));
+        }
+
+        @Override
+        public TransformerHandler newTransformerHandler() throws TransformerConfigurationException {
+            return config(factory.newTransformerHandler());
+        }
+
+        @Override
+        public TemplatesHandler newTemplatesHandler() throws TransformerConfigurationException {
+            return factory.newTemplatesHandler();
+        }
+
+        @Override
+        public XMLFilter newXMLFilter(Source src) throws TransformerConfigurationException {
+            return config(factory.newXMLFilter(src));
+        }
+
+        @Override
+        public XMLFilter newXMLFilter(Templates templates) throws TransformerConfigurationException {
+            return config(factory.newXMLFilter(templates));
+        }
+
+        @Override
+        public String toString() {
+            return "GTSAXTransformerFactory {" + factory + "}";
+        }
+    }
+
+    /** URIResolver that delegates to EntityResolver. */
+    private static class GTURIResolver implements URIResolver {
+        private final EntityResolver entityResolver;
+        private final URIResolver uriResolver;
+
+        public GTURIResolver(EntityResolver entityResolver) {
+            this(entityResolver, null);
+        }
+
+        public GTURIResolver(EntityResolver entityResolver, URIResolver uriResolver) {
+            this.entityResolver = entityResolver;
+            this.uriResolver = uriResolver;
+        }
+
+        @Override
+        public Source resolve(String href, String base) throws TransformerException {
+            try {
+                // step 1: check with entity resolver, will return null (external), source (internal), or exception
+                // (forbidden)
+                entityResolver.resolveEntity(href, base);
+                // step 2: check with uri resolver
+                if (uriResolver != null) {
+                    return uriResolver.resolve(href, base);
+                } else {
+                    // step 3: allow processor to handle URI
+                    return null;
+                }
+            } catch (SAXParseException e) {
+                TransformerException transformerException = new TransformerException(e);
+                SourceLocator sourceLocator = new SaxParseExceptionSourceLocator(e);
+                transformerException.setLocator(sourceLocator);
+                throw transformerException;
+            } catch (SAXException | IOException e) {
+                throw new TransformerException(e);
+            }
+        }
+    }
+
+    /** Wrapper providing SourceLocator from SAXParseException information */
+    private static class SaxParseExceptionSourceLocator implements SourceLocator {
+        private final SAXParseException e;
+
+        public SaxParseExceptionSourceLocator(SAXParseException saxException) {
+            this.e = saxException;
+        }
+
+        @Override
+        public String getPublicId() {
+            return e.getPublicId();
+        }
+
+        @Override
+        public String getSystemId() {
+            return e.getSystemId();
+        }
+
+        @Override
+        public int getLineNumber() {
+            return e.getLineNumber();
+        }
+
+        @Override
+        public int getColumnNumber() {
+            return e.getColumnNumber();
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("SaxParseExceptionSourceLocator:");
+            if (e.getMessage() != null) {
+                sb.append(e.getMessage());
+            }
+            sb.append(" {");
+            if (e.getPublicId() != null) {
+                sb.append(" publicId=").append(e.getPublicId());
+            }
+            if (e.getSystemId() != null) {
+                sb.append(" systemId=").append(e.getSystemId());
+            }
+            if (e.getLineNumber() != -1) {
+                sb.append(" lineNumber=").append(e.getLineNumber());
+            }
+            if (e.getColumnNumber() != -1) {
+                sb.append(" columnNumber=").append(e.getColumnNumber());
+            }
+            sb.append('}');
+            return sb.toString();
         }
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -47,6 +47,8 @@ import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import org.geotools.util.DefaultEntityResolver;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
@@ -696,7 +698,16 @@ public class XMLUtils {
         }
     }
 
-    /** Wrapper ensuring DocumentBuilderFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
+    /**
+     * Wrapper ensuring DocumentBuilderFactory configured with {@code GeoTools.getEntityResolver(hints)}.
+     *
+     * <p>This class provides special handling for known trusted EntityResolver implementations:
+     *
+     * <ul>
+     *   <li>{@code DefaultEntityResolver}: Allowing external {@code http} access
+     *   <li>{@code NullEntityResolver}: Allowing external {@code all} access
+     * </ul>
+     */
     private static class GTDocumentBuilderFactory extends DocumentBuilderFactory {
         final Hints hints;
         private final DocumentBuilderFactory factory;
@@ -708,6 +719,19 @@ public class XMLUtils {
                 this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException e) {
                 // feature secure processing recommended, but not supported
+            }
+            // Sensible factory defaults based on EntityResolver
+            EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+            try {
+                if (entityResolver == DefaultEntityResolver.INSTANCE) {
+                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
+                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "http");
+                } else if (entityResolver == NullEntityResolver.INSTANCE) {
+                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+                }
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
             }
         }
 

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -55,84 +55,13 @@ import org.xml.sax.helpers.NamespaceSupport;
 public class XMLUtils {
 
     /**
-     * Create a new SAXParserFactory
+     * Create a new SAXParserFactory that respects library configuration.
      *
-     * @param hints
-     * @return sax parser
+     * @param hints Factory hints
      */
     public static SAXParserFactory newSAXParserFactory(final Hints hints) {
-        final SAXParserFactory factory = SAXParserFactory.newInstance();
-        try {
-            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-            // feature secure processing recommended, but not supported
-        }
-        // Apply GeoTools configuration to XMLReader
-        return new SAXParserFactory() {
-            @Override
-            public void setNamespaceAware(boolean awareness) {
-                factory.setNamespaceAware(awareness);
-            }
-
-            @Override
-            public void setValidating(boolean validating) {
-                factory.setValidating(validating);
-            }
-
-            @Override
-            public void setXIncludeAware(boolean state) {
-                factory.setXIncludeAware(state);
-            }
-
-            @Override
-            public void setSchema(Schema schema) {
-                factory.setSchema(schema);
-            }
-
-            @Override
-            public void setFeature(String name, boolean value)
-                    throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
-                factory.setFeature(name, value);
-            }
-
-            @Override
-            public boolean getFeature(String name)
-                    throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
-                return factory.getFeature(name);
-            }
-
-            @Override
-            public Schema getSchema() {
-                return factory.getSchema();
-            }
-
-            @Override
-            public boolean isNamespaceAware() {
-                return factory.isNamespaceAware();
-            }
-
-            @Override
-            public boolean isValidating() {
-                return factory.isValidating();
-            }
-
-            @Override
-            public boolean isXIncludeAware() {
-                return factory.isXIncludeAware();
-            }
-
-            @Override
-            public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
-                SAXParser parser = factory.newSAXParser();
-                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(hints));
-                return parser;
-            }
-
-            @Override
-            public String toString() {
-                return "GeoToolsSAXParserFactoryWrapper {" + factory + "}";
-            }
-        };
+        // Factory applying GeoTools configuration to SAXParserFactory
+        return new GTSAXParserFactory(hints);
     }
 
     /** Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}. */
@@ -148,36 +77,14 @@ public class XMLUtils {
             final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
             xformerFactory.setURIResolver((href, base) -> {
                 try {
-                    InputSource source = entityResolver.resolveEntity(href, base);
+                    entityResolver.resolveEntity(href, base);
                     return uriResolver.resolve(href, base);
                 } catch (SAXParseException e) {
                     TransformerException transformerException = new TransformerException(e);
-                    SourceLocator sourceLocator = new SourceLocator() {
-                        @Override
-                        public String getPublicId() {
-                            return e.getPublicId();
-                        }
-
-                        @Override
-                        public String getSystemId() {
-                            return e.getSystemId();
-                        }
-
-                        @Override
-                        public int getLineNumber() {
-                            return e.getLineNumber();
-                        }
-
-                        @Override
-                        public int getColumnNumber() {
-                            return e.getColumnNumber();
-                        }
-                    };
+                    SourceLocator sourceLocator = new SaxParseExceptionSourceLocator(e);
                     transformerException.setLocator(sourceLocator);
                     throw transformerException;
-                } catch (SAXException e) {
-                    throw new TransformerException(e);
-                } catch (IOException e) {
+                } catch (SAXException | IOException e) {
                     throw new TransformerException(e);
                 }
             });
@@ -251,17 +158,27 @@ public class XMLUtils {
      * @return DocumentBuilder configured using GeoTools Hints
      */
     public static DocumentBuilder newDocumentBuilder(Hints hints) throws ParserConfigurationException {
-        if (hints == null) {
-            hints = GeoTools.getDefaultHints();
-        }
+        DocumentBuilderFactory factory = newDocumentBuilderFactory(hints);
 
-        @SuppressWarnings("PMD.AvoidDocumentBuilder")
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
         DocumentBuilder builder = factory.newDocumentBuilder();
         builder.setEntityResolver(GeoTools.getEntityResolver(hints));
-
         return builder;
     }
+
+    /** Create a new DocumentBuilderFactory that respects library configuration. */
+    public static DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+        return newDocumentBuilderFactory(GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Create a new DocumentBuilderFactory that respects library configuration.
+     *
+     * @param Hints Factory hints
+     */
+    public static DocumentBuilderFactory newDocumentBuilderFactory(Hints hints) throws ParserConfigurationException {
+        return new GTDocumentBuilderFactory(hints);
+    }
+
     /**
      * Tests whether the TransformerFactory and SchemaFactory implementations support JAXP 1.5 properties to protect
      * against XML external entity injection (XXE) attacks. The internal JDK XML processors starting with JDK 7u40 would
@@ -354,5 +271,159 @@ public class XMLUtils {
         return c == 0x9 || c == 0xA || c == 0xD || c >= 0x20 && c <= 0xD7FF || c >= 0xE000 && c <= 0xFFFD;
         // removed as a char cannot get this high
         // || ((c >= 0x10000) && (c <= 0x10FFFF));
+    }
+
+    /** Wrapper providing SourceLocator from SAXParseException information */
+    private static class SaxParseExceptionSourceLocator implements SourceLocator {
+        private final SAXParseException e;
+
+        public SaxParseExceptionSourceLocator(SAXParseException saxException) {
+            this.e = saxException;
+        }
+
+        @Override
+        public String getPublicId() {
+            return e.getPublicId();
+        }
+
+        @Override
+        public String getSystemId() {
+            return e.getSystemId();
+        }
+
+        @Override
+        public int getLineNumber() {
+            return e.getLineNumber();
+        }
+
+        @Override
+        public int getColumnNumber() {
+            return e.getColumnNumber();
+        }
+    }
+
+    /** Wrapper ensuring system SAXParserFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
+    private static class GTSAXParserFactory extends SAXParserFactory {
+        private final SAXParserFactory factory;
+        private final Hints hints;
+
+        public GTSAXParserFactory(Hints hints) {
+            this.hints = hints;
+            this.factory = SAXParserFactory.newInstance();
+            try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+                // feature secure processing recommended, but not supported
+            }
+        }
+
+        @Override
+        public void setNamespaceAware(boolean awareness) {
+            factory.setNamespaceAware(awareness);
+        }
+
+        @Override
+        public void setValidating(boolean validating) {
+            factory.setValidating(validating);
+        }
+
+        @Override
+        public void setXIncludeAware(boolean state) {
+            factory.setXIncludeAware(state);
+        }
+
+        @Override
+        public void setSchema(Schema schema) {
+            factory.setSchema(schema);
+        }
+
+        @Override
+        public void setFeature(String name, boolean value)
+                throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+            factory.setFeature(name, value);
+        }
+
+        @Override
+        public boolean getFeature(String name)
+                throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+            return factory.getFeature(name);
+        }
+
+        @Override
+        public Schema getSchema() {
+            return factory.getSchema();
+        }
+
+        @Override
+        public boolean isNamespaceAware() {
+            return factory.isNamespaceAware();
+        }
+
+        @Override
+        public boolean isValidating() {
+            return factory.isValidating();
+        }
+
+        @Override
+        public boolean isXIncludeAware() {
+            return factory.isXIncludeAware();
+        }
+
+        @Override
+        public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+            SAXParser parser = factory.newSAXParser();
+            parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(hints));
+            return parser;
+        }
+
+        @Override
+        public String toString() {
+            return "GeoToolsSAXParserFactoryWrapper {" + factory + "}";
+        }
+    }
+
+    /** Wrapper ensuring DocumentBuilderFactory configured with {@code GeoTools.getEntityResolver(hints)}. */
+    private static class GTDocumentBuilderFactory extends DocumentBuilderFactory {
+        final Hints hints;
+        private final DocumentBuilderFactory factory;
+
+        public GTDocumentBuilderFactory(Hints hints) {
+            this.hints = hints != null ? hints : GeoTools.getDefaultHints();
+            this.factory = DocumentBuilderFactory.newInstance();
+            try {
+                this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (ParserConfigurationException e) {
+                // feature secure processing recommended, but not supported
+            }
+        }
+
+        @Override
+        public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+            // @SuppressWarnings("PMD.AvoidDocumentBuilder")
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            builder.setEntityResolver(GeoTools.getEntityResolver(hints));
+
+            return builder;
+        }
+
+        @Override
+        public void setAttribute(String name, Object value) throws IllegalArgumentException {
+            this.factory.setAttribute(name, value);
+        }
+
+        @Override
+        public Object getAttribute(String name) throws IllegalArgumentException {
+            return this.factory.getAttribute(name);
+        }
+
+        @Override
+        public void setFeature(String name, boolean value) throws ParserConfigurationException {
+            this.factory.setFeature(name, value);
+        }
+
+        @Override
+        public boolean getFeature(String name) throws ParserConfigurationException {
+            return this.factory.getFeature(name);
+        }
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -158,20 +158,64 @@ public class XMLUtils {
      * @return DocumentBuilder configured using GeoTools Hints
      */
     public static DocumentBuilder newDocumentBuilder(Hints hints) throws ParserConfigurationException {
-        DocumentBuilderFactory factory = newDocumentBuilderFactory(hints);
-        @SuppressWarnings("PMD.AvoidDocumentBuilder")
-        DocumentBuilder builder = factory.newDocumentBuilder();
+        return newDocumentBuilder(newDocumentBuilderFactory(hints), hints);
+    }
+
+    /**
+     * Create a new DocumentBuilder using a supplied Factory, allowing GeoTools library configuration to be applied.
+     *
+     * <p>This apporach allows document build factory to be configured to be namespace aware, validating, etc. while
+     * still applying GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     *
+     * <pre>{@literal
+     * DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
+     * factory.setValidating(true);
+     * factory.setNamespaceAware(true);
+     * DocumentBuilder builder = XMLUtils.newDocumentBuilder(factory);
+     * Document document = builder.parse(source);}</pre>
+     *
+     * @param factory Configured DocumentBuildFactory
+     */
+    public static DocumentBuilder newDocumentBuilder(DocumentBuilderFactory factory)
+            throws ParserConfigurationException {
+        return newDocumentBuilder(factory, GeoTools.getDefaultHints());
+    }
+    /**
+     * Create a new DocumentBuilder using a supplied Factory, allowing GeoTools library configuration to be applied.
+     *
+     * <p>This approach allows document build factory to be configured to be namespace aware, validating, etc. while
+     * still applying GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     *
+     * <pre>{@literal
+     * Hints hints = GeoTools.getDefaultHints();
+     * hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+     *
+     * DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory(hints);
+     * factory.setValidating(true);
+     * factory.setNamespaceAware(true);
+     * DocumentBuilder builder = XMLUtils.newDocumentBuilder(factory, hints);
+     * Document document = builder.parse(source);}</pre>
+     *
+     * The above example shows use of this method with NullEntityResolver.
+     *
+     * @param factory Configured DocumentBuildFactory
+     * @param hints Factory hints
+     */
+    public static DocumentBuilder newDocumentBuilder(DocumentBuilderFactory factory, Hints hints)
+            throws ParserConfigurationException {
+
+        DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD.AvoidDocumentBuilder
         builder.setEntityResolver(GeoTools.getEntityResolver(hints));
         return builder;
     }
 
-    /** Create a new DocumentBuilderFactory that respects library configuration. */
+    /** Create a new DocumentBuilderFactory allowing GeoTools library configuration to be applied. */
     public static DocumentBuilderFactory newDocumentBuilderFactory() {
         return newDocumentBuilderFactory(GeoTools.getDefaultHints());
     }
 
     /**
-     * Create a new DocumentBuilderFactory that respects library configuration.
+     * Create a new DocumentBuilder using a supplied Factory, allowing GeoTools library configuration to be applied.
      *
      * @param hints Factory hints
      */
@@ -389,7 +433,7 @@ public class XMLUtils {
 
         public GTDocumentBuilderFactory(Hints hints) {
             this.hints = hints != null ? hints : GeoTools.getDefaultHints();
-            this.factory = DocumentBuilderFactory.newInstance();
+            this.factory = DocumentBuilderFactory.newInstance(); // NOPMD AvoidDocumentBuilderFactory
             try {
                 this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException e) {
@@ -399,11 +443,30 @@ public class XMLUtils {
 
         @Override
         public DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
-            @SuppressWarnings("PMD.AvoidDocumentBuilder")
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD AvoidDocumentBuilder
             builder.setEntityResolver(GeoTools.getEntityResolver(hints));
 
             return builder;
+        }
+
+        @Override
+        public boolean isValidating() {
+            return this.factory.isValidating();
+        }
+
+        @Override
+        public void setValidating(boolean validating) {
+            this.factory.setValidating(validating);
+        }
+
+        @Override
+        public boolean isNamespaceAware() {
+            return this.factory.isNamespaceAware();
+        }
+
+        @Override
+        public void setNamespaceAware(boolean namespaceAware) {
+            this.factory.setNamespaceAware(namespaceAware);
         }
 
         @Override

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -107,6 +107,7 @@ public class XMLUtils {
                 factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
             }
         }
+
         if (factory.isPropertySupported(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) {
             factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         }
@@ -115,7 +116,8 @@ public class XMLUtils {
         if (factory.isPropertySupported(XMLConstants.ACCESS_EXTERNAL_SCHEMA)) {
             factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         }
-         factory.setXMLResolver(new GTXMLResolver(GeoTools.getEntityResolver(hints), factory.getXMLResolver(), hints));
+        // factory.setXMLResolver(new GTXMLResolver(GeoTools.getEntityResolver(hints), factory.getXMLResolver(),
+        // hints));
         return factory;
     }
 

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilder;
@@ -36,15 +38,20 @@ import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.URIResolver;
+import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TemplatesHandler;
 import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+import org.w3c.dom.Node;
 import org.xml.sax.EntityResolver;
+import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
@@ -60,7 +67,7 @@ import org.xml.sax.helpers.NamespaceSupport;
  * @author Andrea Aime - GeoSolutions
  */
 public class XMLUtils {
-
+    static final Logger LOGGER = Logging.getLogger(XMLUtils.class);
     /**
      * Create a new SAXParserFactory that respects library configuration.
      *
@@ -205,43 +212,78 @@ public class XMLUtils {
     }
 
     /**
-     * Alternative to direct use of {@link SAXSource#sourceToInputSource}, allowing GeoTools library configuration to be
-     * applied.
+     * Alternative to direct use of {@code DOMSOurce}, allowing GeoTools library configuration to be applied when
+     * traversal is required.
      *
-     * @param source
-     * @return SAXSource configured with GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     * @param dom Document node
+     * @return Source with any XML streaming subject to GeoTools configuration including
+     *     {@link GeoTools#getEntityResolver(Hints)}.
      */
-    public static SAXSource sourceToInputSource(Source source) {
-        return sourceToInputSource(source, GeoTools.getDefaultHints());
+    public static Source source(Node dom) {
+        // no traversal needed
+        return new DOMSource(dom);
     }
 
     /**
-     * Alternative to direct use of {@link SAXSource#sourceToInputSource}, allowing GeoTools library configuration to be
-     * applied.
+     * Alternative to direct use of {@code Source}, allowing GeoTools library configuration to be applied when traversal
+     * is required.
+     *
+     * @param source
+     * @return Source with any XML streaming subject to GeoTools configuration including
+     *     {@link GeoTools#getEntityResolver(Hints)}.
+     */
+    public static Source source(Source source) {
+        return source(source, GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Alternative to direct use of {@code Source}, allowing GeoTools library configuration to be applied when traversal
+     * is required.
      *
      * @param source transform source
      * @param hints GeoTools library configuration
-     * @return SAXSource configured with GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     * @return Source with any XML streaming subject to GeoTools configuration including
+     *     {@link GeoTools#getEntityResolver(Hints)}.
      */
-    public static SAXSource sourceToInputSource(Source source, Hints hints) {
-        return sourceToInputSource(SAXSource.sourceToInputSource(source), hints);
+    public static Source source(Source source, Hints hints) {
+        if (source == null) return null;
+
+        InputSource inputSource;
+        if (source instanceof SAXSource saxSource) {
+            inputSource = saxSource.getInputSource();
+        } else if (source instanceof StreamSource streamSource) {
+            inputSource = new InputSource(streamSource.getSystemId());
+            inputSource.setByteStream(streamSource.getInputStream());
+            inputSource.setCharacterStream(streamSource.getReader());
+            inputSource.setPublicId(streamSource.getPublicId());
+        } else if (source instanceof InputSource) {
+            inputSource = (InputSource) source;
+        } else if (source instanceof DOMSource domSource) {
+            return domSource; // already traversed
+        } else {
+            return source; // unprocessed
+        }
+
+        // Safe traversal with GeoTools configuration
+        return sax(inputSource, hints);
     }
 
     /**
      * Alternative to direct use of InputSource allowing SAXSource setup with GeoTools configuration to be applied.
      *
-     * @param source sax input source
+     * @param inputSource InputSource
      * @param hints GeoTools library configuration
-     * @return SAXSource configured with GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     * @return Source with any XML streaming subject to GeoTools configuration including
+     *     {@link GeoTools#getEntityResolver(Hints)}.
      */
-    public static SAXSource sourceToInputSource(InputSource source, Hints hints) {
-        if (source == null) return null;
-
-        SAXParserFactory factory = newSAXParserFactory(hints);
+    public static SAXSource sax(InputSource inputSource, Hints hints) {
+        if (inputSource == null) return null;
         try {
-            XMLReader reader = factory.newSAXParser().getXMLReader();
-            reader.setEntityResolver(GeoTools.getEntityResolver(hints));
-            return new SAXSource(reader, source);
+            GTSAXParserFactory factory = new GTSAXParserFactory(hints);
+
+            XMLReader xmlReader = factory.newSAXParser().getXMLReader();
+            xmlReader.setEntityResolver(GeoTools.getEntityResolver(hints));
+            return new SAXSource(xmlReader, inputSource);
         } catch (SAXException | ParserConfigurationException e) {
             throw new RuntimeException(e);
         }
@@ -318,6 +360,9 @@ public class XMLUtils {
 
         DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD AvoidDocumentBuilder
         builder.setEntityResolver(GeoTools.getEntityResolver(hints));
+        if (factory.isValidating()) {
+            builder.setErrorHandler(new SAXErrorHandler());
+        }
         return builder;
     }
 
@@ -339,8 +384,9 @@ public class XMLUtils {
      * Tests whether the TransformerFactory and SchemaFactory implementations support JAXP 1.5 properties to protect
      * against XML external entity injection (XXE) attacks. The internal JDK XML processors starting with JDK 7u40 would
      * support these properties but outdated versions of XML libraries (e.g., Xalan, Xerces) that do not support these
-     * properties may be included in GeoServer's classpath or provided by the web application server. This method is
-     * intended to support using third-party libraries (e.g., Hazelcast) that use these properties internally.
+     * properties may be included in GeoServer's classpath or provided by the web application server.
+     *
+     * <p>GeoTools uses these properties internally.
      *
      * @throws IllegalStateException if the JAXP 1.5 properties are not supported or if there was an error checking for
      *     JAXP 1.5 support
@@ -951,6 +997,30 @@ public class XMLUtils {
             }
             sb.append('}');
             return sb.toString();
+        }
+    }
+
+    /** SAXErrorHandler that logs errors. */
+    public static class SAXErrorHandler implements ErrorHandler {
+
+        @Override
+        public void warning(SAXParseException exception) throws SAXException {
+            LOGGER.log(Level.WARNING, exception.getMessage(), exception);
+        }
+
+        @Override
+        public void error(SAXParseException exception) throws SAXException {
+            LOGGER.log(Level.SEVERE, exception.getMessage(), exception);
+        }
+
+        @Override
+        public void fatalError(SAXParseException exception) throws SAXException {
+            LOGGER.log(Level.SEVERE, exception.getMessage(), exception);
+        }
+
+        @Override
+        public String toString() {
+            return "SAXErrorHandler";
         }
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -52,10 +52,13 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import org.geotools.util.DefaultEntityResolver;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.util.PreventLocalEntityResolver;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.w3c.dom.Node;
+import org.w3c.dom.ls.LSInput;
+import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
@@ -105,24 +108,6 @@ public class XMLUtils {
         // Used to determine sensible defaults based on entity resolver selected
         EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
 
-        // Disable DTD: few of our protocols / formats are old enough to require DTD
-        if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
-            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-            if (factory.isPropertySupported(XMLInputFactory.IS_COALESCING)) {
-                // disable resolving of external DTD entities (coalescing needs to be false)
-                factory.setProperty(XMLInputFactory.IS_COALESCING, false);
-            }
-            if (factory.isPropertySupported(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES)) {
-                if (entityResolver == NullEntityResolver.INSTANCE) {
-                    factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, true);
-                } else if (entityResolver == DefaultEntityResolver.INSTANCE) {
-                    factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-                } else {
-                    factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
-                }
-            }
-        }
-
         if (factory.isPropertySupported(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) {
             factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
         }
@@ -131,8 +116,26 @@ public class XMLUtils {
         if (factory.isPropertySupported(XMLConstants.ACCESS_EXTERNAL_SCHEMA)) {
             factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
         }
-        // factory.setXMLResolver(new GTXMLResolver(GeoTools.getEntityResolver(hints), factory.getXMLResolver(),
-        // hints));
+
+        // Disable DTD: few of our protocols / formats are old enough to require DTD
+        if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        }
+        if (factory.isPropertySupported(XMLInputFactory.IS_COALESCING)) {
+            // disable resolving of external DTD entities (coalescing needs to be false)
+            factory.setProperty(XMLInputFactory.IS_COALESCING, false);
+        }
+        if (factory.isPropertySupported(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES)) {
+            if (entityResolver == NullEntityResolver.INSTANCE) {
+                factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, true);
+            } else if (entityResolver == DefaultEntityResolver.INSTANCE) {
+                factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+            } else {
+                factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+            }
+        }
+
+        factory.setXMLResolver(new GTXMLResolver(entityResolver, factory.getXMLResolver(), hints));
         return factory;
     }
 
@@ -541,6 +544,69 @@ public class XMLUtils {
         return new GTDocumentBuilderFactory(hints);
     }
 
+    //
+    // SchemaFactory
+    //
+    /**
+     * Creates a new SchemaFactory allowing GeoTools configuration to be applied.
+     *
+     * @param schemaLanguage Schema language which the factory will understand
+     * @return New instance of schema factory supporting {@code schemaLanguage}
+     */
+    public static SchemaFactory newSchemaFactory(String schemaLanguage) {
+        return newSchemaFactory(schemaLanguage, GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Creates a new SchemaFactory allowing GeoTools configuration to be applied.
+     *
+     * @param schemaLanguage Schema language which the factory will understand
+     * @param hints Factory hints
+     * @return New instance of schema factory supporting {@code schemaLanguage}
+     */
+    public static SchemaFactory newSchemaFactory(String schemaLanguage, Hints hints) {
+        SchemaFactory factory = SchemaFactory.newInstance(schemaLanguage); // NOPMD AvoidSchemaFactory
+
+        EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+        final String ACCESS = getAccess(entityResolver);
+        try {
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            LOGGER.warning("Parser does not support ACCESS_EXTERNAL_DTD: " + e.getMessage());
+        }
+        try {
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ACCESS);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            LOGGER.warning("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + e.getMessage());
+        }
+        factory.setResourceResolver(new GTLSResourceResolver(entityResolver, factory.getResourceResolver(), hints));
+        return factory;
+    }
+
+    /**
+     * Sensible default for EntityResolver access based on provided entityResolver.
+     *
+     * <p>The provided value is based on recognizing {@code NullEntityResolver} use for local files, and
+     * {@code DefaultEntityResolver} and {@code PreventLocalEntityResolver} for trusted {@code http} locations.
+     *
+     * <p>If the entity provider is not recognized {@code ""} is provided to cut off access.
+     *
+     * @param entityResolver EntityResolver
+     * @return Entity resolution protocol: {@code "all"}, {@code "http"}, or {@code ""} based on provided entityResolver
+     */
+    private static String getAccess(EntityResolver entityResolver) {
+        if (entityResolver == null) {
+            return "";
+        }
+        if (entityResolver == NullEntityResolver.INSTANCE) {
+            return "all";
+        } else if (entityResolver == PreventLocalEntityResolver.INSTANCE
+                || entityResolver == DefaultEntityResolver.INSTANCE) {
+            return "http";
+        }
+        return "";
+    }
+
     /**
      * Tests whether the TransformerFactory and SchemaFactory implementations support JAXP 1.5 properties to protect
      * against XML external entity injection (XXE) attacks. The internal JDK XML processors starting with JDK 7u40 would
@@ -562,7 +628,8 @@ public class XMLUtils {
             } catch (IllegalArgumentException e) {
                 classes.add(transformerFactory.getClass().getName());
             }
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+            SchemaFactory schemaFactory =
+                    SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI); // NOPMD AvoidSchemaFactory
             try {
                 schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
                 schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
@@ -783,20 +850,26 @@ public class XMLUtils {
                 this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException e) {
                 // feature secure processing recommended, but not supported
+                LOGGER.fine("Parser does not support secure processing feature: "
+                        + this.factory.getClass().getName());
             }
             // Sensible factory defaults based on EntityResolver
             EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+            final String ACCESS = getAccess(entityResolver);
+
             try {
-                if (entityResolver == DefaultEntityResolver.INSTANCE) {
-                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
-                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "http");
-                } else if (entityResolver == NullEntityResolver.INSTANCE) {
-                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-                    this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
-                }
+                this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);
             } catch (IllegalArgumentException notSupported) {
                 LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
             }
+            try {
+                this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ACCESS);
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+            }
+
+            //
+
         }
 
         @Override
@@ -1215,7 +1288,7 @@ public class XMLUtils {
         }
     }
 
-    /** EntityResolver that delegates to EntityResolver to verify allowed locations. */
+    /** XMLResolver that delegates to EntityResolver to verify allowed locations. */
     private static class GTXMLResolver implements XMLResolver {
 
         private final EntityResolver entityResolver;
@@ -1264,10 +1337,9 @@ public class XMLUtils {
                 // step 2: check with uri resolver
                 if (xmlResolver != null) {
                     return xmlResolver.resolveEntity(publicID, systemID, baseURI, namespace);
-                } else {
-                    // step 3: allow input factory to handle
-                    return null;
                 }
+                // step 3: allow input factory to handle
+                return null;
             } catch (SAXException | IOException e) {
                 throw new XMLStreamException(e);
             }
@@ -1277,6 +1349,58 @@ public class XMLUtils {
         public String toString() {
             final StringBuilder sb = new StringBuilder("GTXMLResolver{");
             sb.append("xmlResolver=").append(xmlResolver);
+            sb.append('}');
+            return sb.toString();
+        }
+    }
+
+    /** LSResourceResolver that delegates to EntityResolver to verify allowed locations. */
+    private static class GTLSResourceResolver implements LSResourceResolver {
+
+        private final EntityResolver entityResolver;
+        private final LSResourceResolver lsResolver;
+
+        public GTLSResourceResolver(EntityResolver entityResolver, LSResourceResolver lsResolver, Hints hints) {
+            this.entityResolver = entityResolver;
+            this.lsResolver = lsResolver;
+        }
+
+        /**
+         * java.io.InputStream (2) javax.xml.stream.XMLStreamReader (3) java.xml.stream.XMLEventReader.
+         *
+         * @param type The type of the resource being resolved, such as {@code http://www.w3.org/2001/XMLSchema}
+         * @param publicId The public identifier of the external entity being referenced, or null if none was supplied.
+         * @param systemId The system identifier of the external entity being referenced.
+         * @param baseURI Absolute base URI associated with systemId.
+         * @return Returns {@code null} to for default handling, or throws an exception if access not granted
+         * @throws XMLStreamException
+         */
+        @Override
+        public LSInput resolveResource(
+                String type, String namespaceURI, String publicId, String systemId, String baseURI) {
+            // step 1: check with xml resolver: null (external), source (internal), or exception (forbidden)
+            if (XMLConstants.W3C_XML_SCHEMA_NS_URI.equals(type)) {
+                try {
+                    InputSource source = entityResolver.resolveEntity(publicId, systemId);
+                    if (source != null) {
+                        return null; // resolved internally, allow processor to handle
+                    }
+                } catch (SAXException | IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            // step 2: check with uri resolver
+            if (lsResolver != null) {
+                return lsResolver.resolveResource(type, namespaceURI, publicId, systemId, baseURI);
+            }
+            // step 3: allow input factory to handle
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("GTLSResourceResolver{");
+            sb.append("lsResolver=").append(lsResolver);
             sb.append('}');
             return sb.toString();
         }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -51,8 +51,8 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import org.geotools.util.DefaultEntityResolver;
+import org.geotools.util.EntityResolver3;
 import org.geotools.util.NullEntityResolver;
-import org.geotools.util.PreventLocalEntityResolver;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
@@ -568,7 +568,7 @@ public class XMLUtils {
         SchemaFactory factory = SchemaFactory.newInstance(schemaLanguage); // NOPMD AvoidSchemaFactory
 
         EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-        final String ACCESS = getAccess(entityResolver, "file http");
+        final String ACCESS = getAccess(entityResolver, "");
         try {
             factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);
         } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
@@ -599,11 +599,11 @@ public class XMLUtils {
         if (entityResolver == null) {
             return "";
         }
-        if (entityResolver == NullEntityResolver.INSTANCE) {
-            return "all";
-        } else if (entityResolver == PreventLocalEntityResolver.INSTANCE
-                || entityResolver == DefaultEntityResolver.INSTANCE) {
-            return "http";
+        if (entityResolver instanceof EntityResolver3 entityResolver3) {
+            return entityResolver3.getAccess();
+        }
+        if (protocol == null) {
+            return ""; // no access
         }
         return protocol;
     }
@@ -856,7 +856,7 @@ public class XMLUtils {
             }
             // Sensible factory defaults based on EntityResolver
             EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-            final String ACCESS = getAccess(entityResolver, "file http");
+            final String ACCESS = getAccess(entityResolver, "");
 
             try {
                 this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -174,7 +174,8 @@ public class XMLUtils {
      * @param source Source input
      * @param hints Factory configuration
      * @return XML transformer
-     */    public static Transformer newTransformer(Source source, Hints hints) throws TransformerConfigurationException {
+     */
+    public static Transformer newTransformer(Source source, Hints hints) throws TransformerConfigurationException {
         return newTransformerFactory(hints).newTransformer(source);
     }
 

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -568,7 +568,7 @@ public class XMLUtils {
         SchemaFactory factory = SchemaFactory.newInstance(schemaLanguage); // NOPMD AvoidSchemaFactory
 
         EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-        final String ACCESS = getAccess(entityResolver);
+        final String ACCESS = getAccess(entityResolver, "file http");
         try {
             factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);
         } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
@@ -592,9 +592,10 @@ public class XMLUtils {
      * <p>If the entity provider is not recognized {@code ""} is provided to cut off access.
      *
      * @param entityResolver EntityResolver
+     * @param protocol Default protocol to use if entityResolver is not recognized
      * @return Entity resolution protocol: {@code "all"}, {@code "http"}, or {@code ""} based on provided entityResolver
      */
-    private static String getAccess(EntityResolver entityResolver) {
+    private static String getAccess(EntityResolver entityResolver, String protocol) {
         if (entityResolver == null) {
             return "";
         }
@@ -604,7 +605,7 @@ public class XMLUtils {
                 || entityResolver == DefaultEntityResolver.INSTANCE) {
             return "http";
         }
-        return "";
+        return protocol;
     }
 
     /**
@@ -855,7 +856,7 @@ public class XMLUtils {
             }
             // Sensible factory defaults based on EntityResolver
             EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-            final String ACCESS = getAccess(entityResolver);
+            final String ACCESS = getAccess(entityResolver, "file http");
 
             try {
                 this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);
@@ -867,9 +868,6 @@ public class XMLUtils {
             } catch (IllegalArgumentException notSupported) {
                 LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
             }
-
-            //
-
         }
 
         @Override

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -16,13 +16,35 @@
  */
 package org.geotools.xml;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.Source;
+import javax.xml.transform.SourceLocator;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.URIResolver;
+import javax.xml.transform.sax.SAXSource;
+import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
+import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.NamespaceSupport;
 
 /**
@@ -32,6 +54,214 @@ import org.xml.sax.helpers.NamespaceSupport;
  */
 public class XMLUtils {
 
+    /**
+     * Create a new SAXParserFactory
+     *
+     * @param hints
+     * @return sax parser
+     */
+    public static SAXParserFactory newSAXParserFactory(final Hints hints) {
+        final SAXParserFactory factory = SAXParserFactory.newInstance();
+        try {
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+            // feature secure processing recommended, but not supported
+        }
+        // Apply GeoTools configuration to XMLReader
+        return new SAXParserFactory() {
+            @Override
+            public void setNamespaceAware(boolean awareness) {
+                factory.setNamespaceAware(awareness);
+            }
+
+            @Override
+            public void setValidating(boolean validating) {
+                factory.setValidating(validating);
+            }
+
+            @Override
+            public void setXIncludeAware(boolean state) {
+                factory.setXIncludeAware(state);
+            }
+
+            @Override
+            public void setSchema(Schema schema) {
+                factory.setSchema(schema);
+            }
+
+            @Override
+            public void setFeature(String name, boolean value)
+                    throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+                factory.setFeature(name, value);
+            }
+
+            @Override
+            public boolean getFeature(String name)
+                    throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+                return factory.getFeature(name);
+            }
+
+            @Override
+            public Schema getSchema() {
+                return factory.getSchema();
+            }
+
+            @Override
+            public boolean isNamespaceAware() {
+                return factory.isNamespaceAware();
+            }
+
+            @Override
+            public boolean isValidating() {
+                return factory.isValidating();
+            }
+
+            @Override
+            public boolean isXIncludeAware() {
+                return factory.isXIncludeAware();
+            }
+
+            @Override
+            public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+                SAXParser parser = factory.newSAXParser();
+                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(hints));
+                return parser;
+            }
+
+            @Override
+            public String toString() {
+                return "GeoToolsSAXParserFactoryWrapper {" + factory + "}";
+            }
+        };
+    }
+
+    /** Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}. */
+    public static Transformer newTransformer() throws TransformerConfigurationException {
+        return newTransformer(GeoTools.getDefaultHints());
+    }
+
+    /** Creates a new Transformer as an alternative to direct use of {@link TransformerFactory#newTransformer()}. */
+    public static Transformer newTransformer(Hints hints) throws TransformerConfigurationException {
+        TransformerFactory xformerFactory = TransformerFactory.newInstance();
+        URIResolver uriResolver = xformerFactory.getURIResolver();
+        if (uriResolver != null) {
+            final EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+            xformerFactory.setURIResolver((href, base) -> {
+                try {
+                    InputSource source = entityResolver.resolveEntity(href, base);
+                    return uriResolver.resolve(href, base);
+                } catch (SAXParseException e) {
+                    TransformerException transformerException = new TransformerException(e);
+                    SourceLocator sourceLocator = new SourceLocator() {
+                        @Override
+                        public String getPublicId() {
+                            return e.getPublicId();
+                        }
+
+                        @Override
+                        public String getSystemId() {
+                            return e.getSystemId();
+                        }
+
+                        @Override
+                        public int getLineNumber() {
+                            return e.getLineNumber();
+                        }
+
+                        @Override
+                        public int getColumnNumber() {
+                            return e.getColumnNumber();
+                        }
+                    };
+                    transformerException.setLocator(sourceLocator);
+                    throw transformerException;
+                } catch (SAXException e) {
+                    throw new TransformerException(e);
+                } catch (IOException e) {
+                    throw new TransformerException(e);
+                }
+            });
+        }
+        return xformerFactory.newTransformer();
+    }
+
+    /**
+     * Alternative to direct use of {@link SAXSource#sourceToInputSource}, allowing GeoTools library configuration to be
+     * applied.
+     *
+     * @param source
+     * @return SAXSource configured with GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     */
+    public static SAXSource sourceToInputSource(Source source) {
+        return sourceToInputSource(source, GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Alternative to direct use of {@link SAXSource#sourceToInputSource}, allowing GeoTools library configuration to be
+     * applied.
+     *
+     * @param source transform source
+     * @param hints GeoTools library configuration
+     * @return SAXSource configured with GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     */
+    public static SAXSource sourceToInputSource(Source source, Hints hints) {
+        return sourceToInputSource(SAXSource.sourceToInputSource(source), hints);
+    }
+
+    /**
+     * Alternative to direct use of InputSource allowing SAXSource setup with GeoTools configuration to be applied.
+     *
+     * @param source sax input source
+     * @param hints GeoTools library configuration
+     * @return SAXSource configured with GeoTools configuration including {@link GeoTools#getEntityResolver(Hints)}.
+     */
+    public static SAXSource sourceToInputSource(InputSource source, Hints hints) {
+        if (source == null) return null;
+
+        SAXParserFactory factory = newSAXParserFactory(hints);
+        try {
+            XMLReader reader = factory.newSAXParser().getXMLReader();
+            reader.setEntityResolver(GeoTools.getEntityResolver(hints));
+            return new SAXSource(reader, source);
+        } catch (SAXException | ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Creates a new document builder, as an alternative to {@link DocumentBuilder#newDocument()}, allowing GeoTools
+     * library configuration to be applied.
+     *
+     * <p>The document builder is configured using GeoTools configuration including
+     * {@link GeoTools#getEntityResolver(Hints)} .
+     *
+     * @return DocumentBuilder configured with Ge
+     */
+    public static DocumentBuilder newDocumentBuilder() throws ParserConfigurationException {
+        return newDocumentBuilder(GeoTools.getDefaultHints());
+    }
+
+    /**
+     * Creates a new document builder, as an alternative to direct use of {@link DocumentBuilder#newDocument()},
+     * allowing GeoTools library configuration to be applied.
+     *
+     * <p>The document builder is configured using GeoTools configuration including
+     * {@link GeoTools#getEntityResolver(Hints)} .
+     *
+     * @return DocumentBuilder configured using GeoTools Hints
+     */
+    public static DocumentBuilder newDocumentBuilder(Hints hints) throws ParserConfigurationException {
+        if (hints == null) {
+            hints = GeoTools.getDefaultHints();
+        }
+
+        @SuppressWarnings("PMD.AvoidDocumentBuilder")
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        builder.setEntityResolver(GeoTools.getEntityResolver(hints));
+
+        return builder;
+    }
     /**
      * Tests whether the TransformerFactory and SchemaFactory implementations support JAXP 1.5 properties to protect
      * against XML external entity injection (XXE) attacks. The internal JDK XML processors starting with JDK 7u40 would

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -30,6 +30,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLResolver;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.Source;
 import javax.xml.transform.SourceLocator;
@@ -71,6 +74,50 @@ import org.xml.sax.helpers.NamespaceSupport;
  */
 public class XMLUtils {
     static final Logger LOGGER = Logging.getLogger(XMLUtils.class);
+
+    //
+    // XMLInputFactory
+    //
+
+    /**
+     * Creates an XMLInputFactory configured with GeoTools library defaults.
+     *
+     * @return XMLInputFactory
+     */
+    public static XMLInputFactory newXMLInputFactory() {
+        return newXMLInputFactory(GeoTools.getDefaultHints());
+    }
+    /**
+     * Creates an XMLInputFactory configured with GeoTools library defaults.
+     *
+     * @param hints Factory hints
+     * @return XMLInputFactory
+     */
+    public static XMLInputFactory newXMLInputFactory(Hints hints) {
+        XMLInputFactory factory = XMLInputFactory.newInstance(); // NOPMD AvoidXMLInputFactory
+
+        // Disable DTD: few of our protocols / formats are old enough to require DTD
+        if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            if (factory.isPropertySupported(XMLInputFactory.IS_COALESCING)) {
+                // disable resolving of external DTD entities (coalescing needs to be false)
+                factory.setProperty(XMLInputFactory.IS_COALESCING, false);
+            }
+            if (factory.isPropertySupported(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES)) {
+                factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+            }
+        }
+        if (factory.isPropertySupported(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) {
+            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        }
+
+        // Disable XSD: Expect XMLInputFactory to uses Validator for access XSD
+        if (factory.isPropertySupported(XMLConstants.ACCESS_EXTERNAL_SCHEMA)) {
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        }
+         factory.setXMLResolver(new GTXMLResolver(GeoTools.getEntityResolver(hints), factory.getXMLResolver(), hints));
+        return factory;
+    }
 
     //
     // SAXParser and SAXParserFactory utility methods
@@ -1042,8 +1089,7 @@ public class XMLUtils {
         @Override
         public Source resolve(String href, String base) throws TransformerException {
             try {
-                // step 1: check with entity resolver, will return null (external), source (internal), or exception
-                // (forbidden)
+                // step 1: check resolver: null (external), source (internal), or exception (forbidden)
                 InputSource source = entityResolver.resolveEntity(href, base);
                 if (source != null) {
                     // resolved internally, wrap and apply GeoTools configuration
@@ -1065,6 +1111,14 @@ public class XMLUtils {
             } catch (SAXException | IOException e) {
                 throw new TransformerException(e);
             }
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("GTURIResolver{");
+            sb.append("uriResolver=").append(uriResolver);
+            sb.append('}');
+            return sb.toString();
         }
     }
 
@@ -1141,6 +1195,73 @@ public class XMLUtils {
         @Override
         public String toString() {
             return "SAXErrorHandler";
+        }
+    }
+
+    /** EntityResolver that delegates to EntityResolver to verify allowed locations. */
+    private static class GTXMLResolver implements XMLResolver {
+
+        private final EntityResolver entityResolver;
+        private final XMLResolver xmlResolver;
+        private final Hints hints;
+
+        public GTXMLResolver(EntityResolver entityResolver, XMLResolver xmlResolver, Hints hints) {
+            this.entityResolver = entityResolver;
+            this.xmlResolver = xmlResolver;
+            this.hints = hints;
+        }
+
+        /**
+         * java.io.InputStream (2) javax.xml.stream.XMLStreamReader (3) java.xml.stream.XMLEventReader.
+         *
+         * @param publicID The public identifier of the external entity being referenced, or null if none was supplied.
+         * @param systemID The system identifier of the external entity being referenced.
+         * @param baseURI Absolute base URI associated with systemId.
+         * @param namespace The namespace of the entity to resolve.
+         * @return
+         * @throws XMLStreamException
+         */
+        @Override
+        public Object resolveEntity(String publicID, String systemID, String baseURI, String namespace)
+                throws XMLStreamException {
+            // step 1: check with xml resolver: null (external), source (internal), or exception (forbidden)
+            InputSource source = null;
+            try {
+                source = entityResolver.resolveEntity(publicID, systemID);
+                if (source != null) {
+                    // 1. Prefer the character stream (Reader) if available
+                    if (source.getCharacterStream() != null) {
+                        XMLInputFactory factory = XMLUtils.newXMLInputFactory(hints);
+                        return factory.createXMLStreamReader(source.getCharacterStream());
+                    }
+                    // 2. Fall back to the byte stream (InputStream)
+                    else if (source.getByteStream() != null) {
+                        XMLInputFactory factory = XMLUtils.newXMLInputFactory(hints);
+                        return factory.createXMLStreamReader(source.getByteStream(), source.getEncoding());
+                    }
+                    // 3. Allow factory to resolve systemId
+                    else if (source.getSystemId() != null) {
+                        return null;
+                    }
+                }
+                // step 2: check with uri resolver
+                if (xmlResolver != null) {
+                    return xmlResolver.resolveEntity(publicID, systemID, baseURI, namespace);
+                } else {
+                    // step 3: allow input factory to handle
+                    return null;
+                }
+            } catch (SAXException | IOException e) {
+                throw new XMLStreamException(e);
+            }
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder sb = new StringBuilder("GTXMLResolver{");
+            sb.append("xmlResolver=").append(xmlResolver);
+            sb.append('}');
+            return sb.toString();
         }
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -363,8 +363,16 @@ public class SLDParser {
         dbf.setNamespaceAware(namespaceAware);
 
         if (entityResolver != null) {
-            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+            try {
+                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
+            }
+            try {
+                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+            }
             dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             dbf.setFeature("http://xml.org/sax/features/external-general-entities", true);
             dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -105,7 +105,9 @@ import org.geotools.styling.ShadedReliefImpl;
 import org.geotools.styling.UomOgcMapping;
 import org.geotools.styling.UserLayerImpl;
 import org.geotools.util.Base64;
+import org.geotools.util.DefaultEntityResolver;
 import org.geotools.util.GrowableInternationalString;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.SimpleInternationalString;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.xml.XMLUtils;
@@ -357,6 +359,13 @@ public class SLDParser {
         }
     }
 
+    /**
+     * Configured DocumentBuilder for parsing SLD documents, which requires namespace information.
+     *
+     * @param namespaceAware
+     * @return
+     * @throws ParserConfigurationException
+     */
     protected javax.xml.parsers.DocumentBuilder newDocumentBuilder(boolean namespaceAware)
             throws ParserConfigurationException {
         javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
@@ -364,22 +373,23 @@ public class SLDParser {
 
         if (entityResolver != null) {
             try {
-                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                if (entityResolver == DefaultEntityResolver.INSTANCE) {
+                    dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
+                } else if (entityResolver == NullEntityResolver.INSTANCE) {
+                    dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+                } else {
+                    dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "file,http");
+                }
             } catch (IllegalArgumentException notSupported) {
                 LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
             }
-            try {
-                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
-            } catch (IllegalArgumentException notSupported) {
-                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
-            }
             dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", true);
             dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", true);
         }
 
         javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
-
         if (entityResolver != null) {
             db.setEntityResolver(entityResolver);
         } else {

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -107,6 +107,8 @@ import org.geotools.util.Base64;
 import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.SimpleInternationalString;
 import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -357,9 +359,13 @@ public class SLDParser {
 
     protected javax.xml.parsers.DocumentBuilder newDocumentBuilder(boolean namespaceAware)
             throws ParserConfigurationException {
-        javax.xml.parsers.DocumentBuilderFactory dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+        Hints hints = GeoTools.getDefaultHints();
+        if (this.entityResolver != null) {
+            hints.put(Hints.ENTITY_RESOLVER, this.entityResolver);
+        }
+        javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory(hints);
         dbf.setNamespaceAware(namespaceAware);
-        javax.xml.parsers.DocumentBuilder db = dbf.newDocumentBuilder();
+        javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
         if (entityResolver != null) {
             db.setEntityResolver(entityResolver);

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.api.filter.Filter;
@@ -107,7 +108,6 @@ import org.geotools.util.Base64;
 import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.SimpleInternationalString;
 import org.geotools.util.factory.GeoTools;
-import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
@@ -359,16 +359,23 @@ public class SLDParser {
 
     protected javax.xml.parsers.DocumentBuilder newDocumentBuilder(boolean namespaceAware)
             throws ParserConfigurationException {
-        Hints hints = GeoTools.getDefaultHints();
-        if (this.entityResolver != null) {
-            hints.put(Hints.ENTITY_RESOLVER, this.entityResolver);
-        }
-        javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory(hints);
+        javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
         dbf.setNamespaceAware(namespaceAware);
-        javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder();
+
+        if (entityResolver != null) {
+            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
+            dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", true);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        }
+
+        javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
 
         if (entityResolver != null) {
             db.setEntityResolver(entityResolver);
+        } else {
+            db.setEntityResolver(GeoTools.getEntityResolver(null));
         }
 
         return db;

--- a/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
@@ -36,6 +36,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
+import org.geotools.xml.XMLUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.InputSource;
@@ -68,7 +69,7 @@ public abstract class TransformerBase {
 
     /** Create a Transformer which is initialized with the settings of this TransformerBase. */
     public Transformer createTransformer() throws TransformerException {
-        TransformerFactory tFactory = TransformerFactory.newInstance();
+        TransformerFactory tFactory = XMLUtils.newTransformerFactory();
         if (indentation > -1) {
             try {
                 tFactory.setAttribute("indent-number", Integer.valueOf(indentation));
@@ -77,7 +78,7 @@ public abstract class TransformerBase {
             }
         }
 
-        Transformer transformer = tFactory.newTransformer();
+        Transformer transformer = XMLUtils.newTransformer(tFactory);
 
         if (indentation > -1) {
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");

--- a/modules/library/xml/src/test/java/org/geotools/gml/GMLFilterFeature2Test.java
+++ b/modules/library/xml/src/test/java/org/geotools/gml/GMLFilterFeature2Test.java
@@ -5,11 +5,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.feature.DefaultFeatureCollection;
 import org.geotools.feature.FeatureCollection;
+import org.geotools.xml.XMLUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.xml.sax.InputSource;
@@ -30,7 +30,7 @@ public class GMLFilterFeature2Test {
 
     private static SAXParser createParser() {
         try {
-            return SAXParserFactory.newInstance().newSAXParser();
+            return XMLUtils.newSAXParser();
         } catch (ParserConfigurationException | SAXException exception) {
             throw new RuntimeException(exception);
         }

--- a/modules/library/xml/src/test/java/org/geotools/gml/GMLFilterFeatureTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/gml/GMLFilterFeatureTest.java
@@ -33,6 +33,7 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.gml.producer.FeatureTransformer;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -72,9 +73,10 @@ public class GMLFilterFeatureTest {
         final GMLFilterFeature filterFeature = new GMLFilterFeature(handler);
         final GMLFilterGeometry filterGeometry = new GMLFilterGeometry(filterFeature);
         final GMLFilterDocument filterDocument = new GMLFilterDocument(filterGeometry);
-        final SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+        final SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
         parserFactory.setNamespaceAware(true);
-        final SAXParser parser = parserFactory.newSAXParser();
+
+        final SAXParser parser = XMLUtils.newSAXParser(parserFactory);
         final XMLReader reader = parser.getXMLReader();
         reader.setContentHandler(filterDocument);
         reader.parse(new InputSource(new StringReader(gml)));

--- a/modules/library/xml/src/test/java/org/geotools/xml/GMLInheritanceTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/GMLInheritanceTest.java
@@ -32,11 +32,11 @@ public class GMLInheritanceTest {
 
     @Test
     public void testNestedFeature() throws Throwable {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "xml/sample/nestedFeatures.xml";
         File f = TestData.copy(this, path);
@@ -60,11 +60,11 @@ public class GMLInheritanceTest {
 
     @Test
     public void testMultiInheritance() throws Throwable {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "xml/sample/multiInheritance.xml";
         File f = TestData.copy(this, path);

--- a/modules/library/xml/src/test/java/org/geotools/xml/GMLParser2Test.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/GMLParser2Test.java
@@ -41,11 +41,11 @@ public class GMLParser2Test {
     @Test
     public void testFMEPostalFeatures() throws SAXException, IOException {
         try {
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setNamespaceAware(true);
-            spf.setValidating(false);
+            SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setValidating(false);
 
-            SAXParser parser = spf.newSAXParser();
+            SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
             String path = "city/dj.xml";
             File f = TestData.file(this, path);
@@ -67,141 +67,4 @@ public class GMLParser2Test {
             Assert.fail(e.toString());
         }
     }
-
-    //    public void testFMEPostalFeatures() throws SAXException, IOException {
-    //        try {
-    //            SAXParserFactory spf = SAXParserFactory.newInstance();
-    //            spf.setNamespaceAware(true);
-    //            spf.setValidating(false);
-    //
-    //            SAXParser parser = spf.newSAXParser();
-    //
-    //            String path = "fme/postal/postal.gml";
-    //            File f = TestData.file(this,path);
-    //            URI u = f.toURI();
-    //
-    //            XMLSAXHandler xmlContentHandler = new XMLSAXHandler(u,null);
-    //            XMLSAXHandler.setLogLevel(Level.WARNING);
-    //            XSISAXHandler.setLogLevel(Level.WARNING);
-    //            XMLElementHandler.setLogLevel(Level.WARNING);
-    //            XSIElementHandler.setLogLevel(Level.WARNING);
-    //
-    //            parser.parse(f, xmlContentHandler);
-    //
-    //            Object doc = xmlContentHandler.getDocument();
-    //            assertNotNull("Document missing", doc);
-    //            System.out.println(doc);
-    //
-    //            Object[] objs = (Object[])doc;
-    //
-    //            assertTrue("Should have 95054 features + 1 bbox : "+objs.length,objs.length ==
-    // 95055);
-    //
-    //        } catch (Throwable e) {
-    //            e.printStackTrace();
-    //            fail(e.toString());
-    //        }
-    //    }
-    //
-    //    public void testFMEFedCenFeatures() throws SAXException, IOException {
-    //        try {
-    //            SAXParserFactory spf = SAXParserFactory.newInstance();
-    //            spf.setNamespaceAware(true);
-    //            spf.setValidating(false);
-    //
-    //            SAXParser parser = spf.newSAXParser();
-    //
-    //            String path = "fme/fed-cen/fed308_a.gml";
-    //            File f = TestData.file(this,path);
-    //            URI u = f.toURI();
-    //
-    //            XMLSAXHandler xmlContentHandler = new XMLSAXHandler(u,null);
-    //            XMLSAXHandler.setLogLevel(Level.WARNING);
-    //            XSISAXHandler.setLogLevel(Level.WARNING);
-    //            XMLElementHandler.setLogLevel(Level.WARNING);
-    //            XSIElementHandler.setLogLevel(Level.WARNING);
-    //
-    //            parser.parse(f, xmlContentHandler);
-    //
-    //            Object doc = xmlContentHandler.getDocument();
-    //            assertNotNull("Document missing", doc);
-    //            System.out.println(doc);
-    //
-    //            Object[] objs = (Object[])doc;
-    //
-    //            assertTrue("Should have N features + 1 bbox : "+objs.length,objs.length > 2);
-    //
-    //        } catch (Throwable e) {
-    //            e.printStackTrace();
-    //            fail(e.toString());
-    //        }
-    //    }
-    //
-    //    public void testFMEForestFeatures() throws SAXException, IOException {
-    //        try {
-    //            SAXParserFactory spf = SAXParserFactory.newInstance();
-    //            spf.setNamespaceAware(true);
-    //            spf.setValidating(false);
-    //
-    //            SAXParser parser = spf.newSAXParser();
-    //
-    //            String path = "fme/forest_districts/forest-districts-2003-04.gml";
-    //            File f = TestData.file(this,path);
-    //            URI u = f.toURI();
-    //
-    //            XMLSAXHandler xmlContentHandler = new XMLSAXHandler(u,null);
-    //            XMLSAXHandler.setLogLevel(Level.WARNING);
-    //            XSISAXHandler.setLogLevel(Level.WARNING);
-    //            XMLElementHandler.setLogLevel(Level.WARNING);
-    //            XSIElementHandler.setLogLevel(Level.WARNING);
-    //
-    //            parser.parse(f, xmlContentHandler);
-    //
-    //            Object doc = xmlContentHandler.getDocument();
-    //            assertNotNull("Document missing", doc);
-    //            System.out.println(doc);
-    //
-    //            Object[] objs = (Object[])doc;
-    //
-    //            assertTrue("Should have N features + 1 bbox : "+objs.length,objs.length > 2);
-    //
-    //        } catch (Throwable e) {
-    //            e.printStackTrace();
-    //            fail(e.toString());
-    //        }
-    //    }
-    //
-    //    public void testFMEVictoriaFeatures() throws SAXException, IOException {
-    //        try {
-    //            SAXParserFactory spf = SAXParserFactory.newInstance();
-    //            spf.setNamespaceAware(true);
-    //            spf.setValidating(false);
-    //
-    //            SAXParser parser = spf.newSAXParser();
-    //
-    //            String path = "fme/victoria/victoria.gml";
-    //            File f = TestData.file(this,path);
-    //            URI u = f.toURI();
-    //
-    //            XMLSAXHandler xmlContentHandler = new XMLSAXHandler(u,null);
-    //            XMLSAXHandler.setLogLevel(Level.WARNING);
-    //            XSISAXHandler.setLogLevel(Level.WARNING);
-    //            XMLElementHandler.setLogLevel(Level.WARNING);
-    //            XSIElementHandler.setLogLevel(Level.WARNING);
-    //
-    //            parser.parse(f, xmlContentHandler);
-    //
-    //            Object doc = xmlContentHandler.getDocument();
-    //            assertNotNull("Document missing", doc);
-    //            System.out.println(doc);
-    //
-    //            Object[] objs = (Object[])doc;
-    //
-    //            assertTrue("Should have N features + 1 bbox : "+objs.length,objs.length > 2);
-    //
-    //        } catch (Throwable e) {
-    //            e.printStackTrace();
-    //            fail(e.toString());
-    //        }
-    //    }
 }

--- a/modules/library/xml/src/test/java/org/geotools/xml/GMLParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/GMLParserTest.java
@@ -43,11 +43,11 @@ public class GMLParserTest {
 
     @Test
     public void testParseEmptyCollectionFeatures() throws Exception {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "xml/fme/empty-collection/lakes.xml";
         File f = TestData.copy(this, path);
@@ -72,11 +72,11 @@ public class GMLParserTest {
     @Test
     @Ignore
     public void testOneFeature() throws Exception {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "xml/geoserver/oneFeature.xml";
         File f = TestData.copy(this, path);
@@ -103,11 +103,11 @@ public class GMLParserTest {
     @Ignore
     public void testMoreFeatures() {
         try {
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setNamespaceAware(true);
-            spf.setValidating(false);
+            SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setValidating(false);
 
-            SAXParser parser = spf.newSAXParser();
+            SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
             String path = "xml/geoserver/roads.xml";
             File f = TestData.copy(this, path);
@@ -138,11 +138,11 @@ public class GMLParserTest {
     @Test
     public void testPatternSchema() {
         try {
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setNamespaceAware(true);
-            spf.setValidating(false);
+            SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setValidating(false);
 
-            SAXParser parser = spf.newSAXParser();
+            SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
             String path = "xml/patternfacet/states.xml";
             File f = TestData.copy(this, path);
@@ -171,11 +171,11 @@ public class GMLParserTest {
 
     @Test
     public void testFMERoadsFeatures() throws Exception {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "xml/fme/roads/roads.xml";
         File f = TestData.copy(this, path);
@@ -199,11 +199,11 @@ public class GMLParserTest {
 
     @Test
     public void testFMELakesFeatures() throws Exception {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "xml/fme/lakes/lakes.xml";
         File f = TestData.copy(this, path);
@@ -322,11 +322,11 @@ public class GMLParserTest {
     @Test
     public void testProblemFeatures() {
         try {
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setNamespaceAware(true);
-            spf.setValidating(false);
+            SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setValidating(false);
 
-            SAXParser parser = spf.newSAXParser();
+            SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
             String path = "xml/iba-gml-bad.xml";
             File f = TestData.copy(this, path);

--- a/modules/library/xml/src/test/java/org/geotools/xml/SchemaMergeTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/SchemaMergeTest.java
@@ -39,10 +39,10 @@ public class SchemaMergeTest {
     @Before
     public void setUp() throws Exception {
 
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
-        parser = spf.newSAXParser();
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
+        parser = XMLUtils.newSAXParser(parserFactory);
     }
 
     @Test

--- a/modules/library/xml/src/test/java/org/geotools/xml/SchemaParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/SchemaParserTest.java
@@ -37,10 +37,11 @@ public class SchemaParserTest {
     @Before
     public void setUp() throws Exception {
 
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
-        parser = spf.newSAXParser();
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
+
+        parser = XMLUtils.newSAXParser(parserFactory);
     }
 
     @Test

--- a/modules/library/xml/src/test/java/org/geotools/xml/XMLParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/XMLParserTest.java
@@ -33,11 +33,11 @@ public class XMLParserTest {
 
     @Test
     public void testNestedFeature() throws Throwable {
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
 
-        SAXParser parser = spf.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
 
         String path = "/wfsgetfeature.xml";
         File f = TestData.copy(this, path);

--- a/modules/library/xml/src/test/java/org/geotools/xml/XMLUtilsTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/XMLUtilsTest.java
@@ -55,8 +55,7 @@ public class XMLUtilsTest {
         assertTrue("gml", gml.exists());
         assertTrue("xsd", xsd.exists());
         URI uri = gml.toURI();
-        Hints hints = new Hints();
-        hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+        Hints hints = new Hints(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
 
         // parsing InputSource
         InputSource gmlSource = new InputSource(uri.toString());

--- a/modules/library/xml/src/test/java/org/geotools/xml/XMLUtilsTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/XMLUtilsTest.java
@@ -1,0 +1,110 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.logging.Logger;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.stream.StreamResult;
+import org.geotools.TestData;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class XMLUtilsTest {
+    public static Logger LOGGER = Logging.getLogger(XMLUtils.class);
+
+    @Test
+    public void transform() throws Exception {
+        // stage lates.xml and lakes.xsd
+        File gml = TestData.copy(this, "xml/fme/lakes/lakes.xml");
+        File xsd = TestData.copy(this, "xml/fme/lakes/lakes.xsd");
+        assertTrue("gml", gml.exists());
+        assertTrue("xsd", xsd.exists());
+        URI uri = gml.toURI();
+        Hints hints = new Hints();
+        hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+
+        // parsing InputSource
+        InputSource gmlSource = new InputSource(uri.toString());
+
+        DocumentBuilderFactory documentBuilderFactory = XMLUtils.newDocumentBuilderFactory(hints);
+        documentBuilderFactory.setNamespaceAware(true);
+        DocumentBuilder documentBuilder = XMLUtils.newDocumentBuilder(documentBuilderFactory, hints);
+        Document document = documentBuilder.parse(gmlSource);
+        assertNotNull(document);
+
+        TransformerFactory txFactory = XMLUtils.newTransformerFactory(hints);
+        txFactory.setAttribute("indent-number", 3);
+
+        // Transformer
+        Transformer tx = XMLUtils.newTransformer(txFactory, hints);
+        tx.setOutputProperty(OutputKeys.INDENT, "yes");
+
+        StringWriter writer = new StringWriter();
+        tx.transform(XMLUtils.source(document), new StreamResult(writer));
+
+        String text = writer.getBuffer().toString();
+        assertNotNull(text);
+
+        SAXParserFactory sxFactory = XMLUtils.newSAXParserFactory(hints);
+        sxFactory.setNamespaceAware(true);
+        sxFactory.setValidating(true);
+
+        // SAXTransformer
+        SAXParser saxParser = sxFactory.newSAXParser();
+        FeatureMembers handler = new FeatureMembers();
+
+        InputSource internal = new InputSource(new StringReader(text));
+        internal.setPublicId("lakes");
+        saxParser.parse(internal, handler);
+
+        assertEquals(100, handler.count);
+    }
+
+    public static class FeatureMembers extends DefaultHandler {
+        public int count = 0;
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes)
+                throws SAXException {
+            if (localName.equals("featureMember")) {
+                count++;
+            }
+            super.startElement(uri, localName, qName, attributes);
+        }
+    }
+}

--- a/modules/library/xml/src/test/java/org/geotools/xml/filter/DOMParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/filter/DOMParserTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.Id;
 import org.geotools.api.filter.PropertyIsLike;
@@ -42,6 +41,7 @@ import org.geotools.filter.FilterDOMParser;
 import org.geotools.filter.FilterTestSupport;
 import org.geotools.referencing.CRS;
 import org.geotools.test.TestData;
+import org.geotools.xml.XMLUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -289,8 +289,7 @@ public class DOMParserTest extends FilterTestSupport {
 
     public Filter parseDocument(String uri) throws Exception {
         org.geotools.api.filter.Filter filter = null;
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
         Document dom = db.parse(TestData.getResource(this, uri).toExternalForm());
         FilterTestSupport.LOGGER.fine("parsing " + uri);
@@ -326,8 +325,7 @@ public class DOMParserTest extends FilterTestSupport {
 
     public Filter parseDocumentFirst(String uri) throws Exception {
         Filter filter = null;
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(TestData.getResource(this, uri).toExternalForm());
         FilterTestSupport.LOGGER.fine("parsing " + uri);
 

--- a/modules/library/xml/src/test/java/org/geotools/xml/filter/DOMParserTestSuite.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/filter/DOMParserTestSuite.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertNotNull;
 import java.io.File;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import junit.framework.Test;
 import junit.framework.TestResult;
 import junit.framework.TestSuite;
@@ -34,6 +33,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.FilterDOMParser;
 import org.geotools.test.TestData;
+import org.geotools.xml.XMLUtils;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
@@ -176,8 +176,7 @@ public class DOMParserTestSuite extends TestSuite {
 
         public Filter parseDocument(String uri) throws Exception {
             Filter filter = null;
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
             Document dom = db.parse(TestData.getResource(this, uri).toExternalForm());
             LOGGER.fine("parsing " + uri);

--- a/modules/library/xml/src/test/java/org/geotools/xml/filter/FilterFilterTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/filter/FilterFilterTest.java
@@ -29,7 +29,6 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import org.geotools.api.filter.BinaryComparisonOperator;
 import org.geotools.api.filter.BinaryLogicOperator;
 import org.geotools.api.filter.Filter;
@@ -44,6 +43,7 @@ import org.geotools.filter.LogicFilterImpl;
 import org.geotools.gml.GMLFilterDocument;
 import org.geotools.gml.GMLFilterGeometry;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.xml.sax.InputSource;
 import org.xml.sax.helpers.ParserAdapter;
@@ -90,9 +90,7 @@ public class FilterFilterTest {
         GMLFilterDocument documentFilter = new GMLFilterDocument(geometryFilter);
 
         // read in XML file and parse to content handler
-
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        SAXParser parser = factory.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser();
         ParserAdapter adapter = new ParserAdapter(parser.getParser());
         adapter.setContentHandler(documentFilter);
         adapter.parse(requestSource);
@@ -147,8 +145,7 @@ public class FilterFilterTest {
         GMLFilterDocument documentFilter = new GMLFilterDocument(geometryFilter);
 
         // read in XML file and parse to content handler
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        SAXParser parser = factory.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser();
         ParserAdapter adapter = new ParserAdapter(parser.getParser());
         adapter.setContentHandler(documentFilter);
         adapter.parse(requestSource);
@@ -206,9 +203,7 @@ public class FilterFilterTest {
         GMLFilterDocument documentFilter = new GMLFilterDocument(geometryFilter);
 
         // read in XML file and parse to content handler
-
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        SAXParser parser = factory.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser();
         ParserAdapter adapter = new ParserAdapter(parser.getParser());
         adapter.setContentHandler(documentFilter);
         adapter.parse(requestSource);
@@ -260,7 +255,7 @@ public class FilterFilterTest {
 
         InputSource requestSource = new InputSource(reader);
 
-        //		 instantiante parsers and content handlers
+        // instantiate  parsers and content handlers
         MyHandler contentHandler = new MyHandler();
         FilterFilter filterParser = new FilterFilter(contentHandler, null);
         GMLFilterGeometry geometryFilter = new GMLFilterGeometry(filterParser);
@@ -270,10 +265,10 @@ public class FilterFilterTest {
         //        logger.setLevel(Level.ALL);
         //        ConsoleHandler consoleHandler = new ConsoleHandler();
         //        consoleHandler.setLevel(Level.ALL);
-        //		logger.addHandler(consoleHandler);
+        //        logger.addHandler(consoleHandler);
+
         // read in XML file and parse to content handler
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        SAXParser parser = factory.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser();
         ParserAdapter adapter = new ParserAdapter(parser.getParser());
         adapter.setContentHandler(documentFilter);
         adapter.parse(requestSource);
@@ -325,8 +320,7 @@ public class FilterFilterTest {
         logger.addHandler(consoleHandler);
 
         // read in XML file and parse to content handler
-        SAXParserFactory factory = SAXParserFactory.newInstance();
-        SAXParser parser = factory.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser();
         ParserAdapter adapter = new ParserAdapter(parser.getParser());
         adapter.setContentHandler(documentFilter);
         adapter.parse(requestSource);

--- a/modules/library/xml/src/test/java/org/geotools/xml/filter/ParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/filter/ParserTest.java
@@ -18,7 +18,6 @@ package org.geotools.xml.filter;
 
 import java.util.logging.Logger;
 import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.feature.SchemaException;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
@@ -26,6 +25,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.gml.GMLFilterDocument;
 import org.geotools.gml.GMLFilterGeometry;
 import org.geotools.test.TestData;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xml.ogc.FilterTestSupport;
 import org.junit.Before;
 import org.junit.Test;
@@ -256,8 +256,7 @@ public class ParserTest extends FilterTestSupport {
         // uncomment to use xerces parser
         // parser.setContentHandler(documentFilter);
         // parser.parse(uri);
-        SAXParserFactory fac = SAXParserFactory.newInstance();
-        SAXParser parser = fac.newSAXParser();
+        SAXParser parser = XMLUtils.newSAXParser();
 
         ParserAdapter p = new ParserAdapter(parser.getParser());
         p.setContentHandler(documentFilter);

--- a/modules/library/xml/src/test/java/org/geotools/xml/ogc/GeometryEncoderTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/ogc/GeometryEncoderTest.java
@@ -26,6 +26,7 @@ import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import org.geotools.TestData;
 import org.geotools.xml.PrintHandler;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xml.XSISAXHandler;
 import org.geotools.xml.schema.Element;
 import org.geotools.xml.schema.Schema;
@@ -52,10 +53,11 @@ public class GeometryEncoderTest {
         XSISAXHandler contentHandler = new XSISAXHandler(u);
         XSISAXHandler.setLogLevel(Level.WARNING);
 
-        SAXParserFactory spf = SAXParserFactory.newInstance();
-        spf.setNamespaceAware(true);
-        spf.setValidating(false);
-        SAXParser parser = spf.newSAXParser();
+        SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setValidating(false);
+
+        SAXParser parser = XMLUtils.newSAXParser(parserFactory);
         parser.parse(f, contentHandler);
 
         Schema schema = contentHandler.getSchema();

--- a/modules/library/xml/src/test/java/org/geotools/xml/ogc/XMLEncoderTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/ogc/XMLEncoderTest.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.PropertyIsNull;
@@ -37,6 +36,7 @@ import org.geotools.test.TestData;
 import org.geotools.xml.DocumentFactory;
 import org.geotools.xml.DocumentWriter;
 import org.geotools.xml.XMLHandlerHints;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xml.filter.FilterSchema;
 import org.junit.Assert;
 import org.junit.Test;
@@ -191,8 +191,7 @@ public class XMLEncoderTest {
 
     public Filter parseDocument(String uri) throws Exception {
         Filter filter = null;
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(TestData.getResource(this, uri).toExternalForm());
 
         //        LOGGER.fine("exporting " + uri);

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserNamespaceTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserNamespaceTest.java
@@ -30,6 +30,7 @@ import org.geotools.api.style.Style;
 import org.geotools.api.style.StyleFactory;
 import org.geotools.api.style.Symbolizer;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.NullEntityResolver;
 import org.junit.Assert;
 import org.junit.Test;
 import org.xml.sax.helpers.NamespaceSupport;
@@ -74,6 +75,8 @@ public class SLDParserNamespaceTest {
     @Test
     public void testNamespace() throws Exception {
         SLDParser parser = new SLDParser(styleFactory, input());
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
+
         Style[] styles = parser.readXML();
         Assert.assertEquals(styles.length, 1);
         Style style = styles[0];

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -50,6 +50,7 @@ import org.geotools.api.style.Style;
 import org.geotools.api.style.StyleFactory;
 import org.geotools.api.style.Symbolizer;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.xml.sax.InputSource;
@@ -638,6 +639,7 @@ public class SLDParserTest {
     @Test
     public void testLocalizedWithNamespace() throws Exception {
         SLDParser parser = new SLDParser(styleFactory, input(LocalizedSLDWithNamespace));
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         Style[] styles = parser.readXML();
         assertEquals(
                 "english",
@@ -783,14 +785,14 @@ public class SLDParserTest {
     public void testExternalEntitiesDisabled() {
         // this SLD file references as external entity a file on the local filesystem
         SLDParser parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
-
-        // without a custom EntityResolver, the parser will try to read the entity file on the local
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
+        // With NullEntityResolver EntityResolver, the parser be able to read the entity file on the local
         // file system
         try {
             parser.readXML();
             fail("parsing should thrown an error");
         } catch (RuntimeException e) {
-            assertTrue(e.getCause() instanceof FileNotFoundException);
+            assertTrue(e.getMessage(), e.getCause() instanceof FileNotFoundException);
         }
 
         parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.style.ContrastEnhancement;
 import org.geotools.api.style.ContrastMethod;
@@ -51,6 +50,7 @@ import org.geotools.api.style.Style;
 import org.geotools.api.style.StyleFactory;
 import org.geotools.api.style.Symbolizer;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.xml.sax.InputSource;
 
@@ -823,7 +823,7 @@ public class SLDParserTest {
 
     @Test
     public void testStrokeColorWithEnv() throws Exception {
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder builder = XMLUtils.newDocumentBuilder();
         org.w3c.dom.Document node =
                 builder.parse(new ByteArrayInputStream(formattedCssStrokeParameter.getBytes(StandardCharsets.UTF_8)));
         SLDParser parser = new SLDParser(styleFactory);
@@ -835,7 +835,7 @@ public class SLDParserTest {
     @Test
     public void testContrastEnhancement() throws Exception {
 
-        DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder builder = XMLUtils.newDocumentBuilder();
         org.w3c.dom.Document node =
                 builder.parse(new ByteArrayInputStream(contrastEnhance.getBytes(StandardCharsets.UTF_8)));
         // First check the happy path for normalize

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDStyleTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDStyleTest.java
@@ -81,6 +81,7 @@ import org.geotools.filter.function.FilterFunction_buffer;
 import org.geotools.styling.SLD;
 import org.geotools.styling.StyleBuilder;
 import org.geotools.test.TestData;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.factory.GeoTools;
 import org.junit.Assert;
 import org.junit.Test;
@@ -1077,6 +1078,7 @@ public class SLDStyleTest {
         StyleFactory factory = CommonFactoryFinder.getStyleFactory(null);
         URL surl = TestData.getResource(this, s);
         SLDParser stylereader = new SLDParser(factory, surl);
+        stylereader.setEntityResolver(NullEntityResolver.INSTANCE);
 
         // basic checks
         return stylereader.readXML();

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDTransformerTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDTransformerTest.java
@@ -37,7 +37,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import org.geotools.api.filter.FilterFactory;
@@ -87,6 +86,7 @@ import org.geotools.styling.UomOgcMapping;
 import org.geotools.test.xml.XmlTestSupport;
 import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.factory.GeoTools;
+import org.geotools.xml.XMLUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -578,9 +578,7 @@ public class SLDTransformerTest extends XmlTestSupport {
         SLDParser parser = new SLDParser(sf);
 
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder();
             Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
             PointSymbolizer pointSymbolizer2 = parser.parsePointSymbolizer(dom.getFirstChild());
@@ -603,9 +601,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         PolygonSymbolizer polygonSymbolizer2 = parser.parsePolygonSymbolizer(dom.getFirstChild());
@@ -625,9 +621,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         RasterSymbolizer rasterSymbolizer2 = parser.parseRasterSymbolizer(dom.getFirstChild());
@@ -679,9 +673,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         LineSymbolizer lineSymbolizer2 = parser.parseLineSymbolizer(dom.getFirstChild());
@@ -706,9 +698,7 @@ public class SLDTransformerTest extends XmlTestSupport {
         assertNotNull(xmlFragment);
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         TextSymbolizer textSymbolizer2 = parser.parseTextSymbolizer(dom.getFirstChild());
@@ -727,9 +717,7 @@ public class SLDTransformerTest extends XmlTestSupport {
         SLDParser parser = new SLDParser(sf);
 
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-            DocumentBuilder db = dbf.newDocumentBuilder();
+            DocumentBuilder db = XMLUtils.newDocumentBuilder();
             Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
             PointSymbolizer pointSymbolizer2 = parser.parsePointSymbolizer(dom.getFirstChild());
@@ -751,9 +739,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         PolygonSymbolizer polygonSymbolizer2 = parser.parsePolygonSymbolizer(dom.getFirstChild());
@@ -772,9 +758,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         RasterSymbolizer rasterSymbolizer2 = parser.parseRasterSymbolizer(dom.getFirstChild());
@@ -793,9 +777,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         LineSymbolizer lineSymbolizer2 = parser.parseLineSymbolizer(dom.getFirstChild());
@@ -814,9 +796,7 @@ public class SLDTransformerTest extends XmlTestSupport {
 
         SLDParser parser = new SLDParser(sf);
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
         Document dom = db.parse(new InputSource(new StringReader(xmlFragment)));
 
         TextSymbolizer textSymbolizer2 = parser.parseTextSymbolizer(dom.getFirstChild());

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/XmlnsNamespaceTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/XmlnsNamespaceTest.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import org.geotools.api.style.Style;
 import org.geotools.styling.StyleFactoryImpl;
 import org.geotools.test.TestData;
+import org.geotools.util.NullEntityResolver;
 import org.junit.Test;
 
 /**
@@ -37,6 +38,7 @@ public class XmlnsNamespaceTest {
 
         java.net.URL sldUrl = TestData.getResource(this, "xmlnsNamespaces.sld");
         SLDParser parser = new SLDParser(new StyleFactoryImpl(), sldUrl);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         Style style = parser.readXML()[0];
 
         SLDTransformer transformer = new SLDTransformer();

--- a/modules/plugin/coverage-multidim/netcdf/pom.xml
+++ b/modules/plugin/coverage-multidim/netcdf/pom.xml
@@ -142,6 +142,10 @@
       <artifactId>slf4j-jdk14</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/tools/CreateIndexer.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/tools/CreateIndexer.java
@@ -143,6 +143,7 @@ public class CreateIndexer {
         System.out.println("Grabbing the generated xml: " + finalAuxFile);
 
         SAXBuilder saxBuilder = new SAXBuilder();
+        saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
         Document doc = saxBuilder.build(finalAuxFile);
         Element root = doc.getRootElement();
         Set<String> timeAttributes = new HashSet<>();

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/tools/CreateIndexer.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/tools/CreateIndexer.java
@@ -144,6 +144,7 @@ public class CreateIndexer {
 
         SAXBuilder saxBuilder = new SAXBuilder();
         saxBuilder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
         Document doc = saxBuilder.build(finalAuxFile);
         Element root = doc.getRootElement();
         Set<String> timeAttributes = new HashSet<>();

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/tools/CreateIndexer.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/coverage/io/netcdf/tools/CreateIndexer.java
@@ -35,7 +35,6 @@ import javax.imageio.ImageReader;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import org.apache.commons.io.FileUtils;
@@ -43,6 +42,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.geotools.imageio.netcdf.NetCDFImageReaderSpi;
 import org.geotools.util.SuppressFBWarnings;
+import org.geotools.xml.XMLUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -213,7 +213,7 @@ public class CreateIndexer {
 
     private static void formatAuxiliaryXml(File auxiliaryFile, File finalAuxFile)
             throws FileNotFoundException, TransformerException {
-        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        Transformer transformer = XMLUtils.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 

--- a/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/utilities/NetCDFUtilities.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/main/java/org/geotools/imageio/netcdf/utilities/NetCDFUtilities.java
@@ -61,6 +61,7 @@ import org.geotools.io.MemoryMappedFileCache;
 import org.geotools.referencing.operation.projection.MapProjection;
 import org.geotools.util.NumberRange;
 import org.geotools.util.SoftValueHashMap;
+import org.geotools.xml.XMLUtils;
 import thredds.featurecollection.FeatureCollectionConfig;
 import thredds.featurecollection.FeatureCollectionConfigBuilder;
 import ucar.ma2.Array;
@@ -788,8 +789,7 @@ public class NetCDFUtilities {
             XMLStreamReader reader = null;
             try {
                 streamSource = new StreamSource(input);
-                XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-                inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+                XMLInputFactory inputFactory = XMLUtils.newXMLInputFactory();
                 reader = inputFactory.createXMLStreamReader(streamSource);
                 reader.nextTag();
                 if ("netcdf".equals(reader.getName().getLocalPart())) {

--- a/modules/plugin/feature-pregeneralized/pom.xml
+++ b/modules/plugin/feature-pregeneralized/pom.xml
@@ -62,7 +62,10 @@
       <groupId>org.geotools</groupId>
       <artifactId>gt-shapefile</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-sample-data</artifactId>

--- a/modules/plugin/feature-pregeneralized/src/main/java/org/geotools/data/gen/info/GeneralizationInfosProviderImpl.java
+++ b/modules/plugin/feature-pregeneralized/src/main/java/org/geotools/data/gen/info/GeneralizationInfosProviderImpl.java
@@ -29,6 +29,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -109,13 +110,13 @@ public class GeneralizationInfosProviderImpl implements GeneralizationInfosProvi
     protected GeneralizationInfos parseXML(URL url) throws IOException {
 
         Document doc = null;
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
         factory.setIgnoringComments(true);
         factory.setNamespaceAware(true);
         factory.setIgnoringElementContentWhitespace(true);
 
         try {
-            DocumentBuilder db = factory.newDocumentBuilder();
+            DocumentBuilder db = factory.newDocumentBuilder(); // NOPMD: AvoidDocumentBuilder
             doc = db.parse(url.openStream());
             VALIDATOR.validate(new DOMSource(doc));
         } catch (Exception e) {

--- a/modules/plugin/feature-pregeneralized/src/main/java/org/geotools/data/gen/info/GeneralizationInfosProviderImpl.java
+++ b/modules/plugin/feature-pregeneralized/src/main/java/org/geotools/data/gen/info/GeneralizationInfosProviderImpl.java
@@ -68,7 +68,8 @@ public class GeneralizationInfosProviderImpl implements GeneralizationInfosProvi
     protected static Validator VALIDATOR;
 
     static {
-        SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        SchemaFactory factory = XMLUtils.newSchemaFactory(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        // no need for external xsd as we are parsing local geninfos_1.0.xsd resource
         try {
             factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");

--- a/modules/plugin/feature-pregeneralized/src/main/java/org/geotools/data/gen/info/GeneralizationInfosProviderImpl.java
+++ b/modules/plugin/feature-pregeneralized/src/main/java/org/geotools/data/gen/info/GeneralizationInfosProviderImpl.java
@@ -35,6 +35,8 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 /**
  * @author Christian Mueller
@@ -67,7 +69,12 @@ public class GeneralizationInfosProviderImpl implements GeneralizationInfosProvi
 
     static {
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-
+        try {
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
         URL url = GeneralizationInfosProviderImpl.class.getResource("/geninfos_1.0.xsd");
         Schema schema = null;
         try {
@@ -77,6 +84,12 @@ public class GeneralizationInfosProviderImpl implements GeneralizationInfosProvi
             throw new RuntimeException(e);
         }
         VALIDATOR = schema.newValidator();
+        try {
+            VALIDATOR.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            VALIDATOR.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        } catch (SAXNotRecognizedException | SAXNotSupportedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffCRSFactoryDeadlockTest.java
+++ b/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffCRSFactoryDeadlockTest.java
@@ -79,8 +79,7 @@ public class GeoTiffCRSFactoryDeadlockTest {
 
     Future getUnit(ExecutorService executorService, final boolean[] exceptionOccurred) {
         return executorService.submit(() -> {
-            Hints hints = new Hints();
-            hints.add(new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true));
+            Hints hints = new Hints(Hints.FORCE_LONGITUDE_FIRST_AXIS_ORDER, true);
             AllAuthoritiesFactory factory = new AllAuthoritiesFactory(hints);
             Unit<?> unit = null;
             try {

--- a/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffReaderTest.java
+++ b/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffReaderTest.java
@@ -209,8 +209,7 @@ public class GeoTiffReaderTest {
 
         // hint for CRS
         crs = CRS.decode("EPSG:32632", true);
-        final Hints hint = new Hints();
-        hint.put(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crs);
+        final Hints hint = new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crs);
 
         // getting a reader
         reader = new GeoTiffReader(noCrs, hint);

--- a/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffWriterTest.java
+++ b/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffWriterTest.java
@@ -349,8 +349,7 @@ public class GeoTiffWriterTest extends Assert {
 
         // hint for CRS
         final CoordinateReferenceSystem crs = CRS.decode("EPSG:32632", true);
-        final Hints hint = new Hints();
-        hint.put(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crs);
+        final Hints hint = new Hints(Hints.DEFAULT_COORDINATE_REFERENCE_SYSTEM, crs);
 
         // getting a reader
         GeoTiffReader reader = new GeoTiffReader(noCrs, hint);

--- a/modules/plugin/image/src/test/java/org/geotools/gce/image/WorldImageReaderTest.java
+++ b/modules/plugin/image/src/test/java/org/geotools/gce/image/WorldImageReaderTest.java
@@ -178,8 +178,7 @@ public class WorldImageReaderTest extends WorldImageBaseTestCase {
         // HINTS
         //
         ///////////////////////////////////////////////////////////////////////
-        Hints hints = new Hints();
-        hints.put(Hints.OVERVIEW_POLICY, OverviewPolicy.QUALITY);
+        Hints hints = new Hints(Hints.OVERVIEW_POLICY, OverviewPolicy.QUALITY);
         WorldImageReader wiReader = new WorldImageReader(file, hints);
 
         // between 16 and 9, any value should report the match of 16
@@ -221,8 +220,7 @@ public class WorldImageReaderTest extends WorldImageBaseTestCase {
         // HINTS
         //
         ///////////////////////////////////////////////////////////////////////
-        Hints hints = new Hints();
-        hints.put(Hints.OVERVIEW_POLICY, OverviewPolicy.SPEED);
+        Hints hints = new Hints(Hints.OVERVIEW_POLICY, OverviewPolicy.SPEED);
         WorldImageReader wiReader = new WorldImageReader(file, hints);
         // between 16 and 9, any value should report the match of 16
         assertEquals(1, getChosenOverview(15, wiReader));

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/aig/AIGTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/aig/AIGTest.java
@@ -17,7 +17,6 @@
  */
 package org.geotools.coverageio.gdal.aig;
 
-import java.awt.RenderingHints;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -67,8 +66,7 @@ public final class AIGTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(3).setTileWidth(1);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final URL url = file.toURI().toURL();

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/dted/DTEDTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/dted/DTEDTest.java
@@ -18,7 +18,6 @@
 package org.geotools.coverageio.gdal.dted;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -63,8 +62,7 @@ public final class DTEDTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final File file = TestData.file(this, fileName);

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/ecw/ECWTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/ecw/ECWTest.java
@@ -20,7 +20,6 @@ package org.geotools.coverageio.gdal.ecw;
 import static org.junit.Assert.assertEquals;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.io.IOException;
@@ -72,8 +71,7 @@ public final class ECWTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         File file = null;

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/ehdr/EsriHdrTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/ehdr/EsriHdrTest.java
@@ -18,7 +18,6 @@
 package org.geotools.coverageio.gdal.ehdr;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.io.IOException;
@@ -75,8 +74,7 @@ public final class EsriHdrTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final URL url = file.toURI().toURL();

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/envihdr/EnviHdrTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/envihdr/EnviHdrTest.java
@@ -17,7 +17,6 @@
 package org.geotools.coverageio.gdal.envihdr;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.io.IOException;
@@ -72,8 +71,7 @@ public class EnviHdrTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final URL url = file.toURI().toURL();
@@ -162,8 +160,7 @@ public class EnviHdrTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final URL url = file.toURI().toURL();

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/erdasimg/ErdasImgTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/erdasimg/ErdasImgTest.java
@@ -18,7 +18,6 @@
 package org.geotools.coverageio.gdal.erdasimg;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Iterator;
@@ -88,8 +87,7 @@ public final class ErdasImgTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         File file = null;
         try {

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/idrisi/IDRISIImgTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/idrisi/IDRISIImgTest.java
@@ -18,7 +18,6 @@
 package org.geotools.coverageio.gdal.idrisi;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Iterator;
@@ -89,8 +88,7 @@ public final class IDRISIImgTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         File file = null;
         try {

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/nitf/NITFTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/nitf/NITFTest.java
@@ -18,7 +18,6 @@
 package org.geotools.coverageio.gdal.nitf;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
@@ -75,8 +74,7 @@ public final class NITFTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         final BaseGDALGridCoverage2DReader reader = new NITFReader(file, hints);
 

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/rpftoc/RPFTOCTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/rpftoc/RPFTOCTest.java
@@ -18,7 +18,6 @@
 package org.geotools.coverageio.gdal.rpftoc;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.io.File;
 import java.util.Iterator;
 import org.eclipse.imagen.ImageLayout;
@@ -64,8 +63,7 @@ public final class RPFTOCTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         final BaseGDALGridCoverage2DReader reader = new RPFTOCReader(file, hints);
 

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/srp/SRPTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/srp/SRPTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.image.DataBuffer;
 import java.io.File;
 import java.io.IOException;
@@ -100,8 +99,7 @@ public final class SRPTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(64).setTileWidth(64);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final BaseGDALGridCoverage2DReader reader = new SRPReader(source, hints);

--- a/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/vrt/VRTTest.java
+++ b/modules/plugin/imageio-ext-gdal/src/test/java/org/geotools/coverageio/gdal/vrt/VRTTest.java
@@ -28,7 +28,6 @@ import static org.junit.Assert.fail;
 import it.geosolutions.imageio.pam.PAMDataset;
 import it.geosolutions.imageio.pam.PAMParser;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.color.ColorSpace;
 import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
@@ -113,8 +112,7 @@ public final class VRTTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final File file = TestData.file(this, fileName);
@@ -191,8 +189,7 @@ public final class VRTTest extends GDALTestCase {
         final ImageLayout l = new ImageLayout();
         l.setTileGridXOffset(0).setTileGridYOffset(0).setTileHeight(512).setTileWidth(512);
 
-        Hints hints = new Hints();
-        hints.add(new RenderingHints(ImageN.KEY_IMAGE_LAYOUT, l));
+        Hints hints = new Hints(ImageN.KEY_IMAGE_LAYOUT, l);
 
         // get a reader
         final File file = TestData.file(this, "n43.dt0.nan.vrt");

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
@@ -2043,7 +2043,7 @@ public class Utils {
             // TileCache
             TileCache tc = Utils.getTileCacheHint(inputHints);
             if (tc != null) {
-                hints.add(new RenderingHints(ImageN.KEY_TILE_CACHE, tc));
+                hints.put(ImageN.KEY_TILE_CACHE, tc);
             }
 
             // TileScheduler

--- a/modules/plugin/jp2k/pom.xml
+++ b/modules/plugin/jp2k/pom.xml
@@ -90,5 +90,9 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/JP2KReader.java
+++ b/modules/plugin/jp2k/src/main/java/org/geotools/coverageio/jp2k/JP2KReader.java
@@ -49,7 +49,6 @@ import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.spi.ImageReaderSpi;
 import javax.imageio.stream.ImageInputStream;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
@@ -82,6 +81,7 @@ import org.geotools.referencing.operation.transform.AffineTransform2D;
 import org.geotools.referencing.operation.transform.ProjectiveTransform;
 import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
@@ -269,7 +269,7 @@ public final class JP2KReader extends AbstractGridCoverage2DReader implements Gr
             throws IOException, ParserConfigurationException, SAXException, XPathExpressionException, FactoryException,
                     TransformException {
 
-        DocumentBuilder b = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+        DocumentBuilder b = XMLUtils.newDocumentBuilder();
         String xml = xmlBox.getXml();
         Document doc = b.parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
 

--- a/modules/plugin/shapefile/pom.xml
+++ b/modules/plugin/shapefile/pom.xml
@@ -145,6 +145,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>compile</scope>

--- a/modules/plugin/shapefile/pom.xml
+++ b/modules/plugin/shapefile/pom.xml
@@ -147,7 +147,6 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-xml</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/xml/ShpXmlFileReader.java
+++ b/modules/plugin/shapefile/src/main/java/org/geotools/data/shapefile/shp/xml/ShpXmlFileReader.java
@@ -16,9 +16,6 @@
  */
 package org.geotools.data.shapefile.shp.xml;
 
-import static javax.xml.stream.XMLInputFactory.IS_COALESCING;
-import static javax.xml.stream.XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES;
-import static javax.xml.stream.XMLInputFactory.SUPPORT_DTD;
 import static javax.xml.stream.XMLStreamConstants.END_DOCUMENT;
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
@@ -31,6 +28,7 @@ import javax.xml.stream.XMLStreamReader;
 import org.geotools.data.shapefile.files.FileReader;
 import org.geotools.data.shapefile.files.ShpFileType;
 import org.geotools.data.shapefile.files.ShpFiles;
+import org.geotools.xml.XMLUtils;
 import org.locationtech.jts.geom.Envelope;
 
 public class ShpXmlFileReader implements FileReader {
@@ -47,12 +45,7 @@ public class ShpXmlFileReader implements FileReader {
     }
 
     private XMLStreamReader reader(InputStream in) throws XMLStreamException {
-        XMLInputFactory inputFactory = XMLInputFactory.newInstance();
-        // disable resolving of external DTD entities (coalescing needs to be false)
-        inputFactory.setProperty(IS_COALESCING, false);
-        inputFactory.setProperty(IS_REPLACING_ENTITY_REFERENCES, false);
-        // disallow DTDs entirely
-        inputFactory.setProperty(SUPPORT_DTD, false);
+        XMLInputFactory inputFactory = XMLUtils.newXMLInputFactory();
 
         return inputFactory.createXMLStreamReader(in, "UTF-8");
     }

--- a/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapeFileDbaseHeaderCharsetTest.java
+++ b/modules/plugin/shapefile/src/test/java/org/geotools/data/shapefile/ShapeFileDbaseHeaderCharsetTest.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.api.data.FeatureSource;
 import org.geotools.api.data.SimpleFeatureSource;
 import org.geotools.api.data.SimpleFeatureStore;
@@ -49,6 +48,7 @@ import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
 import org.geotools.test.TestData;
+import org.geotools.xml.XMLUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -258,8 +258,7 @@ public class ShapeFileDbaseHeaderCharsetTest extends TestCaseSupport {
             Fields fields = new Fields();
 
             // Document
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = XMLUtils.newDocumentBuilder();
             Document document = builder.parse(inputStream);
             Element root = document.getDocumentElement();
 

--- a/modules/plugin/svg/src/test/java/org/geotools/renderer/lite/DrawSVGTest.java
+++ b/modules/plugin/svg/src/test/java/org/geotools/renderer/lite/DrawSVGTest.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.batik.svggen.SVGGeneratorContext;
 import org.apache.batik.svggen.SVGGraphics2D;
@@ -45,6 +44,7 @@ import org.geotools.referencing.CRS;
 import org.geotools.renderer.RenderListener;
 import org.geotools.test.TestData;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -143,8 +143,7 @@ public class DrawSVGTest {
         mc.addLayer(new FeatureLayer(lineFS, lStyle));
         mc.addLayer(new FeatureLayer(pointFS, pStyle));
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
         // Create an instance of org.w3c.dom.Document
         Document document = db.getDOMImplementation().createDocument(null, "svg", null);
@@ -186,8 +185,7 @@ public class DrawSVGTest {
 
         mc.getViewport().setBounds(lineFS.getBounds());
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
         // Create an instance of org.w3c.dom.Document
         Document document = db.getDOMImplementation().createDocument(null, "svg", null);
@@ -230,8 +228,7 @@ public class DrawSVGTest {
         mc.addLayer(new FeatureLayer(lineFS, baseStyle));
         mc.addLayer(new FeatureLayer(lineFS, lStyle));
 
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = XMLUtils.newDocumentBuilder();
 
         // Create an instance of org.w3c.dom.Document
         Document document = db.getDOMImplementation().createDocument(null, "svg", null);

--- a/modules/unsupported/gml-geometry-streaming/src/main/java/org/geotools/gml/stream/XmlStreamGeometryReader.java
+++ b/modules/unsupported/gml-geometry-streaming/src/main/java/org/geotools/gml/stream/XmlStreamGeometryReader.java
@@ -130,7 +130,7 @@ public class XmlStreamGeometryReader {
      *     {@link #setUnsafeXMLAllowed setUnsafeXMLAllowed}.
      */
     private void checkUnsafeXML() throws IllegalStateException {
-        if (!this.unsafeXMLAllowed) {
+        if (!isUnsafeXMLAllowed()) {
             // Only check whether DTDs are enabled because when DTDs are not supported, XXE and XML
             // bombs are not possible. Even if DTDs are enabled but external entities are disabled,
             // XML entity expansion and thus XML bombs are still possible.

--- a/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderParameterizedTest.java
+++ b/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderParameterizedTest.java
@@ -36,6 +36,7 @@ import org.geotools.geometry.jts.CompoundCurve;
 import org.geotools.geometry.jts.MultiCurve;
 import org.geotools.geometry.jts.MultiSurface;
 import org.geotools.geometry.jts.WKTWriter2;
+import org.geotools.util.NullEntityResolver;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -219,6 +220,7 @@ public class XmlStreamGeometryReaderParameterizedTest {
             configuration = new org.geotools.gml3.GMLConfiguration();
         }
         org.geotools.xsd.Parser parser = new org.geotools.xsd.Parser(configuration);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         return (Geometry) parser.parse(new StringReader(gml));
     }
 }

--- a/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderParameterizedTest.java
+++ b/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderParameterizedTest.java
@@ -37,6 +37,7 @@ import org.geotools.geometry.jts.MultiCurve;
 import org.geotools.geometry.jts.MultiSurface;
 import org.geotools.geometry.jts.WKTWriter2;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -191,8 +192,7 @@ public class XmlStreamGeometryReaderParameterizedTest {
     }
 
     private void testWithGmlString(final String gml, final boolean isGml3_2) throws Exception {
-        XMLInputFactory f = XMLInputFactory.newInstance();
-        f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        XMLInputFactory f = XMLUtils.newXMLInputFactory();
         XMLStreamReader r = f.createXMLStreamReader(new StringReader(gml));
         XmlStreamGeometryReader geometryReader = new XmlStreamGeometryReader(r);
         r.nextTag();

--- a/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderTest.java
+++ b/modules/unsupported/gml-geometry-streaming/src/test/java/org/geotools/gml/stream/XmlStreamGeometryReaderTest.java
@@ -27,6 +27,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import org.geotools.api.referencing.FactoryException;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -36,7 +37,7 @@ import org.locationtech.jts.geom.Point;
 public class XmlStreamGeometryReaderTest {
     @Test
     public void testUnsafeXMLStreamReader() throws Exception {
-        XMLInputFactory f = XMLInputFactory.newInstance();
+        XMLInputFactory f = XMLInputFactory.newInstance(); // NOPMD AvoidXMLInputFactory
         // DTD support allows XXE and XML bombs
         f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.TRUE);
         XMLStreamReader r = f.createXMLStreamReader(new StringReader("<root></root>"));
@@ -48,8 +49,7 @@ public class XmlStreamGeometryReaderTest {
 
     @Test
     public void testUnknownElement() throws XMLStreamException {
-        XMLInputFactory f = XMLInputFactory.newInstance();
-        f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        XMLInputFactory f = XMLUtils.newXMLInputFactory();
         XMLStreamReader r = f.createXMLStreamReader(new StringReader("<unknown></unknown>"));
         XmlStreamGeometryReader geometryReader = new XmlStreamGeometryReader(r, new GeometryFactory());
         r.nextTag();
@@ -59,8 +59,7 @@ public class XmlStreamGeometryReaderTest {
 
     @Test
     public void testZ() throws XMLStreamException, FactoryException, IOException {
-        XMLInputFactory f = XMLInputFactory.newInstance();
-        f.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
+        XMLInputFactory f = XMLUtils.newXMLInputFactory();
         XMLStreamReader r = f.createXMLStreamReader(
                 new StringReader(
                         "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\" srsDimension=\"3\"><gml:pos>1 2 3</gml:pos></gml:Point>"));

--- a/modules/unsupported/postgis-raster/pom.xml
+++ b/modules/unsupported/postgis-raster/pom.xml
@@ -33,6 +33,10 @@
       <artifactId>gt-sample-data</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterConfig.java
+++ b/modules/unsupported/postgis-raster/src/main/java/org/geotools/gce/pgraster/PGRasterConfig.java
@@ -26,11 +26,11 @@ import java.util.logging.Logger;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.geotools.data.jdbc.datasource.DBCPDataSource;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -40,26 +40,26 @@ import org.w3c.dom.NodeList;
  *
  * <p>Configuration is stored as XML with the following basic format:
  *
- * <pre>
- *     &lt;pgraster>
- *       &lt;name//>        // coverage name
- *       &lt;database>     // database connection
- *         &lt;host//>      // database host
- *         &lt;port//>      // database port
- *         &lt;name//>      // database name
- *         &lt;user//>      // database username
- *         &lt;pass//>      // database user password
- *       &lt;/database>
- *       &lt;raster>       // raster column config
- *         &lt;column//>      // column name
- *         &lt;table//>     // table name
- *         &lt;schema//>    // table schema
- *       &lt;/raster>
- *       &lt;time>        // time column config
- *         &lt;enabled//>  // enable / disable time
- *         &lt;column//>     // column name
- *       &lt;/time>
- *     &lt;/pgraster>
+ * <pre>{@literal
+ *     <pgraster>
+ *       <name/>       // coverage name
+ *       <database>    // database connection
+ *         <host/>     // database host
+ *         <port/>     // database port
+ *         <name/>     // database name
+ *         <user/>     // database username
+ *         <pass/>     // database user password
+ *       </database>
+ *       <raster>      // raster column config
+ *         <column/>   // column name
+ *         <table/>    // table name
+ *         <schema/>   // table schema
+ *       </raster>
+ *       <time>        // time column config
+ *         <enabled/>  // enable / disable time
+ *         <column/>   // column name
+ *       </time>
+ *     </pgraster>}
  *   </pre>
  */
 class PGRasterConfig implements Closeable {
@@ -76,12 +76,11 @@ class PGRasterConfig implements Closeable {
     TimeConfig time = new TimeConfig();
 
     static Document parse(File cfgfile) {
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         DocumentBuilder db;
         try {
-            db = dbf.newDocumentBuilder();
+            db = XMLUtils.newDocumentBuilder();
         } catch (Exception e) {
-            throw new RuntimeException("Error creating XML parser");
+            throw new RuntimeException("Error creating XML parser", e);
         }
 
         try {

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/FilterToSolr.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/FilterToSolr.java
@@ -144,7 +144,7 @@ public class FilterToSolr implements FilterVisitor {
                 throw new Exception("Problem writing filter: ", ioe);
             }
         } else {
-            throw new Exception("Filter type not supported");
+            throw new Exception("Filter type not supported: " + filter.toString());
         }
     }
 

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/FilterToSolr.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/FilterToSolr.java
@@ -82,6 +82,7 @@ import org.geotools.api.filter.temporal.TEquals;
 import org.geotools.api.filter.temporal.TOverlaps;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.IllegalFilterException;
 
 /** Encodes a OGC filter into a SOLR query syntax */
 public class FilterToSolr implements FilterVisitor {
@@ -144,7 +145,7 @@ public class FilterToSolr implements FilterVisitor {
                 throw new Exception("Problem writing filter: ", ioe);
             }
         } else {
-            throw new Exception("Filter type not supported: " + filter.toString());
+            throw new IllegalFilterException("Filter type not natively supported: " + filter.toString());
         }
     }
 

--- a/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrDataStore.java
+++ b/modules/unsupported/solr/src/main/java/org/geotools/data/solr/SolrDataStore.java
@@ -55,6 +55,7 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.visitor.UniqueVisitor;
 import org.geotools.filter.FilterCapabilities;
+import org.geotools.filter.IllegalFilterException;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.util.factory.Hints;
 import org.locationtech.jts.geom.Geometry;
@@ -340,15 +341,19 @@ public class SolrDataStore extends ContentDataStore {
             FilterToSolr f2s = initializeFilterToSolr(featureType);
             String fq = layerMapper.prepareFilterQuery(featureType);
             Filter simplified = SimplifyingFilterVisitor.simplify(q.getFilter(), featureType);
-            String ffq = f2s.encodeToString(simplified);
-            if (ffq != null && !ffq.isEmpty()) {
-                fq = fq != null ? fq + " AND " + ffq : ffq;
+            try {
+                String ffq = f2s.encodeToString(simplified);
+                if (ffq != null && !ffq.isEmpty()) {
+                    fq = fq != null ? fq + " AND " + ffq : ffq;
+                }
+                query.setFilterQueries(fq);
+
+                // Add viewpPrams
+                addViewparams(q, query);
+            } catch (IllegalFilterException e) {
+                // Solr could not support this filter, so the result is going to be inefficient client side processing
+                LOGGER.log(Level.WARNING, e.getMessage());
             }
-            query.setFilterQueries(fq);
-
-            // Add viewpPrams
-            addViewparams(q, query);
-
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
@@ -407,7 +412,8 @@ public class SolrDataStore extends ContentDataStore {
 
             // Add viewparams parameters
             addViewparams(q, query);
-
+        } catch (IllegalFilterException e) {
+            LOGGER.log(Level.WARNING, e.getMessage());
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaIT.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaIT.java
@@ -45,7 +45,9 @@ import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
 import org.geotools.test.OnlineTestCase;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -125,12 +127,20 @@ public final class AppSchemaIT extends OnlineTestCase {
 
     @Override
     protected void setUpInternal() throws Exception {
+        super.setUpInternal();
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         TestContainersSupport.solrCoreUrl(CORE_NAME);
         fixture.setProperty(SOLR_URL_KEY, TestContainersSupport.solrServerUrl());
         client = new HttpJdkSolrClient.Builder(getSolrCoreURL()).build();
         solrDataSetup();
         prepareFiles();
         setupDataStore();
+    }
+
+    @Override
+    protected final void tearDownInternal() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+        super.tearDownInternal();
     }
 
     protected void setupDataStore() throws Exception {

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaIT.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaIT.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.FileUtils;
@@ -203,8 +202,7 @@ public final class AppSchemaIT extends OnlineTestCase {
             }
         }
         // write new xml file:
-        TransformerFactory transformerFactory = TransformerFactory.newInstance();
-        Transformer transformer = transformerFactory.newTransformer();
+        Transformer transformer = XMLUtils.newTransformer();
         DOMSource source = new DOMSource(doc);
         StreamResult result = new StreamResult(new File(testDir.getPath() + "/" + xmlFileName));
         transformer.transform(source, result);

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaIT.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaIT.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -48,6 +47,7 @@ import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
 import org.geotools.test.OnlineTestCase;
 import org.geotools.util.URLs;
+import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -193,9 +193,7 @@ public final class AppSchemaIT extends OnlineTestCase {
 
         // Modify datasource and copy xml
         File xmlFile = URLs.urlToFile(AppSchemaIT.class.getResource(testData + xmlFileName));
-        Document doc = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder()
-                .parse(new InputSource(new FileInputStream(xmlFile)));
+        Document doc = XMLUtils.newDocumentBuilder().parse(new InputSource(new FileInputStream(xmlFile)));
         Node solrDs = doc.getElementsByTagName("SolrDataStore").item(0);
         NodeList dsChilds = solrDs.getChildNodes();
         for (int i = 0; i < dsChilds.getLength(); i++) {

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaOnlineTestSupport.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaOnlineTestSupport.java
@@ -26,7 +26,6 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -43,6 +42,7 @@ import org.geotools.data.solr.SolrTypeData.SolrTypes;
 import org.geotools.data.solr.StationData.Stations;
 import org.geotools.test.OnlineTestCase;
 import org.geotools.util.URLs;
+import org.geotools.xml.XMLUtils;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Document;
@@ -169,9 +169,7 @@ public abstract class AppSchemaOnlineTestSupport extends OnlineTestCase {
 
     protected void copyAndPatchTestData(String baseFileName) throws Exception {
         File file = URLs.urlToFile(this.getClass().getResource(testData + baseFileName));
-        Document doc = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder()
-                .parse(new InputSource(new FileInputStream(file)));
+        Document doc = XMLUtils.newDocumentBuilder().parse(new InputSource(new FileInputStream(file)));
         NodeList solrStores = doc.getElementsByTagName("SolrDataStore");
         for (int i = 0; i < solrStores.getLength(); i++) {
             NodeList children = solrStores.item(i).getChildNodes();

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaOnlineTestSupport.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaOnlineTestSupport.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import org.apache.commons.io.FileUtils;
@@ -216,7 +215,7 @@ public abstract class AppSchemaOnlineTestSupport extends OnlineTestCase {
                     break;
             }
         }
-        Transformer transformer = TransformerFactory.newInstance().newTransformer();
+        Transformer transformer = XMLUtils.newTransformer();
         transformer.transform(new DOMSource(doc), new StreamResult(new File(tempDir, baseFileName)));
     }
 

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaOnlineTestSupport.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/AppSchemaOnlineTestSupport.java
@@ -40,7 +40,9 @@ import org.geotools.data.complex.feature.type.Types;
 import org.geotools.data.solr.SolrTypeData.SolrTypes;
 import org.geotools.data.solr.StationData.Stations;
 import org.geotools.test.OnlineTestCase;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -93,6 +95,8 @@ public abstract class AppSchemaOnlineTestSupport extends OnlineTestCase {
 
     @Override
     protected void setUpInternal() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+
         configFieldsSetup();
         TestContainersSupport.solrCoreUrl(CORE_NAME);
         fixture.setProperty(SOLR_URL_KEY, TestContainersSupport.solrServerUrl());

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/SolrTestSupport.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/SolrTestSupport.java
@@ -37,6 +37,10 @@ import org.geotools.temporal.object.DefaultInstant;
 import org.geotools.temporal.object.DefaultPeriod;
 import org.geotools.temporal.object.DefaultPosition;
 import org.geotools.test.OnlineTestCase;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
+import org.junit.After;
+import org.junit.Before;
 import org.locationtech.jts.geom.Geometry;
 
 public abstract class SolrTestSupport extends OnlineTestCase {
@@ -68,6 +72,16 @@ public abstract class SolrTestSupport extends OnlineTestCase {
 
     // tests setup will take care of instantiating the client and closing it
     private HttpJdkSolrClient solrClient;
+
+    @Before
+    public void setup() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void teardown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+    }
 
     @Override
     protected void setUpInternal() throws Exception {

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/TestsSolrUtils.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/TestsSolrUtils.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrRequest;
 import org.apache.solr.client.solrj.impl.HttpJdkSolrClient;
@@ -35,6 +34,7 @@ import org.apache.solr.client.solrj.request.schema.FieldTypeDefinition;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.SolrResponseBase;
 import org.apache.solr.common.SolrInputDocument;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -273,8 +273,7 @@ public final class TestsSolrUtils {
      */
     private static Document parseXmlDocument(InputStream xml) {
         try {
-            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder builder = factory.newDocumentBuilder();
+            DocumentBuilder builder = XMLUtils.newDocumentBuilder();
             // parse the XML document
             return builder.parse(xml);
         } catch (Exception exception) {

--- a/modules/unsupported/solr/src/test/java/org/geotools/data/solr/complex/ComplexFeaturesIT.java
+++ b/modules/unsupported/solr/src/test/java/org/geotools/data/solr/complex/ComplexFeaturesIT.java
@@ -49,6 +49,8 @@ import org.geotools.data.solr.TestsSolrUtils;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.NameImpl;
 import org.geotools.test.OnlineTestCase;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.geotools.xml.resolver.SchemaCache;
 import org.junit.AfterClass;
@@ -85,6 +87,7 @@ public final class ComplexFeaturesIT extends OnlineTestCase {
 
     @Override
     public void setUpInternal() throws IOException {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         fixture.setProperty("solr_url", TestContainersSupport.solrCoreUrl("complex_stations"));
         // instantiate the Apache Solr client
         try (HttpJdkSolrClient client = new HttpJdkSolrClient.Builder(getSolrCoreURL()).build()) {
@@ -108,6 +111,7 @@ public final class ComplexFeaturesIT extends OnlineTestCase {
                     "Error removing tests root directory '%s'.".formatted(TESTS_ROOT_DIR.getAbsolutePath()),
                     exception);
         }
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     /** Tests retrieving all complex feature from App-Schema store that uses Apache Solr as a data store. */

--- a/modules/unsupported/tpk/pom.xml
+++ b/modules/unsupported/tpk/pom.xml
@@ -38,6 +38,10 @@
       <artifactId>gt-epsg-hsql</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-xml</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/modules/unsupported/tpk/src/main/java/org/geotools/tpk/TPKFile.java
+++ b/modules/unsupported/tpk/src/main/java/org/geotools/tpk/TPKFile.java
@@ -32,9 +32,9 @@ import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import org.geotools.api.geometry.Bounds;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.xml.XMLUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -401,8 +401,7 @@ public class TPKFile {
         zoomLevelResolutionMap = new HashMap<>();
 
         try (InputStream is = theTPK.getInputStream(confFile)) {
-            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            DocumentBuilder dBuilder = XMLUtils.newDocumentBuilder();
             Document confDoc = dBuilder.parse(is);
 
             // find the "StorageFormat" element to determine compact cache version/format

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
@@ -39,9 +39,11 @@ import org.geotools.data.wfs.internal.WFSConfig;
 import org.geotools.http.HTTPClient;
 import org.geotools.http.HTTPClientFinder;
 import org.geotools.ows.ServiceException;
+import org.geotools.util.DefaultEntityResolver;
 import org.geotools.util.KVP;
 import org.geotools.util.PreventLocalEntityResolver;
 import org.geotools.util.SimpleInternationalString;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLHandlerHints;
 import org.xml.sax.EntityResolver;
@@ -423,14 +425,20 @@ public class WFSDataAccessFactory implements DataAccessFactory {
         String name = "WFSDataStoreFactory:ENTITY_RESOLVER";
         String title = "EntityResolver";
         String description = "Sets the entity resolver used to expand XML entities";
-        parametersInfo[19] = ENTITY_RESOLVER = new WFSFactoryParam<>(
-                name,
-                EntityResolver.class,
-                title,
-                description,
-                PreventLocalEntityResolver.INSTANCE,
-                Parameter.LEVEL,
-                "program");
+        parametersInfo[19] = ENTITY_RESOLVER =
+                new WFSFactoryParam<>(
+                        name,
+                        EntityResolver.class,
+                        title,
+                        description,
+                        DefaultEntityResolver.INSTANCE,
+                        Parameter.LEVEL,
+                        "program") {
+                    @Override
+                    public Object getDefaultValue() {
+                        return GeoTools.getEntityResolver(null);
+                    }
+                };
     }
 
     /** Optional {@code Boolean} use connection pooling for http(s) requests */

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
@@ -34,6 +34,7 @@ import org.geotools.data.wfs.internal.parsers.EmfAppSchemaParser;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.util.URLs;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.xsd.Configuration;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
@@ -91,7 +92,10 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
     }
 
     private EntityResolver getTempFileEntityResolver(EntityResolver resolver, File tempSchema) {
-        if (resolver == null) return null;
+        if (resolver == null) {
+            resolver = GeoTools.getEntityResolver(null);
+        }
+
         if (resolver instanceof EntityResolver2 resolver2) {
             return new TempEntityResolver2(resolver2, tempSchema);
         }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
@@ -92,10 +92,13 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
 
     private EntityResolver getTempFileEntityResolver(EntityResolver resolver, File tempSchema) {
         if (resolver == null) return null;
-        if (resolver instanceof EntityResolver2 resolver2) return new TempEntityResolver2(resolver2, tempSchema);
+        if (resolver instanceof EntityResolver2 resolver2) {
+            return new TempEntityResolver2(resolver2, tempSchema);
+        }
         return new TempEntityResolver(resolver, tempSchema);
     }
 
+    /** Wraps provided EntityResolver to handle tempSchemaURIs internally. */
     private static class TempEntityResolver implements EntityResolver {
         private final EntityResolver delegate;
         private Set<String> tempSchemaURIs;
@@ -152,8 +155,14 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
         protected boolean isTempSchema(String systemId) {
             return tempSchemaURIs.contains(systemId);
         }
+
+        @Override
+        public String toString() {
+            return "TempEntityResolver{" + this.delegate + "}";
+        }
     }
 
+    /** Wraps provided EntityResolver2 to handle tempSchemaURIs internally. */
     private static class TempEntityResolver2 extends TempEntityResolver implements EntityResolver2 {
         EntityResolver2 delegate;
 
@@ -171,8 +180,15 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
         @Override
         public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId)
                 throws SAXException, IOException {
-            if (isTempSchema(systemId)) return null;
+            if (isTempSchema(systemId)) {
+                return null; // handled internally
+            }
             return delegate.resolveEntity(name, publicId, baseURI, systemId);
+        }
+
+        @Override
+        public String toString() {
+            return "TempEntityResolver2{" + this.delegate + "}";
         }
     }
 }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeStoredQueriesResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeStoredQueriesResponse.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.IOUtils;
 import org.geotools.api.data.DataSourceException;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.DOMParser;
 import org.w3c.dom.Document;
@@ -63,10 +64,10 @@ public class DescribeStoredQueriesResponse extends WFSResponse {
                 RESPONSES.fine("Full ListStoredQueries response: " + new String(rawResponse, StandardCharsets.UTF_8));
             }
             try {
-                DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory builderFactory = XMLUtils.newDocumentBuilderFactory();
                 builderFactory.setNamespaceAware(true);
                 builderFactory.setValidating(false);
-                DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
+                DocumentBuilder documentBuilder = XMLUtils.newDocumentBuilder(builderFactory);
                 rawDocument = documentBuilder.parse(new ByteArrayInputStream(rawResponse));
             } catch (Exception e) {
                 throw new IOException("Error parsing capabilities document: " + e.getMessage(), e);

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetCapabilitiesResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/GetCapabilitiesResponse.java
@@ -35,6 +35,7 @@ import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.util.Version;
 import org.geotools.util.logging.Logging;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.DOMParser;
 import org.w3c.dom.Document;
@@ -53,10 +54,10 @@ public class GetCapabilitiesResponse extends org.geotools.data.ows.GetCapabiliti
         try {
             final Document rawDocument;
             try {
-                DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory builderFactory = XMLUtils.newDocumentBuilderFactory();
                 builderFactory.setNamespaceAware(true);
                 builderFactory.setValidating(false);
-                DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
+                DocumentBuilder documentBuilder = XMLUtils.newDocumentBuilder(builderFactory);
                 if (entityResolver != null) {
                     documentBuilder.setEntityResolver(entityResolver);
                 }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/ListStoredQueriesResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/ListStoredQueriesResponse.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.IOUtils;
 import org.geotools.api.data.DataSourceException;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.DOMParser;
 import org.w3c.dom.Document;
@@ -60,10 +61,10 @@ public class ListStoredQueriesResponse extends WFSResponse {
                 RESPONSES.fine("Full ListStoredQueries response: " + new String(rawResponse, StandardCharsets.UTF_8));
             }
             try {
-                DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory builderFactory = XMLUtils.newDocumentBuilderFactory();
                 builderFactory.setNamespaceAware(true);
                 builderFactory.setValidating(false);
-                DocumentBuilder documentBuilder = builderFactory.newDocumentBuilder();
+                DocumentBuilder documentBuilder = XMLUtils.newDocumentBuilder(builderFactory);
                 rawDocument = documentBuilder.parse(new ByteArrayInputStream(rawResponse));
             } catch (Exception e) {
                 throw new IOException("Error parsing capabilities document: " + e.getMessage(), e);

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/PullParserFeatureReader.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/PullParserFeatureReader.java
@@ -123,7 +123,6 @@ public class PullParserFeatureReader implements GetParser<SimpleFeature> {
         try {
             parsed = parser.parse();
         } catch (XMLStreamException | SAXException e) {
-            e.printStackTrace();
             throw new IOException(
                     "Error parsing xml for features of type: "
                             + (featureType == null ? "Unknown" : featureType.getName()),

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/PullParserFeatureReader.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/PullParserFeatureReader.java
@@ -123,6 +123,7 @@ public class PullParserFeatureReader implements GetParser<SimpleFeature> {
         try {
             parsed = parser.parse();
         } catch (XMLStreamException | SAXException e) {
+            e.printStackTrace();
             throw new IOException(
                     "Error parsing xml for features of type: "
                             + (featureType == null ? "Unknown" : featureType.getName()),

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlFeatureParser.java
@@ -40,6 +40,7 @@ import org.geotools.gml.stream.XmlStreamGeometryReader;
 import org.geotools.gml3.GML;
 import org.geotools.util.Converters;
 import org.geotools.wfs.WFS;
+import org.geotools.xml.XMLUtils;
 import org.locationtech.jts.geom.GeometryFactory;
 
 /**
@@ -77,7 +78,7 @@ public abstract class XmlFeatureParser<FT extends FeatureType, F extends Feature
         this.targetType = targetType;
 
         try {
-            XMLInputFactory factory = XMLInputFactory.newFactory();
+            XMLInputFactory factory = XMLUtils.newXMLInputFactory();
             // disable DTDs
             factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             // disable external entities

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlSimpleFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlSimpleFeatureParser.java
@@ -26,6 +26,7 @@ import java.util.TreeMap;
 import java.util.logging.Logger;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLResolver;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import org.geotools.api.data.DataSourceException;
@@ -43,8 +44,13 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.gml.stream.XmlStreamGeometryReader;
 import org.geotools.gml3.GML;
 import org.geotools.util.Converters;
+import org.geotools.util.factory.GeoTools;
 import org.geotools.wfs.WFS;
+import org.geotools.xml.XMLUtils;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
 
 /**
  * A {@link GetParser<SimpleFeature>} implementation that uses plain xml pull to parse a GetFeature response.
@@ -92,7 +98,25 @@ public class XmlSimpleFeatureParser implements GetParser<SimpleFeature> {
         this.builder = new SimpleFeatureBuilder(targetType);
 
         try {
-            XMLInputFactory factory = XMLInputFactory.newFactory();
+            XMLInputFactory factory = XMLUtils.newXMLInputFactory();
+            final EntityResolver entityResolver = GeoTools.getEntityResolver(null);
+            factory.setXMLResolver(new XMLResolver() {
+                @Override
+                public Object resolveEntity(String publicID, String systemID, String baseURI, String namespace)
+                        throws XMLStreamException {
+                    try {
+                        if (entityResolver instanceof EntityResolver2 entityResolver2) {
+                            entityResolver2.resolveEntity(publicID, systemID, baseURI, namespace);
+                        } else {
+                            entityResolver.resolveEntity(publicID, systemID);
+                        }
+                    } catch (IOException | SAXException e) {
+                        throw new XMLStreamException(e);
+                    }
+                    return null;
+                }
+            });
+
             // disable DTDs
             factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
             // disable external entities

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/MapServerWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/MapServerWFSStrategy.java
@@ -38,6 +38,7 @@ import net.opengis.wfs.FeatureTypeType;
 import org.apache.commons.io.IOUtils;
 import org.geotools.data.wfs.internal.WFSOperationType;
 import org.geotools.data.wfs.internal.WFSRequest;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xs.bindings.XSDoubleBinding;
 import org.geotools.xs.bindings.XSIntegerBinding;
 import org.geotools.xs.bindings.XSStringBinding;
@@ -107,9 +108,9 @@ public class MapServerWFSStrategy extends StrictWFS_1_x_Strategy {
                             && pc.contains("gml:X")
                             && pc.contains("gml:Y")) {
 
-                        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                        DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
                         factory.setNamespaceAware(true);
-                        DocumentBuilder builder = factory.newDocumentBuilder();
+                        DocumentBuilder builder = XMLUtils.newDocumentBuilder(factory);
                         Document doc = builder.parse(new ByteArrayInputStream(pc.getBytes(StandardCharsets.UTF_8)));
 
                         NodeList boxes = doc.getElementsByTagName("gml:Box");

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/MapServerWFSStrategy.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/v1_x/MapServerWFSStrategy.java
@@ -31,7 +31,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import net.opengis.wfs.FeatureTypeType;
@@ -155,8 +154,7 @@ public class MapServerWFSStrategy extends StrictWFS_1_x_Strategy {
                             DOMSource domSource = new DOMSource(doc);
                             StringWriter domsw = new StringWriter();
                             StreamResult result = new StreamResult(domsw);
-                            TransformerFactory tf = TransformerFactory.newInstance();
-                            Transformer transformer = tf.newTransformer();
+                            Transformer transformer = XMLUtils.newTransformer();
                             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
                             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
                             transformer.transform(domSource, result);

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/impl/WFSContentComplexFeatureSourceTest.java
@@ -36,7 +36,11 @@ import org.geotools.filter.text.cql2.CQL;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.http.MockHttpResponse;
 import org.geotools.referencing.CRS;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Point;
 import org.xml.sax.helpers.NamespaceSupport;
@@ -69,6 +73,16 @@ public class WFSContentComplexFeatureSourceTest {
     private static final String DEFAULT_SRS = "urn:ogc:def:crs:EPSG::4258";
 
     private static final Filter FILTER = ff.bbox(GEOM_FIELD_NAME, 58.71, 58.73, 7.39, 7.41, "EPSG:4258");
+
+    @Before
+    public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+    }
 
     @Test
     public void testGetFeaturesWithoutArgument() throws Exception {

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/AbstractIntegrationTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/AbstractIntegrationTest.java
@@ -62,6 +62,8 @@ import org.geotools.data.wfs.internal.ExceptionDetails;
 import org.geotools.data.wfs.internal.WFSException;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.junit.After;
 import org.junit.Before;
@@ -163,6 +165,7 @@ public abstract class AbstractIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
         first = createFirstType();
         second = createSecondType();
 
@@ -181,6 +184,7 @@ public abstract class AbstractIntegrationTest {
     public void tearDown() throws Exception {
         tearDownDataStore(data);
         data = null;
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
     }
 
     @Test

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/GeoServerIntegrationTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/GeoServerIntegrationTest.java
@@ -50,6 +50,7 @@ import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.identity.FeatureIdImpl;
 import org.geotools.referencing.CRS;
 import org.geotools.util.factory.Hints;
+import org.geotools.xml.XMLUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -190,10 +191,9 @@ public class GeoServerIntegrationTest extends AbstractIntegrationTest {
 
             try (ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray())) {
 
-                DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
                 factory.setNamespaceAware(true);
-
-                Document document = factory.newDocumentBuilder().parse(in);
+                Document document = XMLUtils.newDocumentBuilder(factory).parse(in);
 
                 Element root = document.getDocumentElement();
                 NodeList insertNodes = root.getElementsByTagNameNS("http://www.opengis.net/wfs", "Insert");

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureParserTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureParserTest.java
@@ -56,6 +56,10 @@ import org.geotools.data.wfs.WFSDataStoreFactory;
 import org.geotools.data.wfs.WFSTestData;
 import org.geotools.data.wfs.internal.GetParser;
 import org.geotools.referencing.CRS;
+import org.geotools.util.DefaultEntityResolver;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.wfs.v1_1.WFSConfiguration;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.XSD;
@@ -347,24 +351,31 @@ public abstract class AbstractGetFeatureParserTest {
 
     @Test
     public void testParseGeoServer_ArchSites_XXE() throws Exception {
-        final QName featureName = GEOS_ARCHSITES_11.TYPENAME;
-        final URL schemaLocation = GEOS_ARCHSITES_11.SCHEMA;
-        final URL data = WFSTestData.url("GeoServer_2.0/1.1.0_XXE_GetFeature/GetFeature_archsites.xml");
-
-        final String[] properties = {"cat", "str1", "the_geom"};
-        final SimpleFeatureType featureType =
-                getTypeView(featureName, schemaLocation, GEOS_ARCHSITES_11.CRS, properties);
-
-        GetParser<SimpleFeature> parser = getParser(featureName, schemaLocation, featureType, data, null);
         try {
-            IOException exception = assertThrows(IOException.class, () -> parser.parse());
-            assertThat(exception.getCause(), instanceOf(XMLStreamException.class));
-            exception.printStackTrace();
-            assertThat(
-                    exception.getCause().getMessage(),
-                    containsString("The entity \"xxe\" was referenced, but not declared"));
-        } finally {
-            parser.close();
+            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+
+            final QName featureName = GEOS_ARCHSITES_11.TYPENAME;
+            final URL schemaLocation = GEOS_ARCHSITES_11.SCHEMA;
+            final URL data = WFSTestData.url("GeoServer_2.0/1.1.0_XXE_GetFeature/GetFeature_archsites.xml");
+
+            final String[] properties = {"cat", "str1", "the_geom"};
+            final SimpleFeatureType featureType =
+                    getTypeView(featureName, schemaLocation, GEOS_ARCHSITES_11.CRS, properties);
+
+            GetParser<SimpleFeature> parser = getParser(featureName, schemaLocation, featureType, data, null);
+            try {
+                IOException exception = assertThrows(IOException.class, () -> parser.parse());
+                assertThat(exception.getCause(), instanceOf(XMLStreamException.class));
+                exception.printStackTrace();
+                assertThat(
+                        exception.getCause().getMessage(),
+                        containsString("The entity \"xxe\" was referenced, but not declared"));
+            } finally {
+                parser.close();
+            }
+        }
+        finally {
+
         }
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureParserTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureParserTest.java
@@ -359,6 +359,7 @@ public abstract class AbstractGetFeatureParserTest {
         try {
             IOException exception = assertThrows(IOException.class, () -> parser.parse());
             assertThat(exception.getCause(), instanceOf(XMLStreamException.class));
+            exception.printStackTrace();
             assertThat(
                     exception.getCause().getMessage(),
                     containsString("The entity \"xxe\" was referenced, but not declared"));

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureParserTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/AbstractGetFeatureParserTest.java
@@ -58,7 +58,6 @@ import org.geotools.data.wfs.internal.GetParser;
 import org.geotools.referencing.CRS;
 import org.geotools.util.DefaultEntityResolver;
 import org.geotools.util.NullEntityResolver;
-import org.geotools.util.PreventLocalEntityResolver;
 import org.geotools.util.factory.Hints;
 import org.geotools.wfs.v1_1.WFSConfiguration;
 import org.geotools.xsd.Configuration;
@@ -71,6 +70,7 @@ import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
+import org.xml.sax.EntityResolver;
 
 /**
  * This abstract class comprises a sort of compliance tests for {@link GetParser<SimpleFeature>} implementations.
@@ -351,8 +351,9 @@ public abstract class AbstractGetFeatureParserTest {
 
     @Test
     public void testParseGeoServer_ArchSites_XXE() throws Exception {
+        EntityResolver prior = null;
         try {
-            Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+            prior = (EntityResolver) Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
 
             final QName featureName = GEOS_ARCHSITES_11.TYPENAME;
             final URL schemaLocation = GEOS_ARCHSITES_11.SCHEMA;
@@ -366,16 +367,40 @@ public abstract class AbstractGetFeatureParserTest {
             try {
                 IOException exception = assertThrows(IOException.class, () -> parser.parse());
                 assertThat(exception.getCause(), instanceOf(XMLStreamException.class));
-                exception.printStackTrace();
                 assertThat(
                         exception.getCause().getMessage(),
                         containsString("The entity \"xxe\" was referenced, but not declared"));
             } finally {
                 parser.close();
             }
+        } finally {
+            if (prior != null) Hints.putSystemDefault(Hints.ENTITY_RESOLVER, prior);
         }
-        finally {
+    }
 
+    @Test
+    public void testParseGeoServer_ArchSites_XXE_Forgiving() throws Exception {
+        EntityResolver prior = null;
+        try {
+            prior = (EntityResolver) Hints.putSystemDefault(Hints.ENTITY_RESOLVER, DefaultEntityResolver.INSTANCE);
+
+            final QName featureName = GEOS_ARCHSITES_11.TYPENAME;
+            final URL schemaLocation = GEOS_ARCHSITES_11.SCHEMA;
+            final URL data = WFSTestData.url("GeoServer_2.0/1.1.0_XXE_GetFeature/GetFeature_archsites.xml");
+
+            final String[] properties = {"cat", "str1", "the_geom"};
+            final SimpleFeatureType featureType =
+                    getTypeView(featureName, schemaLocation, GEOS_ARCHSITES_11.CRS, properties);
+
+            GetParser<SimpleFeature> parser = getParser(featureName, schemaLocation, featureType, data, null);
+            try {
+                SimpleFeature feature = parser.parse();
+                assertNotNull(feature);
+            } finally {
+                parser.close();
+            }
+        } finally {
+            if (prior != null) Hints.putSystemDefault(Hints.ENTITY_RESOLVER, prior);
         }
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/PullParserTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/internal/parsers/PullParserTest.java
@@ -33,12 +33,15 @@ import org.geotools.http.HTTPResponse;
 import org.geotools.http.MockHttpClient;
 import org.geotools.http.MockHttpResponse;
 import org.geotools.referencing.CRS;
+import org.geotools.util.NullEntityResolver;
+import org.geotools.util.factory.Hints;
 import org.geotools.wfs.v2_0.WFSConfiguration;
 import org.geotools.xsd.Configuration;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.locationtech.jts.geom.Point;
+import org.xml.sax.EntityResolver;
 
 public class PullParserTest extends AbstractGetFeatureParserTest {
 
@@ -77,23 +80,33 @@ public class PullParserTest extends AbstractGetFeatureParserTest {
     /** We inject an HTTPClient that are used for fetching the schema specified in wfs_get_feature.xml */
     @Test
     public void testUsingHttpClientForSchema() throws Exception {
-        Configuration wfsConfiguration = new WFSConfiguration();
-        try (InputStream inputStream = TestData.openStream(this, "wfs_get_feature.xml")) {
-            FeatureType featureType = createMjosovervakFeatureType();
-            String axisOrder = null;
-            HTTPClient httpClient = createMjosovervakHttpClient();
-            GetParser<SimpleFeature> parser =
-                    new PullParserFeatureReader(wfsConfiguration, inputStream, featureType, axisOrder, httpClient);
-            SimpleFeature first = parser.parse();
-            Assert.assertNotNull(first);
-            Assert.assertEquals("Svanfoss", first.getAttribute("STATION_NAME"));
+        EntityResolver prior = null;
+        try {
+            prior = (EntityResolver) Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+            Configuration wfsConfiguration = new WFSConfiguration();
+            try (InputStream inputStream = TestData.openStream(this, "wfs_get_feature.xml")) {
+                FeatureType featureType = createMjosovervakFeatureType();
+                String axisOrder = null;
+                HTTPClient httpClient = createMjosovervakHttpClient();
+                GetParser<SimpleFeature> parser =
+                        new PullParserFeatureReader(wfsConfiguration, inputStream, featureType, axisOrder, httpClient);
+                SimpleFeature first = parser.parse();
+                Assert.assertNotNull(first);
+                Assert.assertEquals("Svanfoss", first.getAttribute("STATION_NAME"));
 
-            SimpleFeature second = parser.parse();
-            Assert.assertNotNull(second);
-            Assert.assertEquals("M071", second.getAttribute("STATION_CODE"));
+                SimpleFeature second = parser.parse();
+                Assert.assertNotNull(second);
+                Assert.assertEquals("M071", second.getAttribute("STATION_CODE"));
 
-            SimpleFeature third = parser.parse();
-            Assert.assertNull(third);
+                SimpleFeature third = parser.parse();
+                Assert.assertNull(third);
+            }
+        } finally {
+            if (prior != null) {
+                Hints.putSystemDefault(Hints.ENTITY_RESOLVER, prior);
+            } else {
+                Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+            }
         }
     }
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/Capabilities200ServiceInfoOnlineTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/online/v2_0/Capabilities200ServiceInfoOnlineTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import java.net.URL;
 import net.opengis.wfs20.WFSCapabilitiesType;
 import org.geotools.data.wfs.internal.v2_0.Capabilities200ServiceInfo;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.wfs.v2_0.WFSConfiguration;
 import org.geotools.xsd.Parser;
 import org.junit.Before;
@@ -40,6 +41,7 @@ public class Capabilities200ServiceInfoOnlineTest {
             URL getCapsUrl = new URL(SERVER_URL);
             WFSConfiguration configuration = new org.geotools.wfs.v2_0.WFSConfiguration();
             Parser parser = new Parser(configuration);
+            parser.setEntityResolver(NullEntityResolver.INSTANCE);
             WFSCapabilitiesType type = (WFSCapabilitiesType) parser.parse(getCapsUrl.openStream());
             featureType =
                     new Capabilities200ServiceInfo("http://schemas.opengis.net/wfs/2.0/wfs.xsd", getCapsUrl, type);

--- a/modules/unsupported/wps/src/main/java/org/geotools/data/wps/response/ExecuteProcessResponse.java
+++ b/modules/unsupported/wps/src/main/java/org/geotools/data/wps/response/ExecuteProcessResponse.java
@@ -31,6 +31,7 @@ import org.geotools.data.ows.Response;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.wps.WPSConfiguration;
+import org.geotools.xml.XMLUtils;
 import org.geotools.xsd.Configuration;
 import org.geotools.xsd.Parser;
 import org.xml.sax.SAXException;
@@ -70,7 +71,7 @@ public class ExecuteProcessResponse extends Response {
                     inputStream.mark(8192);
 
                     try {
-                        XMLInputFactory factory = XMLInputFactory.newFactory();
+                        XMLInputFactory factory = XMLUtils.newXMLInputFactory();
                         // disable DTDs
                         factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
                         // disable external entities


### PR DESCRIPTION
[![GEOT-7898](https://badgen.net/badge/JIRA/GEOT-7898/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7898) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

To be merged at the same time:

* https://github.com/GeoWebCache/geowebcache/pull/1534
* https://github.com/geoserver/geoserver/pull/9502


This is a QA activity to double check that `GeoTools.getEntityResolver(hints)` is used.

To aid in this goal:
* PMD rules put in place to check for direct construction of xml objects that require entity resolver be supplied
* XMLUtils has been updated cover direct use of xml objects, ensuring entity resolver is supplied via `GeoTools.getEntityResolver(hints)`
* Tests that require local file access have been updated to use `NullEntityResolver.INSTANCE` (which is great confirmation the approach is working)

A request has come in for the following:

* https://github.com/geotools/geotools/pull/5662

## XMLUtils API change enforced by PMD Rules

Direct use of DocumentBuilderFactory.newDocumentBuilder() replaced with:

```java
 DocumentBuilder builder = XMLUtils.newDocumentBuilder();
 Document document = builder.parse(source)
```

Or if factory configuration is required direct use of DocumentBuilderFactory.newInstance() replaced with:

```java
 DocumentBuilderFactory factory = XMLUtils.newDocumentBuilderFactory();
 factory.setValidating(true);
 factory.setNamespaceAware(true);
 DocumentBuilder builder = XMLUtils.newDocumentBuilder(factory);
 Document document = builder.parse(source)
```

Test cases that need access to local file system can configure via ENTITY_RESOLVER Hint:
```java
 Hints hints = GeoTools.getDefaultHints();
 hints.put(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);

 DocumentBuilder builder = XMLUtils.newDocumentBuilder(hints);
 Document document = builder.parse(source);
```

While this is a QA activity ahead of release, I would like to backport *just* new `XMLUtil` methods so they are available for use.

## GeoTools Hints

I found some problems with GeoTools initialization and Hints notifications during this work, assigned separate ticket:

* https://osgeo-org.atlassian.net/projects/GEOT-7906

## ⚠️ Integration workflow change

This PR changes `integration.yml` and `integration-qa.yml`to look for a branch of the same name when running integration tests:
```
env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
```

It is my hope that this reduces the need for manual testing of downstream PRs making API changes. The integration branch just needs to be defined, it does not already need to be a pull-request:

```
echo "Checking out GeoServer"
mkdir geoserver
git clone --depth 1 -q https://github.com/geoserver/geoserver.git geoserver
cd geoserver
GS_BRANCH_EXISTS=$(git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; echo $?)
if [ "$GS_BRANCH_EXISTS" -eq 0 ]; then
  echo "Branch found on geoserver. Switching and tracking: $BRANCH_NAME"
  git switch "$BRANCH_NAME"
fi
```

As a result This PR is tested against downstream branches:

* https://github.com/geoserver/geoserver/tree/default-entity-resolver-check
* https://github.com/GeoWebCache/geowebcache/tree/default-entity-resolver-check

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 