### PR TITLE
fixes #GEOT-7910 - wrong timezone for testing on windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1054,7 +1054,7 @@
             <java.util.logging.SimpleFormatter.format>%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS %4$-7s [%3$s] %5$s%6$s%n</java.util.logging.SimpleFormatter.format>
           </systemPropertyVariables>
           <!-- Use systemPropertyVariables @{argLine} late subtitution for jacoco params injection in surefire-->
-          <argLine>@{argLine} -Xmx${test.maxHeapSize} ${jvm.opts} -Dfile.encoding=UTF-8 -Djava.library.path="${java.library.path}" ${test.args} -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=240m -XX:+IgnoreUnrecognizedVMOptions -XX:-OmitStackTraceInFastThrow --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED ${test.otherJVMParams}</argLine>
+          <argLine>@{argLine} -Duser.timezone=GMT -Xmx${test.maxHeapSize} ${jvm.opts} -Dfile.encoding=UTF-8 -Djava.library.path="${java.library.path}" ${test.args} -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=240m -XX:+IgnoreUnrecognizedVMOptions -XX:-OmitStackTraceInFastThrow --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED ${test.otherJVMParams}</argLine>
           <!-- Ignores test failure only if we are generating a       -->
           <!-- report for publication on the web site. See the        -->
           <!-- profiles section at the beginning of this pom.xml file. -->


### PR DESCRIPTION
[![GEOT-7910](https://badgen.net/badge/JIRA/GEOT-7910/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7910) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Add -Duser.timezone=GMT to surefire configuration, to use the right timezone build on Windows. 

GeoTools now is build with all tests locally. 

---


# Checklist
- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).   (a long time ago)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).
For core and extension modules:
- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
