### PR TITLE
[GEOT-7904] Clean up gt-arcgisrest dependencies

### DIFF
--- a/modules/unsupported/arcgis-rest/pom.xml
+++ b/modules/unsupported/arcgis-rest/pom.xml
@@ -42,23 +42,22 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.esri.geometry</groupId>
-        <artifactId>esri-geometry-api</artifactId>
-        <version>2.2.4</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.13.2</version>
       </dependency>
-      <dependency>
-        <groupId>javax.xml.ws</groupId>
-        <artifactId>jaxws-api</artifactId>
-        <version>2.3.1</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-metadata</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
@@ -68,12 +67,16 @@
       <artifactId>gt-referencing</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.esri.geometry</groupId>
-      <artifactId>esri-geometry-api</artifactId>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -100,6 +103,12 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
+      <artifactId>powermock-core</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
       <artifactId>powermock-module-junit4</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
@@ -114,10 +123,6 @@
       <groupId>org.geotools</groupId>
       <artifactId>gt-cql</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.xml.ws</groupId>
-      <artifactId>jaxws-api</artifactId>
     </dependency>
   </dependencies>
 

--- a/modules/unsupported/arcgis-rest/src/main/java/org/geotools/data/arcgisrest/ArcGISRestDataStore.java
+++ b/modules/unsupported/arcgis-rest/src/main/java/org/geotools/data/arcgisrest/ArcGISRestDataStore.java
@@ -28,6 +28,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -40,25 +41,22 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
-import org.apache.http.Consts;
-import org.apache.http.Header;
-import org.apache.http.HttpStatus;
-import org.apache.http.NameValuePair;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
-import org.apache.http.client.config.CookieSpecs;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.entity.UrlEncodedFormEntity;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
+import org.apache.hc.core5.net.URIBuilder;
 import org.geotools.api.data.Query;
 import org.geotools.api.feature.type.Name;
 import org.geotools.data.arcgisrest.schema.catalog.Catalog;
@@ -423,7 +421,7 @@ public class ArcGISRestDataStore extends ContentDataStore {
         });
 
         // Instanties the method based on the methType parameter
-        HttpRequestBase httpRequest;
+        HttpUriRequestBase httpRequest;
         if (methType.equals("GET")) {
             httpRequest = new HttpGet(
                     new URIBuilder(String.valueOf(url)).addParameters(kvps).build());
@@ -431,25 +429,23 @@ public class ArcGISRestDataStore extends ContentDataStore {
                     Level.FINER,
                     String.format(
                             "About to query GET '%s?%s'",
-                            url.toString(), httpRequest.getURI().getQuery()));
+                            url.toString(), httpRequest.getUri().getQuery()));
         } else {
             httpRequest = new HttpPost(new URIBuilder(String.valueOf(url)).build());
-            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(kvps, Consts.UTF_8);
-            entity.setChunked(true);
-            ((HttpPost) (httpRequest)).setEntity(entity);
+            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(kvps, StandardCharsets.UTF_8);
+            ((HttpPost) httpRequest).setEntity(entity);
             this.LOGGER.log(Level.FINER, String.format("About to query POST '%s' with body: %s", url, params));
         }
 
-        httpRequest.setConfig(
-                RequestConfig.custom().setCookieSpec(CookieSpecs.DEFAULT).build());
+        httpRequest.setConfig(RequestConfig.custom().setCookieSpec(null).build());
 
         // Adds authorization if login/password is set
-        CredentialsProvider credsProvider = new BasicCredentialsProvider();
+        BasicCredentialsProvider credsProvider = new BasicCredentialsProvider();
         if (this.user != null && this.password != null) {
             credsProvider.setCredentials(
                     new AuthScope(
-                            httpRequest.getURI().getHost(), httpRequest.getURI().getPort()),
-                    new UsernamePasswordCredentials("user", "passwd"));
+                            httpRequest.getUri().getHost(), httpRequest.getUri().getPort()),
+                    new UsernamePasswordCredentials("user", "passwd".toCharArray()));
         }
         try (CloseableHttpClient client = HttpClients.custom()
                 .setDefaultCredentialsProvider(credsProvider)
@@ -462,10 +458,9 @@ public class ArcGISRestDataStore extends ContentDataStore {
                 try (CloseableHttpResponse httpResponse = client.execute(httpRequest)) {
 
                     // If HTTP error, throws an exception
-                    if (httpResponse.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                    if (httpResponse.getCode() != HttpStatus.SC_OK) {
                         throw new IOException(String.format(
-                                "HTTP Status: %d for URL: %s",
-                                httpResponse.getStatusLine().getStatusCode(), httpRequest.getURI()));
+                                "HTTP Status: %d for URL: %s", httpResponse.getCode(), httpRequest.getUri()));
                     }
 
                     // Retrieve the wait period is returned by the server
@@ -485,7 +480,7 @@ public class ArcGISRestDataStore extends ContentDataStore {
                                 Level.FINE,
                                 String.format(
                                         "Waiting %d seconds before retrying request to %s",
-                                        wait, httpRequest.getURI()));
+                                        wait, httpRequest.getUri()));
                         Thread.sleep(wait * 1000);
 
                     } catch (InterruptedException e) {

--- a/modules/unsupported/arcgis-rest/src/main/java/org/geotools/data/arcgisrest/ArcGISRestFeatureSource.java
+++ b/modules/unsupported/arcgis-rest/src/main/java/org/geotools/data/arcgisrest/ArcGISRestFeatureSource.java
@@ -30,7 +30,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.logging.Level;
-import javax.xml.ws.http.HTTPException;
 import org.geotools.api.data.FeatureReader;
 import org.geotools.api.data.Query;
 import org.geotools.api.data.ResourceInfo;
@@ -273,7 +272,7 @@ public class ArcGISRestFeatureSource extends ContentFeatureSource {
         // Executes the request
         try {
             result = this.dataStore.retrieveJSON("POST", (new URL(this.composeQueryURL())), params);
-        } catch (HTTPException | URISyntaxException e) {
+        } catch (IOException | URISyntaxException e) {
             throw new IOException(e);
         }
 

--- a/modules/unsupported/arcgis-rest/src/test/java/org/geotools/data/arcgisrest/ArcGISRestDataStoreTest.java
+++ b/modules/unsupported/arcgis-rest/src/test/java/org/geotools/data/arcgisrest/ArcGISRestDataStoreTest.java
@@ -25,14 +25,13 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.List;
-import org.apache.http.HttpStatus;
-import org.apache.http.HttpVersion;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.message.BasicHttpResponse;
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.message.BasicHttpResponse;
 import org.geotools.api.data.FeatureSource;
 import org.geotools.api.data.Query;
 import org.geotools.api.feature.simple.SimpleFeature;
@@ -55,7 +54,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 @Ignore
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({HttpRequestBase.class, ArcGISRestDataStore.class})
+@PrepareForTest({HttpUriRequestBase.class, ArcGISRestDataStore.class})
 public class ArcGISRestDataStoreTest {
 
     public static String TYPENAME1 = "LGAProfiles2014Beta";
@@ -93,8 +92,7 @@ public class ArcGISRestDataStoreTest {
 
         PowerMockito.whenNew(HttpClient.class).withNoArguments().thenReturn(clientMock);
         PowerMockito.whenNew(HttpGet.class).withNoArguments().thenReturn(getMock);
-        when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_NOT_FOUND, "Not Found"));
+        when(clientMock.execute(getMock)).thenReturn(new BasicHttpResponse(HttpStatus.SC_NOT_FOUND, "Not Found"));
         try {
             this.dataStore = (ArcGISRestDataStore) ArcGISRestDataStoreFactoryTest.createDefaultOpenDataTestDataStore();
             this.dataStore.createTypeNames();
@@ -114,8 +112,8 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 //                getMock.getResponseBodyAsStream())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/catalog.json"))
@@ -152,13 +150,13 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_BAD_REQUEST, "Bad Request"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_BAD_REQUEST, "Bad Request"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/wsServiceInDistribution.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/error.json"))
@@ -197,8 +195,7 @@ public class ArcGISRestDataStoreTest {
                 .withNoArguments()
                 .thenReturn(getMock)
                 .thenReturn(getMock);
-        when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+        when(clientMock.execute(getMock)).thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/unsupportedCatalog.json"));
 
@@ -217,8 +214,8 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/catalog.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/lgaDataset.json"));
@@ -245,9 +242,9 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/FeatureServerAirport.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/airport2Dataset.json"))
@@ -276,9 +273,9 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/catalog.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/lgaDataset.json"))
@@ -313,8 +310,7 @@ public class ArcGISRestDataStoreTest {
         PowerMockito.whenNew(HttpClient.class).withNoArguments().thenReturn(this.clientMock);
 
         PowerMockito.whenNew(HttpPost.class).withNoArguments().thenReturn(this.postMock);
-        when(this.clientMock.execute(postMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+        when(this.clientMock.execute(postMock)).thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/count.json"));
 
@@ -333,9 +329,9 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/catalog.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/lgaDataset.json"))
@@ -353,8 +349,7 @@ public class ArcGISRestDataStoreTest {
         PowerMockito.whenNew(HttpClient.class).withNoArguments().thenReturn(this.clientMock);
 
         PowerMockito.whenNew(HttpPost.class).withNoArguments().thenReturn(this.postMock);
-        when(this.clientMock.execute(postMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+        when(this.clientMock.execute(postMock)).thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/lgaFeatures.geo.json"));
 
@@ -388,9 +383,9 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/catalog.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/bicycleDataset.json"))
@@ -407,8 +402,7 @@ public class ArcGISRestDataStoreTest {
         PowerMockito.whenNew(HttpClient.class).withNoArguments().thenReturn(this.clientMock);
 
         PowerMockito.whenNew(HttpPost.class).withNoArguments().thenReturn(this.postMock);
-        when(this.clientMock.execute(postMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+        when(this.clientMock.execute(postMock)).thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/bicycleFeatures.geo.json"));
 
@@ -445,9 +439,9 @@ public class ArcGISRestDataStoreTest {
                 .thenReturn(getMock)
                 .thenReturn(getMock);
         when(clientMock.execute(getMock))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"))
-                .thenReturn(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"))
+                .thenReturn(new BasicHttpResponse(HttpStatus.SC_OK, "OK"));
         when(responseMock.getEntity().getContent())
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/FeatureServerLandUse.json"))
                 .thenReturn(ArcGISRestDataStoreFactoryTest.readJSONAsStream("test-data/walkablecatchmentDataset.json"))


### PR DESCRIPTION
[![GEOT-7904](https://badgen.net/badge/JIRA/GEOT-7904/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7904) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Clean up pom to align Jackson and httpcomponents library with versions at 35.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 