### PR TITLE
[GEOT-7908] GeoTIFFWriter should provide a reference image when building the image output stream

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverageWriter.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/AbstractGridCoverageWriter.java
@@ -16,11 +16,18 @@
  */
 package org.geotools.coverage.grid.io;
 
+import it.geosolutions.io.output.adapter.OutputStreamAdapter;
+import java.awt.image.RenderedImage;
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.stream.ImageOutputStream;
 import org.geotools.api.coverage.grid.GridCoverageWriter;
+import org.geotools.image.io.ImageIOExt;
+import org.geotools.util.URLs;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
@@ -46,10 +53,45 @@ public abstract class AbstractGridCoverageWriter implements GridCoverageWriter {
     protected Hints hints = GeoTools.getDefaultHints();
 
     /** The destination {@link ImageOutputStream}. */
-    protected ImageOutputStream outStream = null;
+    private ImageOutputStream outStream = null;
 
     /** Default constructor for an {@link AbstractGridCoverageWriter}. */
     public AbstractGridCoverageWriter() {}
+
+    /**
+     * Computes the {@link ImageOutputStream} to write the geotiff to, based on the type of the destination object. The
+     * destination can be a {@link File}, a {@link URL}, an {@link OutputStream} or an {@link ImageOutputStream}.
+     *
+     * @param image The image that will be written
+     * @return The output stream to write the GeoTIFF to.
+     * @throws IOException Might be thrown during the construction of the output stream, for instance if the destination
+     *     is a file and it cannot be created.
+     */
+    @SuppressWarnings("PMD.CloseResource")
+    protected ImageOutputStream getImageOutputStream(RenderedImage image) throws IOException {
+        if (this.outStream != null) return this.outStream;
+
+        if (destination instanceof File) {
+            this.outStream = ImageIOExt.createImageOutputStream(image, destination);
+        } else if (destination instanceof URL dest) {
+            if (dest.getProtocol().equalsIgnoreCase("file"))
+                this.outStream = ImageIOExt.createImageOutputStream(image, URLs.urlToFile(dest));
+            else this.outStream = ImageIOExt.createImageOutputStream(image, destination);
+        } else if (destination instanceof OutputStream) {
+            if (destination instanceof OutputStreamAdapter adapter) {
+                this.outStream = adapter.getWrappedStream();
+                this.destination = outStream;
+            } else {
+                this.outStream = ImageIOExt.createImageOutputStream(image, destination);
+            }
+        } else if (destination instanceof ImageOutputStream stream) {
+            this.outStream = stream;
+        } else throw new IllegalArgumentException("The provided destination cannot be used!");
+
+        if (this.outStream == null)
+            throw new IOException("Could not create an ImageOutputStream for destination: " + destination);
+        return this.outStream;
+    }
 
     /** Releases resources held by this {@link AbstractGridCoverageWriter}. */
     @Override

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/AbstractGridCoverageWriterTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/AbstractGridCoverageWriterTest.java
@@ -1,0 +1,116 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.coverage.grid.io;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.image.RenderedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import javax.imageio.stream.FileCacheImageOutputStream;
+import javax.imageio.stream.ImageOutputStream;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
+import org.eclipse.imagen.operator.ConstantDescriptor;
+import org.geotools.api.coverage.grid.Format;
+import org.geotools.api.coverage.grid.GridCoverage;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.image.io.ImageIOExt;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Verifies that {@link AbstractGridCoverageWriter#getImageOutputStream} picks the right stream type based on image size
+ * and destination type. Uses {@link ConstantDescriptor} images which are lazy (no pixel RAM allocated) so large
+ * dimensions don't cause OOM.
+ */
+public class AbstractGridCoverageWriterTest {
+
+    private Long savedThreshold;
+
+    @Before
+    public void saveThreshold() {
+        savedThreshold = ImageIOExt.getFilesystemThreshold();
+    }
+
+    @After
+    public void restoreThreshold() {
+        ImageIOExt.setFilesystemThreshold(savedThreshold);
+    }
+
+    static class TestWriter extends AbstractGridCoverageWriter {
+        TestWriter(Object destination) {
+            this.destination = destination;
+        }
+
+        @Override
+        public Format getFormat() {
+            return null;
+        }
+
+        @Override
+        public void write(GridCoverage coverage, GeneralParameterValue... params) {}
+
+        public ImageOutputStream openStream(RenderedImage image) throws IOException {
+            return getImageOutputStream(image);
+        }
+    }
+
+    private static RenderedImage constantImage(int width, int height) {
+        return ConstantDescriptor.create((float) width, (float) height, new Byte[] {0}, null);
+    }
+
+    @Test
+    public void testOutputStreamSmallImageUsesMemoryCache() throws IOException {
+        // 100x100x1 byte = 10000 bytes, threshold = 50000 → memory cache
+        ImageIOExt.setFilesystemThreshold(50_000L);
+        TestWriter writer = new TestWriter(new ByteArrayOutputStream());
+        try {
+            assertTrue(writer.openStream(constantImage(100, 100)) instanceof MemoryCacheImageOutputStream);
+        } finally {
+            writer.dispose();
+        }
+    }
+
+    @Test
+    public void testOutputStreamLargeImageUsesFileCache() throws IOException {
+        // 100000x100000x1 byte = 10^10 bytes >> threshold=1 → file cache (no OOM: ConstantDescriptor is lazy)
+        ImageIOExt.setFilesystemThreshold(1L);
+        TestWriter writer = new TestWriter(new ByteArrayOutputStream());
+        try {
+            assertTrue(writer.openStream(constantImage(100_000, 100_000)) instanceof FileCacheImageOutputStream);
+        } finally {
+            writer.dispose();
+        }
+    }
+
+    @Test
+    public void testFileDestinationNotMemoryCached() throws IOException {
+        // File destination should never use an in-memory buffer, regardless of image size.
+        // imageio-ext registers its own file stream SPI, so check behaviour not exact type.
+        File tmp = File.createTempFile("writer-test", ".tif");
+        tmp.deleteOnExit();
+        TestWriter writer = new TestWriter(tmp);
+        try {
+            assertFalse(writer.openStream(constantImage(100, 100)) instanceof MemoryCacheImageOutputStream);
+        } finally {
+            writer.dispose();
+        }
+    }
+}

--- a/modules/plugin/arcgrid/src/main/java/org/geotools/gce/arcgrid/ArcGridWriter.java
+++ b/modules/plugin/arcgrid/src/main/java/org/geotools/gce/arcgrid/ArcGridWriter.java
@@ -26,7 +26,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.IIOImage;
-import javax.imageio.stream.ImageOutputStream;
 import org.eclipse.imagen.Interpolation;
 import org.geotools.api.coverage.grid.Format;
 import org.geotools.api.coverage.grid.GridCoverage;
@@ -58,7 +56,6 @@ import org.geotools.coverage.processing.operation.Resample;
 import org.geotools.coverage.processing.operation.SelectSampleDimension;
 import org.geotools.coverage.util.CoverageUtilities;
 import org.geotools.geometry.GeneralBounds;
-import org.geotools.image.io.ImageIOExt;
 import org.geotools.metadata.i18n.Vocabulary;
 import org.geotools.metadata.i18n.VocabularyKeys;
 import org.geotools.parameter.Parameter;
@@ -106,41 +103,8 @@ public final class ArcGridWriter extends AbstractGridCoverageWriter implements G
      *
      * @param destination the URL or String pointing to the file to load the ArcGrid
      */
-    @SuppressWarnings("PMD.CloseResource") // ImageOutputStream stream
     public ArcGridWriter(Object destination, Hints hints) throws DataSourceException {
         this.destination = destination;
-        if (destination instanceof File)
-            try {
-                super.outStream = ImageIOExt.createImageOutputStream(null, destination);
-            } catch (IOException e) {
-                if (LOGGER.isLoggable(Level.SEVERE)) LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
-                throw new DataSourceException(e);
-            }
-        else if (destination instanceof URL dest) {
-            if (dest.getProtocol().equalsIgnoreCase("file")) {
-                File destFile = URLs.urlToFile(dest);
-                try {
-                    super.outStream = ImageIOExt.createImageOutputStream(null, destFile);
-                } catch (IOException e) {
-                    if (LOGGER.isLoggable(Level.SEVERE)) LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
-                    throw new DataSourceException(e);
-                }
-            }
-
-        } else if (destination instanceof OutputStream) {
-
-            try {
-                super.outStream = ImageIOExt.createImageOutputStream(null, destination);
-            } catch (IOException e) {
-                if (LOGGER.isLoggable(Level.SEVERE)) LOGGER.log(Level.SEVERE, e.getLocalizedMessage(), e);
-                throw new DataSourceException(e);
-            }
-
-        } else if (destination instanceof ImageOutputStream stream) {
-            this.destination = outStream = stream;
-        } else {
-            throw new DataSourceException("The provided destination cannot be used!");
-        }
         // //
         //
         // managing hints
@@ -275,7 +239,7 @@ public final class ArcGridWriter extends AbstractGridCoverageWriter implements G
             // Setting Output
             // //
             // mWriter.reset();
-            mWriter.setOutput(outStream);
+            mWriter.setOutput(getImageOutputStream(source));
 
             // //
             // no data management

--- a/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
+++ b/modules/plugin/geotiff/src/main/java/org/geotools/gce/geotiff/GeoTiffWriter.java
@@ -19,7 +19,6 @@ package org.geotools.gce.geotiff;
 import it.geosolutions.imageio.plugins.tiff.TIFFImageWriteParam;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageMetadata;
 import it.geosolutions.imageioimpl.plugins.tiff.TIFFImageWriter;
-import it.geosolutions.io.output.adapter.OutputStreamAdapter;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.image.RenderedImage;
@@ -27,8 +26,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,12 +61,10 @@ import org.geotools.coverage.grid.io.imageio.geotiff.GeoTiffIIOMetadataEncoder;
 import org.geotools.coverage.util.CoverageUtilities;
 import org.geotools.data.WorldFileWriter;
 import org.geotools.image.io.GridCoverageWriterProgressAdapter;
-import org.geotools.image.io.ImageIOExt;
 import org.geotools.parameter.Parameter;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.CRS.AxisOrder;
 import org.geotools.referencing.operation.matrix.XAffineTransform;
-import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
 import org.geotools.util.logging.Logging;
 import org.w3c.dom.Node;
@@ -106,27 +101,8 @@ public class GeoTiffWriter extends AbstractGridCoverageWriter implements GridCov
     }
 
     /** Constructor for a {@link GeoTiffWriter}. */
-    @SuppressWarnings("PMD.CloseResource")
     public GeoTiffWriter(Object destination, Hints hints) throws IOException {
-
         this.destination = destination;
-        if (destination instanceof File) this.outStream = ImageIOExt.createImageOutputStream(null, destination);
-        else if (destination instanceof URL dest) {
-            if (dest.getProtocol().equalsIgnoreCase("file")) {
-                final File destFile = URLs.urlToFile(dest);
-                this.outStream = ImageIOExt.createImageOutputStream(null, destFile);
-            }
-
-        } else if (destination instanceof OutputStream) {
-            if (destination instanceof OutputStreamAdapter adapter) {
-                this.outStream = adapter.getWrappedStream();
-                this.destination = outStream;
-            } else {
-                this.outStream = ImageIOExt.createImageOutputStream(null, destination);
-            }
-        } else if (destination instanceof ImageOutputStream stream) {
-            this.outStream = stream;
-        } else throw new IllegalArgumentException("The provided destination canno be used!");
         // //
         //
         // managing hints
@@ -241,7 +217,7 @@ public class GeoTiffWriter extends AbstractGridCoverageWriter implements GridCov
         //
         // write image
         //
-        writeImage(gc.getRenderedImage(), this.outStream, metadata, gtParams, listener);
+        writeImage(gc.getRenderedImage(), metadata, gtParams, listener);
 
         //
         // write tfw
@@ -342,17 +318,17 @@ public class GeoTiffWriter extends AbstractGridCoverageWriter implements GridCov
     }
 
     /** Writes the provided rendered image to the provided image output stream using the supplied geotiff metadata. */
-    @SuppressWarnings("PMD.UseTryWithResources")
+    @SuppressWarnings({"PMD.UseTryWithResources", "PMD.CloseResource"})
     private boolean writeImage(
             final RenderedImage image,
-            final ImageOutputStream outputStream,
             final GeoTiffIIOMetadataEncoder geoTIFFMetadata,
             GeoToolsWriteParams gtParams,
             ProgressListener listener)
             throws IOException {
-        if (image == null || outputStream == null) {
+        if (image == null) {
             throw new NullPointerException("Some input parameters are null");
         }
+        final ImageOutputStream outputStream = getImageOutputStream(image);
         final ImageWriteParam params = gtParams.getAdaptee();
         if (params instanceof TIFFImageWriteParam param && gtParams instanceof GeoTiffWriteParams writeParams) {
             param.setForceToBigTIFF(writeParams.isForceToBigTIFF());

--- a/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffWriterTest.java
+++ b/modules/plugin/geotiff/src/test/java/org/geotools/gce/geotiff/GeoTiffWriterTest.java
@@ -21,16 +21,22 @@ import it.geosolutions.io.output.adapter.OutputStreamAdapter;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
 import java.text.ParseException;
 import java.util.Map;
 import java.util.logging.Logger;
+import javax.imageio.stream.FileCacheImageOutputStream;
 import javax.imageio.stream.FileImageOutputStream;
+import javax.imageio.stream.ImageOutputStream;
+import javax.imageio.stream.MemoryCacheImageOutputStream;
 import org.eclipse.imagen.PlanarImage;
 import org.eclipse.imagen.media.range.NoDataContainer;
+import org.eclipse.imagen.operator.ConstantDescriptor;
 import org.geotools.api.coverage.grid.GridCoverageReader;
 import org.geotools.api.coverage.grid.GridCoverageWriter;
 import org.geotools.api.coverage.grid.GridEnvelope;
@@ -48,6 +54,7 @@ import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.GridCoverageFactory;
 import org.geotools.coverage.grid.GridGeometry2D;
+import org.geotools.coverage.grid.io.AbstractGridCoverageWriter;
 import org.geotools.coverage.grid.io.AbstractGridFormat;
 import org.geotools.coverage.grid.io.imageio.GeoToolsWriteParams;
 import org.geotools.coverage.grid.io.imageio.IIOMetadataDumper;
@@ -58,6 +65,7 @@ import org.geotools.coverage.processing.Operations;
 import org.geotools.data.WorldFileReader;
 import org.geotools.geometry.GeneralBounds;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.image.io.ImageIOExt;
 import org.geotools.referencing.CRS;
 import org.geotools.referencing.CRS.AxisOrder;
 import org.geotools.referencing.crs.DefaultGeographicCRS;
@@ -788,11 +796,42 @@ public class GeoTiffWriterTest extends Assert {
         OutputStream os = new OutputStreamAdapter(fos);
         GeoTiffWriter writer = new GeoTiffWriter(os);
 
-        // Check the writer is actually using the wrapped ImageOutputStream for writing
+        // Check the write
+        writer.write(coverage, (GeneralParameterValue[]) null);
+
+        // Check the writer actually used the wrapped ImageOutputStream for writing
         Assert.assertSame(fos, writer.getDestination());
 
-        // Check the write
-        writeAndRead(coverage, null, -9999d, geotiff, writer);
+        // then dispose
+        writer.dispose();
+        // do not dispose the coverage here as it is reused
+        // coverage.dispose(true);
+
+        // read back
+        readGeotiff(geotiff, null);
+    }
+
+    private static void readGeotiff(File geotiff, Boolean writeNoDataParam) throws IOException {
+        GridCoverage2D coverage;
+        // Reading it back
+        GeoTiffReader reader1 = new GeoTiffReader(geotiff);
+        coverage = reader1.read();
+        Map<?, ?> props = coverage.getProperties();
+        if (writeNoDataParam == null) {
+            writeNoDataParam = GeoTiffFormat.WRITE_NODATA.getDefaultValue();
+            Boolean expected = Boolean.valueOf(System.getProperty("geotiff.writenodata", "true"));
+            assertEquals(expected, writeNoDataParam);
+        }
+        if (writeNoDataParam) {
+            // checking that nodata exists/not exists if the writing params is true/false
+            assertTrue(props.containsKey(NoDataContainer.GC_NODATA));
+            NoDataContainer nodata = (NoDataContainer) props.get(NoDataContainer.GC_NODATA);
+            assertEquals(-9999d, nodata.getAsSingleValue(), 1e-6);
+        } else {
+            // checking that nodata exists/not exists if the writing params is true/false
+            assertFalse(props.containsKey(NoDataContainer.GC_NODATA));
+        }
+        reader1.dispose();
     }
 
     @Test
@@ -828,5 +867,39 @@ public class GeoTiffWriterTest extends Assert {
             if (reader2 != null) reader2.dispose();
             if (writer != null) writer.dispose();
         }
+    }
+
+    /** Writes a 10x10 constant image via GeoTiffWriter and returns the ImageOutputStream used. */
+    private ImageOutputStream writeConstantCoverage(long threshold) throws Exception {
+        Long prev = ImageIOExt.getFilesystemThreshold();
+        ImageIOExt.setFilesystemThreshold(threshold);
+        try {
+            RenderedImage image = ConstantDescriptor.create(10f, 10f, new Byte[] {0}, null);
+            GridCoverage2D coverage = new GridCoverageFactory()
+                    .create("test", image, new ReferencedEnvelope(0, 1, 0, 1, DefaultGeographicCRS.WGS84));
+            GeoTiffWriter writer = new GeoTiffWriter(new ByteArrayOutputStream());
+            try {
+                writer.write(coverage, (GeneralParameterValue[]) null);
+                Field f = AbstractGridCoverageWriter.class.getDeclaredField("outStream");
+                f.setAccessible(true);
+                return (ImageOutputStream) f.get(writer);
+            } finally {
+                writer.dispose();
+            }
+        } finally {
+            ImageIOExt.setFilesystemThreshold(prev);
+        }
+    }
+
+    /** 10x10x1 byte = 100 bytes; threshold = 50000 → memory cache. */
+    @Test
+    public void testSmallImageUsesMemoryCacheOutputStream() throws Exception {
+        assertTrue(writeConstantCoverage(50_000L) instanceof MemoryCacheImageOutputStream);
+    }
+
+    /** threshold = 1 byte → 100-byte image exceeds it → file cache, avoiding in-memory buffering for large rasters. */
+    @Test
+    public void testLargeImageUsesFileCacheOutputStream() throws Exception {
+        assertTrue(writeConstantCoverage(1L) instanceof FileCacheImageOutputStream);
     }
 }

--- a/modules/plugin/image/src/main/java/org/geotools/gce/image/WorldImageWriter.java
+++ b/modules/plugin/image/src/main/java/org/geotools/gce/image/WorldImageWriter.java
@@ -49,7 +49,6 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.coverage.grid.io.AbstractGridCoverageWriter;
 import org.geotools.coverage.util.CoverageUtilities;
 import org.geotools.image.ImageWorker;
-import org.geotools.image.io.ImageIOExt;
 import org.geotools.parameter.Parameter;
 import org.geotools.referencing.operation.matrix.XAffineTransform;
 import org.geotools.util.factory.Hints;
@@ -178,16 +177,7 @@ public final class WorldImageWriter extends AbstractGridCoverageWriter implement
             createProjectionFile(baseFile, coverage.getCoordinateReferenceSystem());
         }
 
-        // /////////////////////////////////////////////////////////////////////
-        //
-        // Encoding of the original coverage
-        //
-        // ////////////////////////////////////////////////////////////////////
-        outStream = ImageIOExt.createImageOutputStream(gc.getRenderedImage(), destination);
-        if (outStream == null)
-            throw new IOException(
-                    "WorldImageWriter::write:No image output stream avalaible for the provided destination");
-        this.encode(gc, outStream, extension);
+        encode(gc, getImageOutputStream(gc.getRenderedImage()), extension);
     }
 
     /**


### PR DESCRIPTION
[![GEOT-7908](https://badgen.net/badge/JIRA/GEOT-7908/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7908) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 