### PR TITLE
fixes #GEOT-7885 - correct CQL2 grammar

### DIFF
--- a/modules/library/cql2-text/src/main/jjtree/CQL2Grammar.jjt
+++ b/modules/library/cql2-text/src/main/jjtree/CQL2Grammar.jjt
@@ -354,7 +354,7 @@ void InPredicate() #void:
 {}
 {
         LOOKAHEAD(Attribute() <NOT>)    Attribute() <NOT> <IN> InPredicateList()    #Not_In_Predicate_Node
-    |   LOOKAHEAD(Attribute())    Attribute()       <IN> InPredicateList()    #In_Predicate_Node
+    |   LOOKAHEAD(Attribute() <IN>)    Attribute()       <IN> InPredicateList()    #In_Predicate_Node
     |                   Function()        <IN> InPredicateList()    #In_Predicate_Node
 }
 

--- a/modules/library/cql2-text/src/main/jjtree/CQL2Grammar.jjt
+++ b/modules/library/cql2-text/src/main/jjtree/CQL2Grammar.jjt
@@ -353,8 +353,8 @@ void Predicate() #void:
 void InPredicate() #void:
 {}
 {
-        LOOKAHEAD(3)    Attribute() <NOT> <IN> InPredicateList()    #Not_In_Predicate_Node
-    |   LOOKAHEAD(2)    Attribute()       <IN> InPredicateList()    #In_Predicate_Node
+        LOOKAHEAD(Attribute() <NOT>)    Attribute() <NOT> <IN> InPredicateList()    #Not_In_Predicate_Node
+    |   LOOKAHEAD(Attribute())    Attribute()       <IN> InPredicateList()    #In_Predicate_Node
     |                   Function()        <IN> InPredicateList()    #In_Predicate_Node
 }
 

--- a/modules/library/cql2-text/src/test/java/org/geotools/filter/text/cql_2/CQL2Test.java
+++ b/modules/library/cql2-text/src/test/java/org/geotools/filter/text/cql_2/CQL2Test.java
@@ -189,6 +189,11 @@ public class CQL2Test {
         assertFilter("processing:level IN ('L0', 'L1')", "\"processing:level\" IN ('L0','L1')", Or.class);
     }
 
+    @Test
+    public void inPredicateFuncGEOT7885() throws CQLException {
+        assertFilter("strToUpperCase('L0') IN ('L0', 'L1')", "strToUpperCase('L0') IN ('L0','L1')", Or.class);
+    }
+
     /**
      * Like predicate sample
      *

--- a/modules/library/cql2-text/src/test/java/org/geotools/filter/text/cql_2/CQL2Test.java
+++ b/modules/library/cql2-text/src/test/java/org/geotools/filter/text/cql_2/CQL2Test.java
@@ -184,6 +184,11 @@ public class CQL2Test {
         assertFilter("A = 1 OR A = 2 OR A = 3", "(A IN (1,2)) OR A = 3", Or.class);
     }
 
+    @Test
+    public void inPredicateGEOT7885() throws CQLException {
+        assertFilter("processing:level IN ('L0', 'L1')", "\"processing:level\" IN ('L0','L1')", Or.class);
+    }
+
     /**
      * Like predicate sample
      *


### PR DESCRIPTION
[![GEOT-7885](https://badgen.net/badge/JIRA/GEOT-7885/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7885) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

For multipart identifiers a lookahead is to small. Since an Identifier is parsed like

```
<IdentifierPart> (<colon> <IdentifierPart>)*
```

a fixed Lookahead is not going to work. 

So I included a dynamic lookahead. 

---


# Checklist
- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).   (a long time ago)
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).
For core and extension modules:
- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).
