### PR TITLE
[GEOT-7905] DuckDB temporal metadata mapping is inconsistent for extended TIME* and TIMESTAMP* types

### DIFF
--- a/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
+++ b/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
@@ -26,6 +26,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.time.Instant;
@@ -33,7 +34,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
@@ -179,6 +183,20 @@ public class DuckDBDialect extends BasicSQLDialect {
         Class<?> parentMapping = getParentMapping(columnMetaData, cx);
         String typeName = columnMetaData.getString("TYPE_NAME");
 
+        if (typeName != null) {
+            String normalizedTypeName = typeName.toUpperCase(Locale.ROOT);
+            if ("TIME_NS".equals(normalizedTypeName)
+                    || "TIMETZ".equals(normalizedTypeName)
+                    || "TIME WITH TIME ZONE".equals(normalizedTypeName)) {
+                return Time.class;
+            }
+            // DuckDB reports precision and timezone variants in the SQL type name.
+            // Keep all TIMESTAMP family variants normalized to java.sql.Timestamp.
+            if (normalizedTypeName.startsWith("TIMESTAMP")) {
+                return Timestamp.class;
+            }
+        }
+
         // Check if it's a geometry column
         if ("GEOMETRY".equalsIgnoreCase(typeName)) {
             return Geometry.class;
@@ -204,12 +222,20 @@ public class DuckDBDialect extends BasicSQLDialect {
     public void registerSqlTypeToClassMappings(Map<Integer, Class<?>> mappings) {
         super.registerSqlTypeToClassMappings(mappings);
         mappings.put(Types.STRUCT, Struct.class);
+        mappings.put(Types.TIME_WITH_TIMEZONE, Time.class);
         mappings.put(Types.TIMESTAMP_WITH_TIMEZONE, Timestamp.class);
     }
 
     @Override
     public void registerSqlTypeNameToClassMappings(Map<String, Class<?>> mappings) {
         super.registerSqlTypeNameToClassMappings(mappings);
+        mappings.put("TIME_NS", Time.class);
+        mappings.put("TIMETZ", Time.class);
+        mappings.put("TIME WITH TIME ZONE", Time.class);
+        mappings.put("TIMESTAMP_S", Timestamp.class);
+        mappings.put("TIMESTAMP_MS", Timestamp.class);
+        mappings.put("TIMESTAMP_NS", Timestamp.class);
+        mappings.put("TIMESTAMPTZ", Timestamp.class);
         mappings.put("TIMESTAMP WITH TIME ZONE", Timestamp.class);
     }
 
@@ -281,11 +307,37 @@ public class DuckDBDialect extends BasicSQLDialect {
                 return Timestamp.from(instant);
             }
         }
-        if (binding == java.sql.Time.class && value instanceof LocalTime localTime) {
-            return java.sql.Time.valueOf(localTime);
+        if (binding == Time.class) {
+            if (value instanceof LocalTime localTime) {
+                return Time.valueOf(localTime);
+            }
+            if (value instanceof OffsetTime offsetTime) {
+                return Time.valueOf(offsetTime.toLocalTime());
+            }
+            if (value instanceof String text) {
+                Time parsed = parseDuckDbTime(text);
+                if (parsed != null) {
+                    return parsed;
+                }
+            }
         }
 
         return super.convertValue(value, ad);
+    }
+
+    private Time parseDuckDbTime(String text) {
+        try {
+            return Time.valueOf(OffsetTime.parse(text).toLocalTime());
+        } catch (DateTimeParseException e) {
+            // Fallback to local-time parsing for non-timezone time values.
+            if (LOGGER.isLoggable(Level.FINE)) LOGGER.log(Level.FINE, "Unable to parse time string: " + text, e);
+        }
+        try {
+            return Time.valueOf(LocalTime.parse(text));
+        } catch (DateTimeParseException e) {
+            if (LOGGER.isLoggable(Level.FINE)) LOGGER.log(Level.FINE, "Unable to parse time string: " + text, e);
+            return null;
+        }
     }
 
     @Override

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDatetimeRegressionTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDatetimeRegressionTest.java
@@ -190,19 +190,31 @@ public class DuckDBDatetimeRegressionTest {
                 DuckDBTestUtils.createStore(tmp.newFolder().toPath().resolve("datetime.duckdb"), false);
         DuckDBTestUtils.runSetupSql(
                 store,
-                "CREATE TABLE \"" + TABLE_NAME + "\" ("
-                        + "id INTEGER PRIMARY KEY, "
-                        + "geom GEOMETRY, "
-                        + "d DATE, "
-                        + "ts TIMESTAMP, "
-                        + "grp VARCHAR"
-                        + ")",
-                "INSERT INTO \"" + TABLE_NAME + "\" VALUES "
-                        + "(1, ST_GeomFromText('POINT (0 0)'), DATE '2020-02-19', TIMESTAMP '2020-02-19 22:00:00', 'a')",
-                "INSERT INTO \"" + TABLE_NAME + "\" VALUES "
-                        + "(2, ST_GeomFromText('POINT (1 1)'), DATE '2020-02-20', TIMESTAMP '2020-02-20 02:00:00', 'a')",
-                "INSERT INTO \"" + TABLE_NAME + "\" VALUES "
-                        + "(3, ST_GeomFromText('POINT (2 2)'), DATE '2020-03-19', TIMESTAMP '2020-03-19 01:00:00', 'b')");
+                """
+                CREATE TABLE "%s" (
+                    id INTEGER PRIMARY KEY,
+                    geom GEOMETRY,
+                    d DATE,
+                    ts TIMESTAMP,
+                    grp VARCHAR
+                )
+                """
+                        .formatted(TABLE_NAME),
+                """
+                INSERT INTO "%s" VALUES
+                    (1, ST_GeomFromText('POINT (0 0)'), DATE '2020-02-19', TIMESTAMP '2020-02-19 22:00:00', 'a')
+                """
+                        .formatted(TABLE_NAME),
+                """
+                INSERT INTO "%s" VALUES
+                    (2, ST_GeomFromText('POINT (1 1)'), DATE '2020-02-20', TIMESTAMP '2020-02-20 02:00:00', 'a')
+                """
+                        .formatted(TABLE_NAME),
+                """
+                INSERT INTO "%s" VALUES
+                    (3, ST_GeomFromText('POINT (2 2)'), DATE '2020-03-19', TIMESTAMP '2020-03-19 01:00:00', 'b')
+                """
+                        .formatted(TABLE_NAME));
         return store;
     }
 
@@ -211,24 +223,29 @@ public class DuckDBDatetimeRegressionTest {
                 DuckDBTestUtils.createStore(tmp.newFolder().toPath().resolve("timestamp-variants.duckdb"), false);
         DuckDBTestUtils.runSetupSql(
                 store,
-                "CREATE TABLE \"timestamp_variants\" ("
-                        + "id INTEGER PRIMARY KEY, "
-                        + "ts_plain TIMESTAMP, "
-                        + "ts_s TIMESTAMP_S, "
-                        + "ts_ms TIMESTAMP_MS, "
-                        + "ts_ns TIMESTAMP_NS, "
-                        + "ts_tz TIMESTAMPTZ, "
-                        + "ts_tz_long TIMESTAMP WITH TIME ZONE"
-                        + ")",
-                "INSERT INTO \"timestamp_variants\" VALUES "
-                        + "(1, "
-                        + "TIMESTAMP '2020-01-01 00:00:00', "
-                        + "CAST('2020-01-01 00:00:00' AS TIMESTAMP_S), "
-                        + "CAST('2020-01-01 00:00:00.123' AS TIMESTAMP_MS), "
-                        + "CAST('2020-01-01 00:00:00.123456789' AS TIMESTAMP_NS), "
-                        + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMPTZ), "
-                        + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMP WITH TIME ZONE)"
-                        + ")");
+                """
+                CREATE TABLE "timestamp_variants" (
+                    id INTEGER PRIMARY KEY,
+                    ts_plain TIMESTAMP,
+                    ts_s TIMESTAMP_S,
+                    ts_ms TIMESTAMP_MS,
+                    ts_ns TIMESTAMP_NS,
+                    ts_tz TIMESTAMPTZ,
+                    ts_tz_long TIMESTAMP WITH TIME ZONE
+                )
+                """
+                        .formatted(),
+                """
+                INSERT INTO "timestamp_variants" VALUES
+                    (1,
+                    TIMESTAMP '2020-01-01 00:00:00',
+                    CAST('2020-01-01 00:00:00' AS TIMESTAMP_S),
+                    CAST('2020-01-01 00:00:00.123' AS TIMESTAMP_MS),
+                    CAST('2020-01-01 00:00:00.123456789' AS TIMESTAMP_NS),
+                    CAST('2020-01-01 00:00:00+00' AS TIMESTAMPTZ),
+                    CAST('2020-01-01 00:00:00+00' AS TIMESTAMP WITH TIME ZONE))
+                """
+                        .formatted());
         return store;
     }
 
@@ -237,21 +254,27 @@ public class DuckDBDatetimeRegressionTest {
                 DuckDBTestUtils.createStore(tmp.newFolder().toPath().resolve("temporal-variants.duckdb"), false);
         DuckDBTestUtils.runSetupSql(
                 store,
-                "CREATE TABLE \"temporal_variants\" ("
-                        + "id INTEGER PRIMARY KEY, "
-                        + "d DATE, "
-                        + "t_plain TIME, "
-                        + "t_ns TIME_NS, "
-                        + "t_tz TIMETZ, "
-                        + "t_tz_long TIME WITH TIME ZONE, "
-                        + "ts_tz TIMESTAMPTZ"
-                        + ")",
-                "INSERT INTO \"temporal_variants\" VALUES "
-                        + "(1, DATE '2020-01-01', TIME '12:34:56', "
-                        + "CAST('12:34:56.123456789' AS TIME_NS), "
-                        + "CAST('12:34:56+02' AS TIMETZ), "
-                        + "CAST('12:34:56+02' AS TIME WITH TIME ZONE), "
-                        + "CAST('2020-01-01 12:34:56+02' AS TIMESTAMPTZ))");
+                """
+                CREATE TABLE "temporal_variants" (
+                    id INTEGER PRIMARY KEY,
+                    d DATE,
+                    t_plain TIME,
+                    t_ns TIME_NS,
+                    t_tz TIMETZ,
+                    t_tz_long TIME WITH TIME ZONE,
+                    ts_tz TIMESTAMPTZ
+                )
+                """
+                        .formatted(),
+                """
+                INSERT INTO "temporal_variants" VALUES
+                    (1, DATE '2020-01-01', TIME '12:34:56',
+                    CAST('12:34:56.123456789' AS TIME_NS),
+                    CAST('12:34:56+02' AS TIMETZ),
+                    CAST('12:34:56+02' AS TIME WITH TIME ZONE),
+                    CAST('2020-01-01 12:34:56+02' AS TIMESTAMPTZ))
+                """
+                        .formatted());
         return store;
     }
 

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDatetimeRegressionTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDatetimeRegressionTest.java
@@ -17,9 +17,11 @@
 package org.geotools.data.duckdb;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.sql.Date;
+import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.Arrays;
@@ -27,8 +29,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.data.util.NullProgressListener;
 import org.geotools.feature.visitor.Aggregate;
 import org.geotools.feature.visitor.GroupByVisitor;
@@ -59,6 +64,64 @@ public class DuckDBDatetimeRegressionTest {
             assertEquals(
                     Timestamp.class,
                     store.getSchema(TABLE_NAME).getDescriptor("ts").getType().getBinding());
+        } finally {
+            store.dispose();
+        }
+    }
+
+    @Test
+    public void testTimestampVariantSchemaBindingsUseSqlTimestamp() throws Exception {
+        JDBCDataStore store = createTimestampVariantStore();
+        try {
+            SimpleFeatureType schema = store.getSchema("timestamp_variants");
+            assertEquals(
+                    Timestamp.class, schema.getDescriptor("ts_plain").getType().getBinding());
+            assertEquals(Timestamp.class, schema.getDescriptor("ts_s").getType().getBinding());
+            assertEquals(
+                    Timestamp.class, schema.getDescriptor("ts_ms").getType().getBinding());
+            assertEquals(
+                    Timestamp.class, schema.getDescriptor("ts_ns").getType().getBinding());
+            assertEquals(
+                    Timestamp.class, schema.getDescriptor("ts_tz").getType().getBinding());
+            assertEquals(
+                    Timestamp.class,
+                    schema.getDescriptor("ts_tz_long").getType().getBinding());
+        } finally {
+            store.dispose();
+        }
+    }
+
+    @Test
+    public void testTimeVariantSchemaBindingsUseSqlTime() throws Exception {
+        JDBCDataStore store = createTemporalVariantStore();
+        try {
+            SimpleFeatureType schema = store.getSchema("temporal_variants");
+            assertEquals(Date.class, schema.getDescriptor("d").getType().getBinding());
+            assertEquals(Time.class, schema.getDescriptor("t_plain").getType().getBinding());
+            assertEquals(Time.class, schema.getDescriptor("t_ns").getType().getBinding());
+            assertEquals(Time.class, schema.getDescriptor("t_tz").getType().getBinding());
+            assertEquals(Time.class, schema.getDescriptor("t_tz_long").getType().getBinding());
+            assertEquals(
+                    Timestamp.class, schema.getDescriptor("ts_tz").getType().getBinding());
+        } finally {
+            store.dispose();
+        }
+    }
+
+    @Test
+    public void testTimeVariantRuntimeValuesUseSqlTypes() throws Exception {
+        JDBCDataStore store = createTemporalVariantStore();
+        try {
+            SimpleFeatureSource source = store.getFeatureSource("temporal_variants");
+            try (SimpleFeatureIterator features = source.getFeatures().features()) {
+                assertTrue(features.hasNext());
+                SimpleFeature feature = features.next();
+                assertEquals(Time.class, feature.getAttribute("t_plain").getClass());
+                assertEquals(Time.class, feature.getAttribute("t_ns").getClass());
+                assertEquals(Time.class, feature.getAttribute("t_tz").getClass());
+                assertEquals(Time.class, feature.getAttribute("t_tz_long").getClass());
+                assertEquals(Timestamp.class, feature.getAttribute("ts_tz").getClass());
+            }
         } finally {
             store.dispose();
         }
@@ -140,6 +203,55 @@ public class DuckDBDatetimeRegressionTest {
                         + "(2, ST_GeomFromText('POINT (1 1)'), DATE '2020-02-20', TIMESTAMP '2020-02-20 02:00:00', 'a')",
                 "INSERT INTO \"" + TABLE_NAME + "\" VALUES "
                         + "(3, ST_GeomFromText('POINT (2 2)'), DATE '2020-03-19', TIMESTAMP '2020-03-19 01:00:00', 'b')");
+        return store;
+    }
+
+    private JDBCDataStore createTimestampVariantStore() throws Exception {
+        JDBCDataStore store =
+                DuckDBTestUtils.createStore(tmp.newFolder().toPath().resolve("timestamp-variants.duckdb"), false);
+        DuckDBTestUtils.runSetupSql(
+                store,
+                "CREATE TABLE \"timestamp_variants\" ("
+                        + "id INTEGER PRIMARY KEY, "
+                        + "ts_plain TIMESTAMP, "
+                        + "ts_s TIMESTAMP_S, "
+                        + "ts_ms TIMESTAMP_MS, "
+                        + "ts_ns TIMESTAMP_NS, "
+                        + "ts_tz TIMESTAMPTZ, "
+                        + "ts_tz_long TIMESTAMP WITH TIME ZONE"
+                        + ")",
+                "INSERT INTO \"timestamp_variants\" VALUES "
+                        + "(1, "
+                        + "TIMESTAMP '2020-01-01 00:00:00', "
+                        + "CAST('2020-01-01 00:00:00' AS TIMESTAMP_S), "
+                        + "CAST('2020-01-01 00:00:00.123' AS TIMESTAMP_MS), "
+                        + "CAST('2020-01-01 00:00:00.123456789' AS TIMESTAMP_NS), "
+                        + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMPTZ), "
+                        + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMP WITH TIME ZONE)"
+                        + ")");
+        return store;
+    }
+
+    private JDBCDataStore createTemporalVariantStore() throws Exception {
+        JDBCDataStore store =
+                DuckDBTestUtils.createStore(tmp.newFolder().toPath().resolve("temporal-variants.duckdb"), false);
+        DuckDBTestUtils.runSetupSql(
+                store,
+                "CREATE TABLE \"temporal_variants\" ("
+                        + "id INTEGER PRIMARY KEY, "
+                        + "d DATE, "
+                        + "t_plain TIME, "
+                        + "t_ns TIME_NS, "
+                        + "t_tz TIMETZ, "
+                        + "t_tz_long TIME WITH TIME ZONE, "
+                        + "ts_tz TIMESTAMPTZ"
+                        + ")",
+                "INSERT INTO \"temporal_variants\" VALUES "
+                        + "(1, DATE '2020-01-01', TIME '12:34:56', "
+                        + "CAST('12:34:56.123456789' AS TIME_NS), "
+                        + "CAST('12:34:56+02' AS TIMETZ), "
+                        + "CAST('12:34:56+02' AS TIME WITH TIME ZONE), "
+                        + "CAST('2020-01-01 12:34:56+02' AS TIMESTAMPTZ))");
         return store;
     }
 

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDialectTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBDialectTest.java
@@ -33,6 +33,15 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.util.HashMap;
+import java.util.Map;
+import org.geotools.api.feature.type.AttributeDescriptor;
+import org.geotools.api.feature.type.AttributeType;
 import org.geotools.api.feature.type.GeometryDescriptor;
 import org.geotools.api.filter.And;
 import org.geotools.api.filter.Filter;
@@ -91,6 +100,122 @@ public class DuckDBDialectTest {
         Mockito.when(columnMetaData.getString("TYPE_NAME")).thenReturn("VARCHAR");
 
         assertEquals(String.class, dialect.getMapping(columnMetaData, cx));
+    }
+
+    @Test
+    public void testGetMappingRecognizesTimestampSecondPrecisionTypeName() throws Exception {
+        DuckDBDialect dialect = createDialect();
+        ResultSet columnMetaData = Mockito.mock(ResultSet.class);
+        Connection cx = Mockito.mock(Connection.class);
+
+        Mockito.when(columnMetaData.getString("TYPE_NAME")).thenReturn("TIMESTAMP_S");
+
+        assertEquals(Timestamp.class, dialect.getMapping(columnMetaData, cx));
+    }
+
+    @Test
+    public void testGetMappingRecognizesLongTimestampWithTimeZoneTypeName() throws Exception {
+        DuckDBDialect dialect = createDialect();
+        ResultSet columnMetaData = Mockito.mock(ResultSet.class);
+        Connection cx = Mockito.mock(Connection.class);
+
+        Mockito.when(columnMetaData.getString("TYPE_NAME")).thenReturn("TIMESTAMP WITH TIME ZONE");
+
+        assertEquals(Timestamp.class, dialect.getMapping(columnMetaData, cx));
+    }
+
+    @Test
+    public void testGetMappingRecognizesTimestamptzAliasTypeName() throws Exception {
+        DuckDBDialect dialect = createDialect();
+        ResultSet columnMetaData = Mockito.mock(ResultSet.class);
+        Connection cx = Mockito.mock(Connection.class);
+
+        Mockito.when(columnMetaData.getString("TYPE_NAME")).thenReturn("TIMESTAMPTZ");
+
+        assertEquals(Timestamp.class, dialect.getMapping(columnMetaData, cx));
+    }
+
+    @Test
+    public void testGetMappingRecognizesLongTimeWithTimeZoneTypeName() throws Exception {
+        DuckDBDialect dialect = createDialect();
+        ResultSet columnMetaData = Mockito.mock(ResultSet.class);
+        Connection cx = Mockito.mock(Connection.class);
+
+        Mockito.when(columnMetaData.getString("TYPE_NAME")).thenReturn("TIME WITH TIME ZONE");
+
+        assertEquals(Time.class, dialect.getMapping(columnMetaData, cx));
+    }
+
+    @Test
+    public void testRegisterSqlTypeToClassMappingsIncludesTemporalTimezoneTypes() {
+        DuckDBDialect dialect = createDialect();
+        Map<Integer, Class<?>> mappings = new HashMap<>();
+
+        dialect.registerSqlTypeToClassMappings(mappings);
+
+        assertEquals(Time.class, mappings.get(Types.TIME_WITH_TIMEZONE));
+        assertEquals(Timestamp.class, mappings.get(Types.TIMESTAMP_WITH_TIMEZONE));
+    }
+
+    @Test
+    public void testRegisterSqlTypeNameToClassMappingsIncludesTemporalAliases() {
+        DuckDBDialect dialect = createDialect();
+        Map<String, Class<?>> mappings = new HashMap<>();
+
+        dialect.registerSqlTypeNameToClassMappings(mappings);
+
+        assertEquals(Time.class, mappings.get("TIME_NS"));
+        assertEquals(Time.class, mappings.get("TIMETZ"));
+        assertEquals(Time.class, mappings.get("TIME WITH TIME ZONE"));
+        assertEquals(Timestamp.class, mappings.get("TIMESTAMP_S"));
+        assertEquals(Timestamp.class, mappings.get("TIMESTAMP_MS"));
+        assertEquals(Timestamp.class, mappings.get("TIMESTAMP_NS"));
+        assertEquals(Timestamp.class, mappings.get("TIMESTAMPTZ"));
+        assertEquals(Timestamp.class, mappings.get("TIMESTAMP WITH TIME ZONE"));
+    }
+
+    @Test
+    public void testConvertValueConvertsOffsetTimeToSqlTime() {
+        DuckDBDialect dialect = createDialect();
+        AttributeDescriptor descriptor = mockDescriptor(Time.class);
+        OffsetTime value = OffsetTime.parse("12:34:56+02:00");
+
+        Object converted = dialect.convertValue(value, descriptor);
+
+        assertEquals(Time.class, converted.getClass());
+        assertEquals(Time.valueOf(LocalTime.of(12, 34, 56)), converted);
+    }
+
+    @Test
+    public void testConvertValueConvertsTimeWithTimezoneTextToSqlTime() {
+        DuckDBDialect dialect = createDialect();
+        AttributeDescriptor descriptor = mockDescriptor(Time.class);
+
+        Object converted = dialect.convertValue("12:34:56+02:00", descriptor);
+
+        assertEquals(Time.class, converted.getClass());
+        assertEquals(Time.valueOf(LocalTime.of(12, 34, 56)), converted);
+    }
+
+    @Test
+    public void testConvertValueConvertsLocalTimeTextWithNanosToSqlTime() {
+        DuckDBDialect dialect = createDialect();
+        AttributeDescriptor descriptor = mockDescriptor(Time.class);
+
+        Object converted = dialect.convertValue("12:34:56.123456789", descriptor);
+
+        assertEquals(Time.class, converted.getClass());
+        assertEquals(Time.valueOf(LocalTime.of(12, 34, 56, 123456789)), converted);
+    }
+
+    @Test
+    public void testConvertValueLeavesInvalidTimeTextUnchanged() {
+        DuckDBDialect dialect = createDialect();
+        AttributeDescriptor descriptor = mockDescriptor(Time.class);
+
+        Object converted = dialect.convertValue("not-a-time", descriptor);
+
+        assertNull(converted);
     }
 
     @Test
@@ -266,6 +391,14 @@ public class DuckDBDialectTest {
             store.dispose();
             DuckDBTestUtils.deleteRecursively(directory);
         }
+    }
+
+    private AttributeDescriptor mockDescriptor(Class<?> binding) {
+        AttributeDescriptor descriptor = Mockito.mock(AttributeDescriptor.class);
+        AttributeType attributeType = Mockito.mock(AttributeType.class);
+        Mockito.when(descriptor.getType()).thenReturn(attributeType);
+        Mockito.doReturn(binding).when(attributeType).getBinding();
+        return descriptor;
     }
 
     private static final class ParentMappingDuckDBDialect extends DuckDBDialect {

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTemporalVariantsOnlineTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTemporalVariantsOnlineTest.java
@@ -1,0 +1,157 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.duckdb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.geotools.api.data.Query;
+import org.geotools.api.data.SimpleFeatureSource;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Expression;
+import org.geotools.api.filter.sort.SortOrder;
+import org.geotools.api.filter.temporal.Before;
+import org.geotools.api.filter.temporal.During;
+import org.geotools.api.filter.temporal.TEquals;
+import org.geotools.api.temporal.Instant;
+import org.geotools.api.temporal.Period;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.jdbc.JDBCTestSetup;
+import org.geotools.jdbc.JDBCTestSupport;
+import org.geotools.temporal.object.DefaultInstant;
+import org.geotools.temporal.object.DefaultPeriod;
+import org.geotools.temporal.object.DefaultPosition;
+import org.junit.Test;
+
+/** Online end-to-end checks for DuckDB temporal variants. */
+public class DuckDBTemporalVariantsOnlineTest extends JDBCTestSupport {
+
+    @Override
+    protected JDBCTestSetup createTestSetup() {
+        return new DuckDBTemporalVariantsTestSetup();
+    }
+
+    @Test
+    public void testFeatureCollectionReadExposesSqlTemporalTypes() throws Exception {
+        SimpleFeatureSource source = dataStore.getFeatureSource(tname(DuckDBTemporalVariantsTestSetup.TABLE));
+        Query query = new Query(source.getName().getLocalPart());
+        query.setSortBy(dataStore.getFilterFactory().sort(aname("ts_plain"), SortOrder.ASCENDING));
+
+        SimpleFeatureCollection collection = source.getFeatures(query);
+        assertEquals(3, collection.size());
+
+        try (SimpleFeatureIterator it = collection.features()) {
+            assertTrue(it.hasNext());
+            SimpleFeature feature = it.next();
+            assertEquals(
+                    Timestamp.class, feature.getAttribute(aname("ts_plain")).getClass());
+            assertEquals(Timestamp.class, feature.getAttribute(aname("ts_s")).getClass());
+            assertEquals(Timestamp.class, feature.getAttribute(aname("ts_ms")).getClass());
+            assertEquals(Timestamp.class, feature.getAttribute(aname("ts_ns")).getClass());
+            assertEquals(Timestamp.class, feature.getAttribute(aname("ts_tz")).getClass());
+            assertEquals(
+                    Timestamp.class, feature.getAttribute(aname("ts_tz_long")).getClass());
+            assertEquals(Time.class, feature.getAttribute(aname("t_plain")).getClass());
+            assertEquals(Time.class, feature.getAttribute(aname("t_ns")).getClass());
+            assertEquals(Time.class, feature.getAttribute(aname("t_tz")).getClass());
+            assertEquals(Time.class, feature.getAttribute(aname("t_tz_long")).getClass());
+        }
+    }
+
+    @Test
+    public void testTemporalFiltersOnAllTimestampVariants() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+
+        assertIds(ff.after(ff.property(aname("ts_plain")), ff.literal("2020-01-01 12:00:00")), 2, 3);
+        assertIds(ff.after(ff.property(aname("ts_s")), ff.literal("2020-01-01 12:00:00")), 2, 3);
+        assertIds(ff.after(ff.property(aname("ts_ms")), ff.literal("2020-01-01 12:00:00")), 2, 3);
+        assertIds(ff.after(ff.property(aname("ts_ns")), ff.literal("2020-01-01 12:00:00")), 2, 3);
+        assertIds(ff.after(ff.property(aname("ts_tz")), ff.literal("2020-01-01 12:00:00")), 2, 3);
+        assertIds(ff.after(ff.property(aname("ts_tz_long")), ff.literal("2020-01-01 12:00:00")), 2, 3);
+    }
+
+    @Test
+    public void testBeforeDuringAndEqualsTemporalFilters() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+
+        Before before = ff.before(ff.property(aname("ts_ns")), ff.literal("2020-01-03 00:00:00"));
+        assertIds(before, 1, 2);
+
+        During during = ff.during(
+                ff.property(aname("ts_tz_long")), ff.literal(period("2020-01-01 12:00:00", "2020-01-03 00:00:00")));
+        assertIds(during, 2, 3);
+
+        TEquals equalsSecondPrecision = ff.tequals(ff.property(aname("ts_s")), ff.literal("2020-01-02 00:00:00"));
+        assertIds(equalsSecondPrecision, 2);
+
+        TEquals equalsLongTimezone = ff.tequals(ff.property(aname("ts_tz_long")), ff.literal("2020-01-02 00:00:00"));
+        assertIds(equalsLongTimezone, 2);
+    }
+
+    @Test
+    public void testTimeFamilyComparisonFilters() throws Exception {
+        FilterFactory ff = dataStore.getFilterFactory();
+        Expression noon = ff.literal(Time.valueOf("12:00:00"));
+
+        assertIds(ff.greater(ff.property(aname("t_plain")), noon), 3);
+        assertIds(ff.greater(ff.property(aname("t_ns")), noon), 2, 3);
+        assertIds(ff.greater(ff.property(aname("t_tz")), noon), 3);
+        assertIds(ff.greater(ff.property(aname("t_tz_long")), noon), 3);
+    }
+
+    private void assertIds(Filter filter, int... expectedIds) throws Exception {
+        SimpleFeatureSource source = dataStore.getFeatureSource(tname(DuckDBTemporalVariantsTestSetup.TABLE));
+        Query query = new Query(source.getName().getLocalPart(), filter);
+        query.setSortBy(dataStore.getFilterFactory().sort(aname("ts_plain"), SortOrder.ASCENDING));
+        SimpleFeatureCollection collection = source.getFeatures(query);
+        assertEquals(expectedIds.length, collection.size());
+
+        try (SimpleFeatureIterator it = collection.features()) {
+            int idx = 0;
+            while (it.hasNext()) {
+                SimpleFeature feature = it.next();
+                assertEquals(expectedIds[idx++], extractFeatureId(feature));
+            }
+        }
+    }
+
+    private int extractFeatureId(SimpleFeature feature) {
+        String featureId = feature.getID();
+        int separator = featureId.lastIndexOf('.');
+        return Integer.parseInt(featureId.substring(separator + 1));
+    }
+
+    private Date date(String value) throws ParseException {
+        return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse(value);
+    }
+
+    private Instant instant(String value) throws ParseException {
+        return new DefaultInstant(new DefaultPosition(date(value)));
+    }
+
+    private Period period(String start, String end) throws ParseException {
+        return new DefaultPeriod(instant(start), instant(end));
+    }
+}

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTemporalVariantsTestSetup.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTemporalVariantsTestSetup.java
@@ -49,61 +49,74 @@ public class DuckDBTemporalVariantsTestSetup extends JDBCDelegatingTestSetup {
     }
 
     protected void createTemporalVariantsTable() throws Exception {
-        run("CREATE TABLE \"" + TABLE + "\" ("
-                + "\"id\" INTEGER PRIMARY KEY, "
-                + "\"ts_plain\" TIMESTAMP, "
-                + "\"ts_s\" TIMESTAMP_S, "
-                + "\"ts_ms\" TIMESTAMP_MS, "
-                + "\"ts_ns\" TIMESTAMP_NS, "
-                + "\"ts_tz\" TIMESTAMPTZ, "
-                + "\"ts_tz_long\" TIMESTAMP WITH TIME ZONE, "
-                + "\"t_plain\" TIME, "
-                + "\"t_ns\" TIME_NS, "
-                + "\"t_tz\" TIMETZ, "
-                + "\"t_tz_long\" TIME WITH TIME ZONE"
-                + ")");
+        run(
+                """
+                CREATE TABLE "%s" (
+                    "id" INTEGER PRIMARY KEY,
+                    "ts_plain" TIMESTAMP,
+                    "ts_s" TIMESTAMP_S,
+                    "ts_ms" TIMESTAMP_MS,
+                    "ts_ns" TIMESTAMP_NS,
+                    "ts_tz" TIMESTAMPTZ,
+                    "ts_tz_long" TIMESTAMP WITH TIME ZONE,
+                    "t_plain" TIME,
+                    "t_ns" TIME_NS,
+                    "t_tz" TIMETZ,
+                    "t_tz_long" TIME WITH TIME ZONE
+                )
+                """
+                        .formatted(TABLE));
 
-        run("INSERT INTO \"" + TABLE + "\" VALUES "
-                + "(1, "
-                + "TIMESTAMP '2020-01-01 00:00:00', "
-                + "CAST('2020-01-01 00:00:00' AS TIMESTAMP_S), "
-                + "CAST('2020-01-01 00:00:00.100' AS TIMESTAMP_MS), "
-                + "CAST('2020-01-01 00:00:00.100000000' AS TIMESTAMP_NS), "
-                + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMPTZ), "
-                + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMP WITH TIME ZONE), "
-                + "TIME '10:00:00', "
-                + "CAST('10:00:00.100000000' AS TIME_NS), "
-                + "CAST('10:00:00+00' AS TIMETZ), "
-                + "CAST('10:00:00+00' AS TIME WITH TIME ZONE)"
-                + ")");
+        run(
+                """
+                INSERT INTO "%s" VALUES
+                    (1,
+                    TIMESTAMP '2020-01-01 00:00:00',
+                    CAST('2020-01-01 00:00:00' AS TIMESTAMP_S),
+                    CAST('2020-01-01 00:00:00.100' AS TIMESTAMP_MS),
+                    CAST('2020-01-01 00:00:00.100000000' AS TIMESTAMP_NS),
+                    CAST('2020-01-01 00:00:00+00' AS TIMESTAMPTZ),
+                    CAST('2020-01-01 00:00:00+00' AS TIMESTAMP WITH TIME ZONE),
+                    TIME '10:00:00',
+                    CAST('10:00:00.100000000' AS TIME_NS),
+                    CAST('10:00:00+00' AS TIMETZ),
+                    CAST('10:00:00+00' AS TIME WITH TIME ZONE))
+                """
+                        .formatted(TABLE));
 
-        run("INSERT INTO \"" + TABLE + "\" VALUES "
-                + "(2, "
-                + "TIMESTAMP '2020-01-02 00:00:00', "
-                + "CAST('2020-01-02 00:00:00' AS TIMESTAMP_S), "
-                + "CAST('2020-01-02 00:00:00.200' AS TIMESTAMP_MS), "
-                + "CAST('2020-01-02 00:00:00.200000000' AS TIMESTAMP_NS), "
-                + "CAST('2020-01-02 00:00:00+00' AS TIMESTAMPTZ), "
-                + "CAST('2020-01-02 00:00:00+00' AS TIMESTAMP WITH TIME ZONE), "
-                + "TIME '12:00:00', "
-                + "CAST('12:00:00.200000000' AS TIME_NS), "
-                + "CAST('12:00:00+00' AS TIMETZ), "
-                + "CAST('12:00:00+00' AS TIME WITH TIME ZONE)"
-                + ")");
+        run(
+                """
+                INSERT INTO "%s" VALUES
+                    (2,
+                    TIMESTAMP '2020-01-02 00:00:00',
+                    CAST('2020-01-02 00:00:00' AS TIMESTAMP_S),
+                    CAST('2020-01-02 00:00:00.200' AS TIMESTAMP_MS),
+                    CAST('2020-01-02 00:00:00.200000000' AS TIMESTAMP_NS),
+                    CAST('2020-01-02 00:00:00+00' AS TIMESTAMPTZ),
+                    CAST('2020-01-02 00:00:00+00' AS TIMESTAMP WITH TIME ZONE),
+                    TIME '12:00:00',
+                    CAST('12:00:00.200000000' AS TIME_NS),
+                    CAST('12:00:00+00' AS TIMETZ),
+                    CAST('12:00:00+00' AS TIME WITH TIME ZONE))
+                """
+                        .formatted(TABLE));
 
-        run("INSERT INTO \"" + TABLE + "\" VALUES "
-                + "(3, "
-                + "TIMESTAMP '2020-01-03 00:00:00', "
-                + "CAST('2020-01-03 00:00:00' AS TIMESTAMP_S), "
-                + "CAST('2020-01-03 00:00:00.300' AS TIMESTAMP_MS), "
-                + "CAST('2020-01-03 00:00:00.300000000' AS TIMESTAMP_NS), "
-                + "CAST('2020-01-03 00:00:00+00' AS TIMESTAMPTZ), "
-                + "CAST('2020-01-03 00:00:00+00' AS TIMESTAMP WITH TIME ZONE), "
-                + "TIME '14:00:00', "
-                + "CAST('14:00:00.300000000' AS TIME_NS), "
-                + "CAST('14:00:00+00' AS TIMETZ), "
-                + "CAST('14:00:00+00' AS TIME WITH TIME ZONE)"
-                + ")");
+        run(
+                """
+                INSERT INTO "%s" VALUES
+                    (3,
+                    TIMESTAMP '2020-01-03 00:00:00',
+                    CAST('2020-01-03 00:00:00' AS TIMESTAMP_S),
+                    CAST('2020-01-03 00:00:00.300' AS TIMESTAMP_MS),
+                    CAST('2020-01-03 00:00:00.300000000' AS TIMESTAMP_NS),
+                    CAST('2020-01-03 00:00:00+00' AS TIMESTAMPTZ),
+                    CAST('2020-01-03 00:00:00+00' AS TIMESTAMP WITH TIME ZONE),
+                    TIME '14:00:00',
+                    CAST('14:00:00.300000000' AS TIME_NS),
+                    CAST('14:00:00+00' AS TIMETZ),
+                    CAST('14:00:00+00' AS TIME WITH TIME ZONE))
+                """
+                        .formatted(TABLE));
     }
 
     private void dropTemporalVariantsTable() {

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTemporalVariantsTestSetup.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTemporalVariantsTestSetup.java
@@ -1,0 +1,112 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2002-2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.data.duckdb;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.geotools.jdbc.JDBCDelegatingTestSetup;
+
+/** Online setup that adds DuckDB temporal variant columns for end-to-end temporal tests. */
+public class DuckDBTemporalVariantsTestSetup extends JDBCDelegatingTestSetup {
+
+    public static final String TABLE = "temporal_variants_online";
+
+    protected DuckDBTemporalVariantsTestSetup() {
+        super(new DuckDBTestSetup());
+    }
+
+    @Override
+    protected Connection getConnection() throws SQLException, IOException {
+        return ((DuckDBTestSetup) delegate).getConnection();
+    }
+
+    @Override
+    protected void setUpData() throws Exception {
+        super.setUpData();
+        dropTemporalVariantsTable();
+        createTemporalVariantsTable();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        dropTemporalVariantsTable();
+    }
+
+    protected void createTemporalVariantsTable() throws Exception {
+        run("CREATE TABLE \"" + TABLE + "\" ("
+                + "\"id\" INTEGER PRIMARY KEY, "
+                + "\"ts_plain\" TIMESTAMP, "
+                + "\"ts_s\" TIMESTAMP_S, "
+                + "\"ts_ms\" TIMESTAMP_MS, "
+                + "\"ts_ns\" TIMESTAMP_NS, "
+                + "\"ts_tz\" TIMESTAMPTZ, "
+                + "\"ts_tz_long\" TIMESTAMP WITH TIME ZONE, "
+                + "\"t_plain\" TIME, "
+                + "\"t_ns\" TIME_NS, "
+                + "\"t_tz\" TIMETZ, "
+                + "\"t_tz_long\" TIME WITH TIME ZONE"
+                + ")");
+
+        run("INSERT INTO \"" + TABLE + "\" VALUES "
+                + "(1, "
+                + "TIMESTAMP '2020-01-01 00:00:00', "
+                + "CAST('2020-01-01 00:00:00' AS TIMESTAMP_S), "
+                + "CAST('2020-01-01 00:00:00.100' AS TIMESTAMP_MS), "
+                + "CAST('2020-01-01 00:00:00.100000000' AS TIMESTAMP_NS), "
+                + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMPTZ), "
+                + "CAST('2020-01-01 00:00:00+00' AS TIMESTAMP WITH TIME ZONE), "
+                + "TIME '10:00:00', "
+                + "CAST('10:00:00.100000000' AS TIME_NS), "
+                + "CAST('10:00:00+00' AS TIMETZ), "
+                + "CAST('10:00:00+00' AS TIME WITH TIME ZONE)"
+                + ")");
+
+        run("INSERT INTO \"" + TABLE + "\" VALUES "
+                + "(2, "
+                + "TIMESTAMP '2020-01-02 00:00:00', "
+                + "CAST('2020-01-02 00:00:00' AS TIMESTAMP_S), "
+                + "CAST('2020-01-02 00:00:00.200' AS TIMESTAMP_MS), "
+                + "CAST('2020-01-02 00:00:00.200000000' AS TIMESTAMP_NS), "
+                + "CAST('2020-01-02 00:00:00+00' AS TIMESTAMPTZ), "
+                + "CAST('2020-01-02 00:00:00+00' AS TIMESTAMP WITH TIME ZONE), "
+                + "TIME '12:00:00', "
+                + "CAST('12:00:00.200000000' AS TIME_NS), "
+                + "CAST('12:00:00+00' AS TIMETZ), "
+                + "CAST('12:00:00+00' AS TIME WITH TIME ZONE)"
+                + ")");
+
+        run("INSERT INTO \"" + TABLE + "\" VALUES "
+                + "(3, "
+                + "TIMESTAMP '2020-01-03 00:00:00', "
+                + "CAST('2020-01-03 00:00:00' AS TIMESTAMP_S), "
+                + "CAST('2020-01-03 00:00:00.300' AS TIMESTAMP_MS), "
+                + "CAST('2020-01-03 00:00:00.300000000' AS TIMESTAMP_NS), "
+                + "CAST('2020-01-03 00:00:00+00' AS TIMESTAMPTZ), "
+                + "CAST('2020-01-03 00:00:00+00' AS TIMESTAMP WITH TIME ZONE), "
+                + "TIME '14:00:00', "
+                + "CAST('14:00:00.300000000' AS TIME_NS), "
+                + "CAST('14:00:00+00' AS TIMETZ), "
+                + "CAST('14:00:00+00' AS TIME WITH TIME ZONE)"
+                + ")");
+    }
+
+    private void dropTemporalVariantsTable() {
+        ((DuckDBTestSetup) delegate).removeTable(TABLE);
+    }
+}


### PR DESCRIPTION
[![GEOT-7905](https://badgen.net/badge/JIRA/GEOT-7905/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7905) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

JIRA ticket:
https://osgeo-org.atlassian.net/browse/GEOT-7905

A found issue on DuckDB store makes only TIMESTAMP/TIMESTAMP WITH TIME ZONE had explicit bindigns in the dialect, meanwhile TIMESTAMP_NS (and other TIMESTAMP* variants) depends on metadata/type-name seems to be failing to surface as a GeoServer-recognized time attribute.

DuckDB exposes extended temporal types through JDBC TYPE_NAME values that do not always match the base JDBC type names. GeoTools needs to map these names consistently during schema discovery so feature type creation and temporal dimension support work reliably.

This PR extends DuckDB temporal metadata handling so GeoTools can correclty handle extended temporal types:
- TIME_NS
- TIMETZ
- TIME WITH TIME ZONE
- TIMESTAMP_S
- TIMESTAMP_MS
- TIMESTAMP_NS
- TIMESTAMPTZ
- TIMESTAMP WITH TIME ZONE
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 