### PR TITLE
[GEOT-7903] Add an immutable flag on GeoPackage data store

### DIFF
--- a/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDataStoreFactory.java
+++ b/modules/plugin/geopkg/src/main/java/org/geotools/geopkg/GeoPkgDataStoreFactory.java
@@ -50,6 +50,8 @@ public class GeoPkgDataStoreFactory extends JDBCDataStoreFactory {
 
     public static final Param READ_ONLY = new Param("read_only", Boolean.class, "Read only", false);
 
+    public static final Param IMMUTABLE = new Param("immutable", Boolean.class, "Immutable", false);
+
     public static final Param CONTENTS_ONLY =
             new Param("contents_only", Boolean.class, "Contents only", false, Boolean.TRUE);
 
@@ -134,8 +136,10 @@ public class GeoPkgDataStoreFactory extends JDBCDataStoreFactory {
         }
         String jdbcUri = "jdbc:sqlite:" + db.toURI();
         Object readOnly = READ_ONLY.lookUp(params);
-        if (Boolean.TRUE.equals(readOnly) && isNeedImmutable(db.toPath())) {
-            // if the readOnly mode has been requested and the geopackage file and parent directory are also
+        Object immutable = IMMUTABLE.lookUp(params);
+        if (Boolean.TRUE.equals(immutable) || (Boolean.TRUE.equals(readOnly) && isNeedImmutable(db.toPath()))) {
+            // If immutable is requested, enable it, it will avoid even read only locking.
+            // If the readOnly mode has been requested and the GeoPackage file and parent directory are also
             // readonly we also set the immutable flag. This prevents any exceptions being thrown in the
             // unlikely case the GeoPackage has an incomplete transaction because sqlite will otherwise
             // attempt to recover the transaction and that will fail on a read only file system.
@@ -174,8 +178,9 @@ public class GeoPkgDataStoreFactory extends JDBCDataStoreFactory {
         parameters.put(DATABASE.key, DATABASE);
         // replace dbtype
         parameters.put(DBTYPE.key, DBTYPE);
-        // add the read only flag
+        // add the read only and immutable flags
         parameters.put(READ_ONLY.key, READ_ONLY);
+        parameters.put(IMMUTABLE.key, IMMUTABLE);
         // memory mapping
         parameters.put(MEMORY_MAP_SIZE.key, MEMORY_MAP_SIZE);
     }

--- a/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDataStoreFactoryTest.java
+++ b/modules/plugin/geopkg/src/test/java/org/geotools/geopkg/GeoPkgDataStoreFactoryTest.java
@@ -27,6 +27,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -104,6 +105,23 @@ public class GeoPkgDataStoreFactoryTest {
         thread2.join();
         assertFalse(failed.get());
         assertTrue(time.get() <= 10000);
+    }
+
+    @Test
+    public void testImmutableUrlParameter() throws IOException {
+        GeoPkgDataStoreFactory factory = new GeoPkgDataStoreFactory();
+        Map<String, Serializable> map = new HashMap<>();
+        map.put(GeoPkgDataStoreFactory.DBTYPE.key, "geopkg");
+        map.put(GeoPkgDataStoreFactory.DATABASE.key, tmp.newFile("immutable.gpkg"));
+        map.put(GeoPkgDataStoreFactory.IMMUTABLE.key, true);
+
+        assertTrue(factory.createDataSource(map).getUrl().endsWith("?immutable=true"));
+    }
+
+    @Test
+    public void testImmutableParameterInfo() {
+        assertTrue(Arrays.asList(new GeoPkgDataStoreFactory().getParametersInfo())
+                .contains(GeoPkgDataStoreFactory.IMMUTABLE));
     }
 
     private void createGeoPackage(String geoPackageName, Integer connectTimeout, String tableName) throws IOException {


### PR DESCRIPTION
[![GEOT-7903](https://badgen.net/badge/JIRA/GEOT-7903/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7903) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This new flag helps GeoPackage perform better when placed on network shares.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 