### PR TITLE
Update plexus-utils to 3.6.1, centralize dependency management

### DIFF
--- a/build/maven/enforce-managed-dependencies/pom.xml
+++ b/build/maven/enforce-managed-dependencies/pom.xml
@@ -27,7 +27,6 @@
   <properties>
     <maven.version>3.8.1</maven.version>
     <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
-    <plexus-utils.version>3.0.24</plexus-utils.version>
   </properties>
 
   <dependencies>
@@ -64,7 +63,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>${plexus-utils.version}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/build/maven/enforce-managed-dependencies/src/main/java/org/geotools/maven/enforcer/EnforceManagedDependencies.java
+++ b/build/maven/enforce-managed-dependencies/src/main/java/org/geotools/maven/enforcer/EnforceManagedDependencies.java
@@ -222,8 +222,8 @@ public class EnforceManagedDependencies extends AbstractEnforcerRule {
     }
 
     private Artifact createArtifact(Dependency dependency) {
-        String type = StringUtils.defaultString(dependency.getType(), "jar");
-        String classifier = StringUtils.defaultString(dependency.getClassifier(), "");
+        String type = dependency.getType() != null ? dependency.getType() : "jar";
+        String classifier = dependency.getClassifier() != null ? dependency.getClassifier() : "";
 
         return new DefaultArtifact(
                 dependency.getGroupId(),
@@ -256,11 +256,11 @@ public class EnforceManagedDependencies extends AbstractEnforcerRule {
     }
 
     private boolean dependencyMatches(Dependency dependency, Dependency managed) {
-        String dependencyType = StringUtils.defaultString(dependency.getType(), "jar");
-        String managedType = StringUtils.defaultString(managed.getType(), "jar");
+        String dependencyType = dependency.getType() != null ? dependency.getType() : "jar";
+        String managedType = managed.getType() != null ? managed.getType() : "jar";
 
-        String dependencyClassifier = StringUtils.defaultString(dependency.getClassifier(), "");
-        String manageClassifier = StringUtils.defaultString(managed.getClassifier(), "");
+        String dependencyClassifier = dependency.getClassifier() != null ? dependency.getClassifier() : "";
+        String manageClassifier = managed.getClassifier() != null ? managed.getClassifier() : "";
         return Objects.equals(dependency.getGroupId(), managed.getGroupId())
                 && Objects.equals(dependency.getArtifactId(), managed.getArtifactId())
                 && Objects.equals(dependencyType, managedType)

--- a/build/maven/jjtree-javacc/pom.xml
+++ b/build/maven/jjtree-javacc/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/build/maven/pom.xml
+++ b/build/maven/pom.xml
@@ -46,4 +46,14 @@
     <module>enforce-managed-dependencies</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>3.6.1</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
 </project>

--- a/build/maven/xmlcodegen/pom.xml
+++ b/build/maven/xmlcodegen/pom.xml
@@ -62,7 +62,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.24</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Centralizes plexus-utils version management, updates to 3.6.1 (not 4.x, for that we'll wait Maven 4)
Replaces 4 dependabot issued PRs.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->