### PR TITLE
[GEOT-7912] Overview decimation bug in heterogeneous CRS mosaic with direct reproject path

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ReadParamsController.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ReadParamsController.java
@@ -100,16 +100,10 @@ public class ReadParamsController {
                 }
             }
         } else {
-            // work on overviews
-            // TODO this is bad side effect of how the Overviews are managed
-            // right now. There are two problems here,
-            // first we are assuming that we are working with LON/LAT,
-            // second is that we are getting just an approximation of
-            // raster dimensions. The solution is to have the rater
-            // dimensions on each level and to confront raster dimensions,
-            // which means working
-            rasterWidth = (int) Math.round(spatialDomainManager.coverageBBox.getSpan(0) / selectedRes[0]);
-            rasterHeight = (int) Math.round(spatialDomainManager.coverageBBox.getSpan(1) / selectedRes[1]);
+            // Scale level-0 raster dimensions by overview scale factor.
+            // Avoids dividing bbox span by resolution (broken when CRS units differ, e.g. 4326 bbox + meter res).
+            rasterWidth = (int) Math.round(spatialDomainManager.coverageRasterArea.width / level.scaleFactor);
+            rasterHeight = (int) Math.round(spatialDomainManager.coverageRasterArea.height / level.scaleFactor);
         }
         // /////////////////////////////////////////////////////////////////////
         ImageUtilities.setSubsamplingFactors(readParameters, requestedRes, selectedRes, rasterWidth, rasterHeight);

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/HeterogenousCRSTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/HeterogenousCRSTest.java
@@ -798,6 +798,40 @@ public class HeterogenousCRSTest {
         imReader.dispose();
     }
 
+    @Test
+    public void testHeteroExternalOverviewsInNativeCRS() throws Exception {
+        String testLocation = "hetero_s2_ovr";
+        URL storeUrl = TestData.url(this, testLocation);
+        File testDirectory = crsMosaicFolder.newFolder(testLocation);
+        FileUtils.copyDirectory(new File(storeUrl.toURI()), testDirectory);
+
+        ImageMosaicReader imReader = new ImageMosaicReader(testDirectory, null);
+        Assert.assertNotNull(imReader);
+
+        // All granules are EPSG:32632; mosaic CRS is 4326.
+        // Requesting in UTM32N at 1/4 resolution forces overview use (levelIndex > 0)
+        // on the same-CRS path — the bug in ReadParamsController would produce wrong subsampling.
+        CoordinateReferenceSystem utm32n = CRS.decode("EPSG:32632", true);
+        ReferencedEnvelope env4326 = ReferencedEnvelope.reference(imReader.getOriginalEnvelope());
+        ReferencedEnvelope envUtm = env4326.transform(utm32n, true);
+        GridEnvelope originalRange = imReader.getOriginalGridRange();
+        GridEnvelope2D readRange = new GridEnvelope2D(0, 0, originalRange.getSpan(0) / 4, originalRange.getSpan(1) / 4);
+
+        ParameterValue<GridGeometry2D> ggp = AbstractGridFormat.READ_GRIDGEOMETRY2D.createValue();
+        ggp.setValue(new GridGeometry2D(readRange, envUtm));
+
+        GridCoverage2D coverage = imReader.read(new GeneralParameterValue[] {ggp});
+        assertNotNull(coverage);
+        assertTrue(CRS.equalsIgnoreMetadata(utm32n, coverage.getCoordinateReferenceSystem()));
+
+        // resolution ~4× native (100m) = ~400m; 50m tolerance
+        AffineTransform tx = (AffineTransform) coverage.getGridGeometry().getGridToCRS();
+        assertEquals(400, XAffineTransform.getScaleX0(tx), 50);
+        assertEquals(400, XAffineTransform.getScaleY0(tx), 50);
+
+        imReader.dispose();
+    }
+
     public List<String> getSourceFilesForParams(ImageMosaicReader imReader, GeneralParameterValue... params)
             throws IOException {
         GridCoverage2D coverage = imReader.read(params);


### PR DESCRIPTION
[![GEOT-7912](https://badgen.net/badge/JIRA/GEOT-7912/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7912) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Happens when a hetero mosaic set to 4326 footprints is hit with a request that is not actually reprojecting anything, say data in 32632 and request also in 32632 only, as the bbox in 4326 is divided by a pixel resolution expressed in meters.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 