### PR TITLE
[GEOT-7902] DuckDB read_only parameter is not propagated to the JDBC driver

### DIFF
--- a/modules/unsupported/duckdb/README.md
+++ b/modules/unsupported/duckdb/README.md
@@ -21,6 +21,7 @@ The public DuckDB store is exposed through a restricted GeoTools-side wrapper.
 - GeoTools JDBC virtual tables are disabled for the public store
 - Native filters are disabled (`DuckDBFilterToSQL` rejects `NativeFilter`)
 - Initialization SQL is managed internally by GeoTools
+- `read_only=true` is enforced both at the GeoTools API layer and at the DuckDB engine level, so file-backed databases are opened with DuckDB's read-only connection property
 
 This module is intended to reduce the exposed SQL surface while still allowing DuckDB-backed access through standard GeoTools APIs.
 
@@ -76,6 +77,7 @@ SimpleFeatureCollection features = source.getFeatures(filter);
 | **dbtype** | String | Yes | Must be `"duckdb"` |
 | **memory** | Boolean | No | Use an in-memory DuckDB database (default: `false`) |
 | **database** | String | No | Path to a DuckDB database file; required unless `memory=true` |
+| **read_only** | Boolean | No | Open the DuckDB database in read-only mode at both the GeoTools API layer and the engine level (default: `true`) |
 | **namespace** | String | No | Namespace URI to use for features |
 | **fetch size** | Integer | No | JDBC fetch size used for result streaming |
 | **screenmap** | Boolean | No | Enable screenmap support for rendering optimization (default: `true`) |

--- a/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/AbstractDuckDBDataStoreFactory.java
+++ b/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/AbstractDuckDBDataStoreFactory.java
@@ -57,7 +57,8 @@ public abstract class AbstractDuckDBDataStoreFactory extends JDBCDataStoreFactor
     public static final Param READ_ONLY = new ParamBuilder("read_only")
             .type(Boolean.class)
             .title("Read only")
-            .description("Restrict the DuckDB datastore to read-only GeoTools operations")
+            .description(
+                    "Open file-backed DuckDB databases in read-only mode at both the GeoTools API layer and the DuckDB engine level")
             .required(false)
             .defaultValue(true)
             .userLevel()
@@ -145,12 +146,18 @@ public abstract class AbstractDuckDBDataStoreFactory extends JDBCDataStoreFactor
 
         DuckDBDialect duckDBDialect = (DuckDBDialect) dialect;
         List<String> databaseInitSqls = duckDBDialect.getDatabaseInitSql();
+        Boolean readOnly = (Boolean) READ_ONLY.lookUp(params);
+        String jdbcUrl = getJDBCUrl(params);
+        boolean inMemory = "jdbc:duckdb:".equals(jdbcUrl);
 
         DuckdbDataSource dataSource = new DuckdbDataSource(databaseInitSqls);
-        dataSource.setUrl(getJDBCUrl(params));
+        dataSource.setUrl(jdbcUrl);
         dataSource.setDriverClassName(getDriverClassName());
         // configure the driver for streaming
         dataSource.addConnectionProperty(DuckDBDriver.JDBC_STREAM_RESULTS, "true");
+        if (!inMemory && (readOnly == null || readOnly)) {
+            dataSource.addConnectionProperty(DuckDBDriver.DUCKDB_READONLY_PROPERTY, "true");
+        }
         // keep at least one open connection to not lose memory databases
         dataSource.setMinIdle(1);
         dataSource.setMaxActive(2 * Runtime.getRuntime().availableProcessors());

--- a/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
+++ b/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
@@ -329,14 +329,12 @@ public class DuckDBDialect extends BasicSQLDialect {
     private boolean probeStSridAvailability(Connection cx) throws SQLException {
         try (Statement statement = cx.createStatement();
                 ResultSet rs = statement.executeQuery(ST_SRID_CAPABILITY_SQL)) {
-            // PMD false-positive safe pattern: navigation result is checked and then consumed.
-            boolean available = rs.next();
-            if (available) {
+            if (rs.next()) {
                 LOGGER.log(Level.FINE, "DuckDB spatial extension exposes ST_SRID for native GEOMETRY");
-            } else {
-                LOGGER.log(Level.FINE, "DuckDB spatial extension does not expose ST_SRID for native GEOMETRY");
+                return true;
             }
-            return available;
+            LOGGER.log(Level.FINE, "DuckDB spatial extension does not expose ST_SRID for native GEOMETRY");
+            return false;
         }
     }
 

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDataStoreFactoryTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDataStoreFactoryTest.java
@@ -27,6 +27,9 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -35,6 +38,7 @@ import org.geotools.api.data.DataStore;
 import org.geotools.api.data.DataStoreFactorySpi;
 import org.geotools.api.data.DataStoreFinder;
 import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.jdbc.JDBCDataStore;
 import org.geotools.util.decorate.Wrapper;
 import org.junit.Rule;
 import org.junit.Test;
@@ -146,6 +150,49 @@ public class DuckDBDataStoreFactoryTest {
     }
 
     @Test
+    public void testCreateDataStoreDefaultsToEngineReadOnlyWhenParameterOmitted() throws Exception {
+        File database = new File(temporaryFolder.newFolder("duckdb-read-only"), "store.duckdb");
+        createSeedTable(database);
+
+        DuckDBDataStoreFactory factory = new DuckDBDataStoreFactory();
+        Map<String, Object> params = new HashMap<>();
+        params.put("dbtype", "duckdb");
+        params.put("database", database.getAbsolutePath());
+
+        DuckDBDataStore store = null;
+        try {
+            store = factory.createDataStore(params);
+            assertReadOnlyCreateTableFails(store, "read_only_engine_check");
+        } finally {
+            if (store != null) {
+                store.dispose();
+            }
+        }
+    }
+
+    @Test
+    public void testCreateDataStoreOpensEngineWritableWhenConfigured() throws Exception {
+        File database = new File(temporaryFolder.newFolder("duckdb-writable"), "store.duckdb");
+        createSeedTable(database);
+
+        DuckDBDataStoreFactory factory = new DuckDBDataStoreFactory();
+        Map<String, Object> params = new HashMap<>();
+        params.put("dbtype", "duckdb");
+        params.put("database", database.getAbsolutePath());
+        params.put("read_only", Boolean.FALSE);
+
+        DuckDBDataStore store = null;
+        try {
+            store = factory.createDataStore(params);
+            assertWritableCreateTableSucceeds(store, "writable_engine_check");
+        } finally {
+            if (store != null) {
+                store.dispose();
+            }
+        }
+    }
+
+    @Test
     public void testCreateDataStoreRejectsMissingDatabaseWhenNotInMemory() {
         DuckDBDataStoreFactory factory = new DuckDBDataStoreFactory();
         Map<String, Object> params = new HashMap<>();
@@ -182,7 +229,6 @@ public class DuckDBDataStoreFactoryTest {
         Map<String, Object> params = new HashMap<>();
         params.put("dbtype", "duckdb");
         params.put("memory", Boolean.TRUE);
-        params.put("read_only", Boolean.FALSE);
 
         DataStore store = null;
         try {
@@ -190,6 +236,26 @@ public class DuckDBDataStoreFactoryTest {
             assertNotNull(store);
             assertTrue(store instanceof DuckDBDataStore);
             assertEquals(0, store.getTypeNames().length);
+        } finally {
+            if (store != null) {
+                store.dispose();
+            }
+        }
+    }
+
+    @Test
+    public void testCreateDataStoreSupportsInMemoryModeWithDefaultReadOnly() throws Exception {
+        DuckDBDataStoreFactory factory = new DuckDBDataStoreFactory();
+        Map<String, Object> params = new HashMap<>();
+        params.put("dbtype", "duckdb");
+        params.put("memory", Boolean.TRUE);
+        params.put("read_only", Boolean.TRUE);
+
+        DuckDBDataStore store = null;
+        try {
+            store = factory.createDataStore(params);
+            executeCreateTable(store, "in_memory_read_only_guard");
+            assertTrue(store.getTypeNames().length >= 1);
         } finally {
             if (store != null) {
                 store.dispose();
@@ -224,7 +290,7 @@ public class DuckDBDataStoreFactoryTest {
     }
 
     private void createSeedTable(File database) throws Exception {
-        org.geotools.jdbc.JDBCDataStore store = DuckDBTestUtils.createStore(database.toPath(), false);
+        JDBCDataStore store = DuckDBTestUtils.createStore(database.toPath(), false);
         try {
             DuckDBTestUtils.runSetupSql(
                     store,
@@ -232,6 +298,40 @@ public class DuckDBDataStoreFactoryTest {
                     "INSERT INTO existing VALUES (1, ST_GeomFromText('POINT (0 0)'), 'seed')");
         } finally {
             store.dispose();
+        }
+    }
+
+    private void assertReadOnlyCreateTableFails(DuckDBDataStore store, String tableName) throws Exception {
+        try {
+            executeCreateTable(store, tableName);
+            fail("Expected DuckDB engine read-only mode to reject DDL");
+        } catch (SQLException e) {
+            assertNotNull(e.getMessage());
+            String message = e.getMessage().toLowerCase();
+            assertTrue(message.contains("read-only") || message.contains("readonly"));
+        }
+    }
+
+    private void assertWritableCreateTableSucceeds(DuckDBDataStore store, String tableName) throws Exception {
+        executeCreateTable(store, tableName);
+        try {
+            executeDropTable(store, tableName);
+        } catch (SQLException e) {
+            fail("Expected cleanup DROP TABLE to succeed, but got: " + e.getMessage());
+        }
+    }
+
+    private void executeCreateTable(DuckDBDataStore store, String tableName) throws SQLException {
+        try (Connection connection = store.delegate.getDataSource().getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE " + tableName + " (id INTEGER)");
+        }
+    }
+
+    private void executeDropTable(DuckDBDataStore store, String tableName) throws SQLException {
+        try (Connection connection = store.delegate.getDataSource().getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE " + tableName);
         }
     }
 }

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDataStoreOnlineTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDataStoreOnlineTest.java
@@ -17,6 +17,9 @@
 package org.geotools.data.duckdb;
 
 import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Map;
 import org.geotools.jdbc.JDBCDataStoreOnlineTest;
 import org.geotools.jdbc.JDBCTestSetup;
@@ -125,5 +128,35 @@ public class DuckDBDataStoreOnlineTest extends JDBCDataStoreOnlineTest {
     @Test
     public void testGetFeatureWriterAppend() throws IOException {
         super.testGetFeatureWriterAppend();
+    }
+
+    /** Verifies that writable mode leaves the DuckDB engine open for DDL on a borrowed connection. */
+    @Test
+    public void testBorrowedConnectionAllowsCreateTableWhenWritable() throws Exception {
+        String tableName = tname("writable_engine_guard");
+
+        try {
+            executeCreateTable(tableName);
+        } finally {
+            try {
+                dropTable(tableName);
+            } catch (Exception e) {
+                throw new AssertionError("Failed to clean up table " + tableName, e);
+            }
+        }
+    }
+
+    private void executeCreateTable(String tableName) throws SQLException {
+        try (Connection connection = dataStore.getDataSource().getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("CREATE TABLE \"" + tableName + "\" (\"id\" INTEGER)");
+        }
+    }
+
+    private void dropTable(String tableName) throws Exception {
+        try (Connection connection = setup.getDataSource().getConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE IF EXISTS \"" + tableName + "\"");
+        }
     }
 }

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDataStoreFactory.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDataStoreFactory.java
@@ -17,9 +17,12 @@
 package org.geotools.data.geoparquet;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import org.geotools.api.data.DataAccessFactory;
+import org.geotools.api.data.DataStore;
 import org.geotools.api.data.DataStoreFactorySpi;
+import org.geotools.data.duckdb.AbstractDuckDBDataStoreFactory;
 import org.geotools.data.duckdb.ForwardingDataStoreFactory;
 import org.geotools.jdbc.JDBCDataStore;
 
@@ -68,7 +71,19 @@ public class GeoParquetDataStoreFactory extends ForwardingDataStoreFactory<GeoPa
 
     @Override
     public GeoparquetDataStore createDataStore(Map<String, ?> params) throws IOException {
-        JDBCDataStore delegateStore = delegate.createDataStore(params);
+        JDBCDataStore delegateStore = delegate.createDataStore(withWritableDuckDb(params));
         return new GeoparquetDataStore(delegateStore);
+    }
+
+    @Override
+    public DataStore createNewDataStore(Map<String, ?> params) throws IOException {
+        JDBCDataStore delegateStore = (JDBCDataStore) delegate.createNewDataStore(withWritableDuckDb(params));
+        return new GeoparquetDataStore(delegateStore);
+    }
+
+    private Map<String, Object> withWritableDuckDb(Map<String, ?> params) {
+        Map<String, Object> writableParams = new HashMap<>(params);
+        writableParams.put(AbstractDuckDBDataStoreFactory.READ_ONLY.key, Boolean.FALSE);
+        return writableParams;
     }
 }


### PR DESCRIPTION
[![GEOT-7902](https://badgen.net/badge/JIRA/GEOT-7902/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7902) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

JIRA issue:
https://osgeo-org.atlassian.net/browse/GEOT-7902

This PR propagates the DuckDB datastore `read_only` setting to the JDBC driver so file-backed stores are opened in true engine read-only mode, while preserving the existing GeoTools wrapper-level API protections. It also adds regression coverage for the default read-only path, writable mode, and in-memory behavior.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 