### PR TITLE
Stop Maven 4.x related updates, we'll move to it once it's ready to become the minimum version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,17 @@ updates:
       - dependency-name: "org.codehaus.mojo:*"
       - dependency-name: "*:*maven-plugin*"
       - dependency-name: "org.xmlunit:xmlunit-matchers"
+      # Block Maven 4.x ecosystem until Maven 4 adopted as minimum
+      - dependency-name: "org.codehaus.plexus:*"
+        versions: [ "[4.0.0,)" ]
+      - dependency-name: "org.apache.maven:*"
+        versions: [ "[4.0.0,)" ]
+      - dependency-name: "org.apache.maven.shared:*"
+        versions: [ "[4.0.0,)" ]
+      - dependency-name: "org.apache.maven.wagon:*"
+        versions: [ "[4.0.0,)" ]
+      - dependency-name: "org.apache.maven.doxia:*"
+        versions: [ "[4.0.0,)" ]
       # Keep Java 17-compatible tool versions; newer releases require Java 21.
       - dependency-name: "com.google.errorprone:error_prone_core"
         versions: [ "[2.43.0,)" ]


### PR DESCRIPTION
The current list of maven updates is mostly noise and won't always work properly with maven 3.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->