### PR TITLE
[GEOT-7899] and [GEOT-7900] Speed up attributes lookup

### DIFF
--- a/modules/library/main/src/main/java/org/geotools/feature/AttributeTypeBuilder.java
+++ b/modules/library/main/src/main/java/org/geotools/feature/AttributeTypeBuilder.java
@@ -85,6 +85,15 @@ import org.locationtech.jts.geom.Geometry;
  */
 public class AttributeTypeBuilder {
 
+    /**
+     * Looking up the feature type factory incurs in synchronization overhead, so we cache the default one here for use
+     * in the no-arg constructor and as a default
+     */
+    private static final FeatureTypeFactory DEFAULT_FEATURE_TYPE_FACTORY =
+            CommonFactoryFinder.getFeatureTypeFactory(null);
+
+    private static final FilterFactory DEFAULT_FILTER_FACTORY = CommonFactoryFinder.getFilterFactory(null);
+
     /** factory */
     protected FeatureTypeFactory factory;
 
@@ -147,7 +156,7 @@ public class AttributeTypeBuilder {
     protected Map<Object, Object> userData = null;
 
     /** filter factory */
-    protected FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+    protected static final FilterFactory ff = DEFAULT_FILTER_FACTORY;
 
     /** The list of valid values for attributes described by this type (enumeration). */
     private List<?> options;
@@ -157,7 +166,7 @@ public class AttributeTypeBuilder {
 
     /** Constructs the builder. */
     public AttributeTypeBuilder() {
-        this(CommonFactoryFinder.getFeatureTypeFactory(null));
+        this(DEFAULT_FEATURE_TYPE_FACTORY);
         init();
     }
 

--- a/modules/library/main/src/main/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactory.java
+++ b/modules/library/main/src/main/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactory.java
@@ -53,30 +53,6 @@ public class SimpleFeaturePropertyAccessorFactory implements PropertyAccessorFac
 
     static Pattern idPattern = Pattern.compile("@(\\w+:)?id");
 
-    private static final String NAME_START_CHAR = ":"
-            + "A-Z"
-            + "_"
-            + "a-z"
-            + "\\u00c0-\\u00d6"
-            + "\\u00d8-\\u00f6"
-            + "\\u00f8-\\u02ff"
-            + "\\u0370-\\u037d"
-            + "\\u037f-\\u1fff"
-            + "\\u200c-\\u200d"
-            + "\\u2070-\\u218f"
-            + "\\u2c00-\\u2fef"
-            + "\\u3001-\\ud7ff"
-            + "\\uf900-\\ufdcf"
-            + "\\ufdf0-\\ufffd";
-    private static final String NAME_CHAR =
-            NAME_START_CHAR + "\\-" + "\\." + "0-9" + "\\u00b7" + "\\u0300-\\u036f" + "\\u203f-\\u2040";
-    /**
-     * Based on definition of valid xml element name at http://www.w3.org/TR/xml/#NT-Name, eventually inclusive of
-     * namespace, plus an optional [1] at the end and no @ anywhere in the string
-     */
-    static final Pattern propertyPattern =
-            Pattern.compile("^(?!@)([" + NAME_START_CHAR + "][" + NAME_CHAR + "]*)(\\[1])?$");
-
     @Override
     public PropertyAccessor createPropertyAccessor(Class type, String xpath, Class target, Hints hints) {
 
@@ -90,12 +66,8 @@ public class SimpleFeaturePropertyAccessorFactory implements PropertyAccessorFac
         // check for fid access
         if (idPattern.matcher(xpath).matches()) return FID_ACCESS;
 
-        // check for simple property acess
-        if (propertyPattern.matcher(xpath).matches()) {
-            return ATTRIBUTE_ACCESS;
-        }
-
-        return null;
+        // check for simple property access
+        return ATTRIBUTE_ACCESS;
     }
 
     /**

--- a/modules/library/main/src/test/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactoryTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorFactoryTest.java
@@ -16,10 +16,12 @@
  */
 package org.geotools.filter.expression;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import java.util.Map;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -36,21 +38,14 @@ public class SimpleFeaturePropertyAccessorFactoryTest {
     public void test() {
 
         // make sure features are supported
-        Assert.assertNotNull(factory.createPropertyAccessor(SimpleFeature.class, "xpath", null, null));
-        Assert.assertNotNull(factory.createPropertyAccessor(SimpleFeatureType.class, "xpath", null, null));
-        Assert.assertNull(factory.createPropertyAccessor(Map.class, "xpath", null, null));
+        assertNotNull(factory.createPropertyAccessor(SimpleFeature.class, "xpath", null, null));
+        assertNotNull(factory.createPropertyAccessor(SimpleFeatureType.class, "xpath", null, null));
+        assertNull(factory.createPropertyAccessor(Map.class, "xpath", null, null));
 
-        // make sure only simple xpath
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeature.class, "@xpath", null, null));
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeatureType.class, "@xpath", null, null));
+        // check for default geometry
+        assertNotNull(factory.createPropertyAccessor(SimpleFeature.class, "\"\"", null, null));
 
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeature.class, "/xpath", null, null));
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeatureType.class, "/xpath", null, null));
-
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeature.class, "*[0]", null, null));
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeatureType.class, "*[0]", null, null));
-
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeature.class, "===", null, null));
-        Assert.assertNull(factory.createPropertyAccessor(SimpleFeature.class, "34x?<>", null, null));
+        // any other property value will be tested against the simple feature contents by the accessor,
+        // an attribute name in simple features can be anything
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/expression/SimpleFeaturePropertyAccessorTest.java
@@ -16,6 +16,11 @@
  */
 package org.geotools.filter.expression;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import org.geotools.api.feature.IllegalAttributeException;
 import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
@@ -45,6 +50,7 @@ public class SimpleFeaturePropertyAccessorTest {
         typeBuilder.add("foo", Integer.class);
         typeBuilder.add("bar", Double.class);
         typeBuilder.add(COMPLEX_PROPERTY, Double.class);
+        typeBuilder.add("a@b-c", Double.class);
 
         type = typeBuilder.buildFeatureType();
 
@@ -52,6 +58,7 @@ public class SimpleFeaturePropertyAccessorTest {
         builder.add(Integer.valueOf(1));
         builder.add(Double.valueOf(2.0));
         builder.add(Double.valueOf(3.0));
+        builder.add(Double.valueOf(4));
 
         feature = builder.buildFeature("fid");
         accessor = SimpleFeaturePropertyAccessorFactory.ATTRIBUTE_ACCESS;
@@ -59,45 +66,48 @@ public class SimpleFeaturePropertyAccessorTest {
 
     @Test
     public void testCanHandle() {
-        Assert.assertTrue(accessor.canHandle(feature, "foo", null));
-        Assert.assertTrue(accessor.canHandle(feature, "bar", null));
+        assertTrue(accessor.canHandle(feature, "foo", null));
+        assertTrue(accessor.canHandle(feature, "bar", null));
+        assertTrue(accessor.canHandle(feature, "a@b-c", null));
 
-        Assert.assertFalse(accessor.canHandle(feature, "illegal", null));
+        assertFalse(accessor.canHandle(feature, "illegal", null));
     }
 
     @Test
     public void testCanHandleType() {
-        Assert.assertTrue(accessor.canHandle(type, "foo", null));
-        Assert.assertTrue(accessor.canHandle(type, "sf:foo", null));
-        Assert.assertTrue(accessor.canHandle(type, "foo[1]", null));
-        Assert.assertTrue(accessor.canHandle(type, "sf:foo[1]", null));
-        Assert.assertTrue(accessor.canHandle(type, "bar", null));
-        Assert.assertTrue(accessor.canHandle(type, COMPLEX_PROPERTY, null));
+        assertTrue(accessor.canHandle(type, "foo", null));
+        assertTrue(accessor.canHandle(type, "sf:foo", null));
+        assertTrue(accessor.canHandle(type, "foo[1]", null));
+        assertTrue(accessor.canHandle(type, "sf:foo[1]", null));
+        assertTrue(accessor.canHandle(type, "bar", null));
+        assertTrue(accessor.canHandle(type, COMPLEX_PROPERTY, null));
+        assertTrue(accessor.canHandle(type, "foo", null));
+        assertTrue(accessor.canHandle(type, "a@b-c", null));
 
-        Assert.assertFalse(accessor.canHandle(type, "illegal", null));
-        Assert.assertFalse(accessor.canHandle(type, "sf:foo[0]", null));
-        Assert.assertFalse(accessor.canHandle(type, "sf:foo[2]", null));
+        assertFalse(accessor.canHandle(type, "illegal", null));
+        assertFalse(accessor.canHandle(type, "sf:foo[0]", null));
+        assertFalse(accessor.canHandle(type, "sf:foo[2]", null));
     }
 
     @Test
     public void testGet() {
-        Assert.assertEquals(Integer.valueOf(1), accessor.get(feature, "foo", null));
-        Assert.assertEquals(Integer.valueOf(1), accessor.get(feature, "sf:foo", null));
-        Assert.assertEquals(Integer.valueOf(1), accessor.get(feature, "foo[1]", null));
-        Assert.assertEquals(Integer.valueOf(1), accessor.get(feature, "sf:foo[1]", null));
-        Assert.assertEquals(Double.valueOf(2.0), accessor.get(feature, "bar", null));
-        Assert.assertEquals(Double.valueOf(3.0), accessor.get(feature, COMPLEX_PROPERTY, null));
-        Assert.assertEquals("fid", SimpleFeaturePropertyAccessorFactory.FID_ACCESS.get(feature, "@id", null));
-        Assert.assertEquals("fid", SimpleFeaturePropertyAccessorFactory.FID_ACCESS.get(feature, "@gml:id", null));
-        Assert.assertFalse(accessor.canHandle(feature, "illegal", null));
-        Assert.assertNull(accessor.get(feature, "illegal", null));
+        assertEquals(Integer.valueOf(1), accessor.get(feature, "foo", null));
+        assertEquals(Integer.valueOf(1), accessor.get(feature, "sf:foo", null));
+        assertEquals(Integer.valueOf(1), accessor.get(feature, "foo[1]", null));
+        assertEquals(Integer.valueOf(1), accessor.get(feature, "sf:foo[1]", null));
+        assertEquals(Double.valueOf(2.0), accessor.get(feature, "bar", null));
+        assertEquals(Double.valueOf(3.0), accessor.get(feature, COMPLEX_PROPERTY, null));
+        assertEquals("fid", SimpleFeaturePropertyAccessorFactory.FID_ACCESS.get(feature, "@id", null));
+        assertEquals("fid", SimpleFeaturePropertyAccessorFactory.FID_ACCESS.get(feature, "@gml:id", null));
+        assertFalse(accessor.canHandle(feature, "illegal", null));
+        assertNull(accessor.get(feature, "illegal", null));
     }
 
     @Test
     public void testGetType() {
-        Assert.assertEquals(type.getDescriptor("foo"), accessor.get(type, "foo", null));
-        Assert.assertEquals(type.getDescriptor("bar"), accessor.get(type, "bar", null));
-        Assert.assertNull(accessor.get(type, "illegal", null));
+        assertEquals(type.getDescriptor("foo"), accessor.get(type, "foo", null));
+        assertEquals(type.getDescriptor("bar"), accessor.get(type, "bar", null));
+        assertNull(accessor.get(type, "illegal", null));
     }
 
     @Test
@@ -107,14 +117,14 @@ public class SimpleFeaturePropertyAccessorTest {
         } catch (IllegalAttributeException e) {
             Assert.fail();
         }
-        Assert.assertEquals(Integer.valueOf(2), accessor.get(feature, "foo", null));
+        assertEquals(Integer.valueOf(2), accessor.get(feature, "foo", null));
 
         try {
             accessor.set(feature, "bar", Double.valueOf(1.0), null);
         } catch (IllegalAttributeException e) {
             Assert.fail();
         }
-        Assert.assertEquals(Double.valueOf(1.0), accessor.get(feature, "bar", null));
+        assertEquals(Double.valueOf(1.0), accessor.get(feature, "bar", null));
         try {
             accessor.set(feature, "@id", "fid2", null);
             Assert.fail("Should have thrown exception trying to set fid");
@@ -149,8 +159,7 @@ public class SimpleFeaturePropertyAccessorTest {
         b.set("g2", p);
         SimpleFeature feature = b.buildFeature(null);
 
-        Assert.assertNull(feature.getDefaultGeometry());
-        Assert.assertEquals(
-                p, SimpleFeaturePropertyAccessorFactory.DEFAULT_GEOMETRY_ACCESS.get(feature, "", Geometry.class));
+        assertNull(feature.getDefaultGeometry());
+        assertEquals(p, SimpleFeaturePropertyAccessorFactory.DEFAULT_GEOMETRY_ACCESS.get(feature, "", Geometry.class));
     }
 }


### PR DESCRIPTION
[![GEOT-7899](https://badgen.net/badge/JIRA/GEOT-7899/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7899) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Significantly speeds up simple feature attribute speed, and provides access to all simple feature attributes, no matter how weird their name might be.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 