### PR TITLE
[GEOT-7907] serialization of JTS geometries to a JsonNode fails

### DIFF
--- a/modules/unsupported/geojson-core/src/main/java/com/bedatadriven/jackson/datatype/jts/serialization/GeometrySerializer.java
+++ b/modules/unsupported/geojson-core/src/main/java/com/bedatadriven/jackson/datatype/jts/serialization/GeometrySerializer.java
@@ -54,7 +54,7 @@ import tools.jackson.databind.ValueSerializer;
  */
 public class GeometrySerializer extends ValueSerializer<Geometry> {
 
-    private RoundingMode roundingMode = RoundingMode.HALF_UP;
+    private final RoundingMode roundingMode = RoundingMode.HALF_UP;
     NumberFormat format = NumberFormat.getNumberInstance(Locale.ENGLISH);
 
     int maximumFractionDigits;
@@ -234,7 +234,7 @@ public class GeometrySerializer extends ValueSerializer<Geometry> {
     }
 
     private void writeNumber(final JsonGenerator jgen, final double n) {
-        jgen.writeNumber(format.format(n));
+        jgen.writeRawValue(format.format(n));
     }
 
     public RoundingMode getRoundingMode() {

--- a/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
@@ -22,6 +22,7 @@ package com.bedatadriven.jackson.datatype.jts;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ObjectWriter;
 import tools.jackson.databind.json.JsonMapper;
@@ -81,11 +83,17 @@ public abstract class BaseJtsModuleTest<T extends Geometry> {
         assertThat(toJson(geometry), equalTo(geometryAsGeoJson));
     }
 
-    protected String toJson(Object value) throws IOException {
+    @Test
+    public void shouldSerializeAsJsonNOde() {
+        var node = mapper.valueToTree(geometry);
+        assertThat(node.toString(), equalTo(geometryAsGeoJson));
+    }
+
+    protected String toJson(Object value) {
         return writer.writeValueAsString(value);
     }
 
-    protected void assertRoundTrip(T geom) throws IOException {
+    protected void assertRoundTrip(T geom) {
         String json = writer.writeValueAsString(geom);
 
         Geometry regeom = mapper.readerFor(Geometry.class).readValue(json);

--- a/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ObjectWriter;
 import tools.jackson.databind.json.JsonMapper;
@@ -82,7 +83,7 @@ public abstract class BaseJtsModuleTest<T extends Geometry> {
 
     @Test
     public void shouldSerializeAsJsonNOde() {
-        var node = mapper.valueToTree(geometry);
+        JsonNode node = mapper.valueToTree(geometry);
         assertThat(node.toString(), equalTo(geometryAsGeoJson));
     }
 

--- a/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/BaseJtsModuleTest.java
@@ -22,16 +22,13 @@ package com.bedatadriven.jackson.datatype.jts;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
-import java.io.IOException;
 import java.math.RoundingMode;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
-import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.ObjectWriter;
 import tools.jackson.databind.json.JsonMapper;


### PR DESCRIPTION
[![GEOT-7907](https://badgen.net/badge/JIRA/GEOT-7907/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7907) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

After the upgrade to Jackson 3, serialization of JTS geometries to a JsonNode fails with the following exception:

```
Caused by: tools.jackson.core.exc.StreamWriteException: `tools.jackson.databind.node.TreeBuildingGenerator` does not support `writeNumber(String)`, must write Numbers as typed
 at [No location information]
	at tools.jackson.core.JsonGenerator._constructWriteException(JsonGenerator.java:2455)
	at tools.jackson.core.JsonGenerator._constructWriteException(JsonGenerator.java:2459)
	at tools.jackson.databind.node.TreeBuildingGenerator.writeNumber(TreeBuildingGenerator.java:449)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.writeNumber(GeometrySerializer.java:237)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.writePointCoords(GeometrySerializer.java:226)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.writeLineStringCoords(GeometrySerializer.java:200)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.writePolygonCoordinates(GeometrySerializer.java:187)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.writePolygon(GeometrySerializer.java:180)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.writeGeometry(GeometrySerializer.java:81)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.serialize(GeometrySerializer.java:75)
	at com.bedatadriven.jackson.datatype.jts.serialization.GeometrySerializer.serialize(GeometrySerializer.java:55)
	at tools.jackson.databind.ser.SerializationContextExt._serialize(SerializationContextExt.java:456)
	at tools.jackson.databind.ser.SerializationContextExt.valueToTree(SerializationContextExt.java:194)
	at tools.jackson.databind.ObjectMapper.valueToTree(ObjectMapper.java:1387)
```
  
This problem, however, is easily solved with using a slightly different method.

This PR does it and adds test for this behaviour.


<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 