### PR TITLE
[GEOT-7913] Sort namespace declarations for deterministic XML output

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/transform/TransformerBase.java
@@ -22,12 +22,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.xml.XMLConstants;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Source;
@@ -415,14 +417,17 @@ public abstract class TransformerBase {
                 throws SAXException {
             if (namespaceDecls != null) {
 
-                // call startPrefixMapping for any namespace prefixes
+                // Collect namespace prefixes into a TreeMap for deterministic output
+                Map<String, String> nsPrefixes = new TreeMap<>();
                 for (int i = 0; i < namespaceDecls.getLength(); i++) {
                     final String nsQName = namespaceDecls.getQName(i);
                     if (nsQName != null && nsQName.startsWith("xmlns:")) {
-                        final String nsPrefix = nsQName.substring(6);
-                        final String nsUri = namespaceDecls.getValue(i);
-                        startPrefixMapping(nsPrefix, nsUri);
+                        nsPrefixes.put(nsQName.substring(6), namespaceDecls.getValue(i));
                     }
+                }
+                // call startPrefixMapping in sorted order
+                for (Map.Entry<String, String> entry : nsPrefixes.entrySet()) {
+                    startPrefixMapping(entry.getKey(), entry.getValue());
                 }
 
                 for (int i = 0, ii = atts.getLength(); i < ii; i++) {
@@ -786,7 +791,7 @@ public abstract class TransformerBase {
         /** Utility method to copy namespace declarations from "sub" translators into this ns support... */
         protected void addNamespaceDeclarations(TranslatorSupport trans) {
             NamespaceSupport additional = trans.getNamespaceSupport();
-            java.util.Enumeration declared = additional.getDeclaredPrefixes();
+            Enumeration declared = additional.getDeclaredPrefixes();
             while (declared.hasMoreElements()) {
                 String prefix1 = declared.nextElement().toString();
                 nsSupport.declarePrefix(prefix1, additional.getURI(prefix1));
@@ -1042,40 +1047,35 @@ public abstract class TransformerBase {
                 ContentHandlerFilter filter = new ContentHandlerFilter(handler, atts);
                 translator = base.createTranslator(filter);
 
+                // Collect all namespace declarations, then add them in sorted order
+                // for deterministic XML output
+                Map<String, String> nsDeclarations = new TreeMap<>();
+
                 if (translator.getDefaultNamespace() != null) {
-                    // declare the default mapping
+                    // declare the default mapping (xmlns="...")
                     atts.addAttribute(XMLNS_NAMESPACE, null, "xmlns", "CDATA", translator.getDefaultNamespace());
 
-                    // if prefix non-null, declare the mapping
+                    // if prefix non-null, include it in the sorted declarations
                     if (translator.getDefaultPrefix() != null) {
-                        atts.addAttribute(
-                                XMLNS_NAMESPACE,
-                                null,
-                                "xmlns:" + translator.getDefaultPrefix(),
-                                "CDATA",
-                                translator.getDefaultNamespace());
+                        nsDeclarations.put(translator.getDefaultPrefix(), translator.getDefaultNamespace());
                     }
                 }
 
                 NamespaceSupport ns = translator.getNamespaceSupport();
-                java.util.Enumeration e = ns.getPrefixes();
-
-                // TODO: only add schema locations for namespaces that are
-                // actually here, or some sort of better checking.
-                // Set namespaces = new HashSet();
+                Enumeration e = ns.getPrefixes();
                 while (e.hasMoreElements()) {
                     String prefix = e.nextElement().toString();
-
                     if (prefix.equals("xml")) {
                         continue;
                     }
+                    nsDeclarations.put(prefix, ns.getURI(prefix));
+                }
 
-                    String xmlns = "xmlns:" + prefix;
-
+                // Add all prefixed namespace declarations in alphabetical order
+                for (Map.Entry<String, String> entry : nsDeclarations.entrySet()) {
+                    String xmlns = "xmlns:" + entry.getKey();
                     if (atts.getValue(xmlns) == null) {
-                        atts.addAttribute(XMLNS_NAMESPACE, null, xmlns, "CDATA", ns.getURI(prefix));
-
-                        // namespaces.add(ns.getURI(prefix));
+                        atts.addAttribute(XMLNS_NAMESPACE, null, xmlns, "CDATA", entry.getValue());
                     }
                 }
 

--- a/modules/library/xml/src/test/java/org/geotools/xml/transform/NamespaceAttributeOrderTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/transform/NamespaceAttributeOrderTest.java
@@ -1,0 +1,128 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2024, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.xml.transform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.geotools.api.style.Style;
+import org.geotools.api.style.StyleFactory;
+import org.geotools.api.style.StyledLayerDescriptor;
+import org.geotools.api.style.UserLayer;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.xml.styling.SLDTransformer;
+import org.junit.Test;
+
+/**
+ * Tests that XML namespace attributes are written in a deterministic (sorted) order. This prevents spurious diffs when
+ * SLD files are re-serialized.
+ */
+public class NamespaceAttributeOrderTest {
+
+    private static final StyleFactory sf = CommonFactoryFinder.getStyleFactory(null);
+
+    /**
+     * Verifies that namespace declarations in the root element of a transformed SLD are emitted in alphabetical order
+     * by prefix. This ensures deterministic output regardless of internal HashMap iteration order.
+     */
+    @Test
+    public void testNamespaceDeclarationsAreSortedByPrefix() throws Exception {
+        // Create a minimal SLD that will trigger multiple namespace declarations
+        StyledLayerDescriptor sld = sf.createStyledLayerDescriptor();
+        sld.setName("test");
+        UserLayer layer = sf.createUserLayer();
+        layer.setName("testLayer");
+        Style style = sf.createStyle();
+        style.setName("testStyle");
+        layer.addUserStyle(style);
+        sld.addStyledLayer(layer);
+
+        SLDTransformer transformer = new SLDTransformer();
+        transformer.setIndentation(2);
+
+        // Transform multiple times to verify determinism
+        String xml1 = transformer.transform(sld);
+        String xml2 = transformer.transform(sld);
+
+        // Output should be identical across multiple serializations
+        assertEquals("Repeated serialization should produce identical output", xml1, xml2);
+
+        // Extract the root element's opening tag (everything up to the first >)
+        // Skip the XML declaration if present
+        int rootStart = xml1.indexOf("<sld:");
+        if (rootStart < 0) {
+            rootStart = xml1.indexOf("<StyledLayerDescriptor");
+        }
+        assertTrue("Should find root element in output: " + xml1, rootStart >= 0);
+        String rootTag = xml1.substring(rootStart, xml1.indexOf(">", rootStart) + 1);
+
+        // Extract all xmlns:prefix declarations and verify the non-element prefixes are sorted.
+        // Note: The JAXP Transformer always emits the element's own namespace prefix first
+        // (e.g., "sld" for <sld:StyledLayerDescriptor>), so we skip the first prefix and verify
+        // the remaining ones are in alphabetical order.
+        Pattern nsPattern = Pattern.compile("xmlns:(\\w+)=");
+        Matcher matcher = nsPattern.matcher(rootTag);
+
+        java.util.List<String> prefixes = new java.util.ArrayList<>();
+        while (matcher.find()) {
+            prefixes.add(matcher.group(1));
+        }
+
+        // Verify we found multiple namespace prefixes (sld, ogc, gml at minimum)
+        assertTrue("Should have found at least 3 namespace prefixes in: " + rootTag, prefixes.size() >= 3);
+
+        // Skip the first prefix (element's own namespace, placed first by JAXP Transformer)
+        // and verify the rest are sorted
+        java.util.List<String> remainingPrefixes = prefixes.subList(1, prefixes.size());
+        for (int i = 1; i < remainingPrefixes.size(); i++) {
+            String prev = remainingPrefixes.get(i - 1);
+            String curr = remainingPrefixes.get(i);
+            assertTrue(
+                    "Namespace prefix '" + curr + "' should come after '" + prev + "' (alphabetical order). Root tag: "
+                            + rootTag,
+                    curr.compareTo(prev) >= 0);
+        }
+    }
+
+    /**
+     * Verifies that the output is byte-identical across many iterations, ruling out any non-determinism from hash-based
+     * data structures.
+     */
+    @Test
+    public void testRepeatedSerializationIsDeterministic() throws Exception {
+        StyledLayerDescriptor sld = sf.createStyledLayerDescriptor();
+        sld.setName("determinism-test");
+        UserLayer layer = sf.createUserLayer();
+        layer.setName("layer1");
+        Style style = sf.createStyle();
+        style.setName("style1");
+        layer.addUserStyle(style);
+        sld.addStyledLayer(layer);
+
+        SLDTransformer transformer = new SLDTransformer();
+
+        String reference = transformer.transform(sld);
+
+        // Run 20 times to increase chance of catching non-determinism
+        for (int i = 0; i < 20; i++) {
+            String result = transformer.transform(sld);
+            assertEquals("Serialization attempt " + (i + 1) + " differs from reference", reference, result);
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7913](https://badgen.net/badge/JIRA/GEOT-7913/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7913) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

https://osgeo-org.atlassian.net/browse/GEOT-7913

Sort xmlns:prefix attributes alphabetically in TransformerBase to ensure deterministic XML output. Previously, namespace declarations were emitted in HashMap iteration order which varies across JVM restarts, causing spurious diffs when SLD files are re-serialized.

The fix collects all namespace prefix declarations into a TreeMap before adding them to the output attributes, and sorts startPrefixMapping calls in ContentHandlerFilter for consistent JAXP Transformer output.

Note: The JAXP Transformer always places the element's own namespace prefix first (e.g. 'sld' for sld:StyledLayerDescriptor), which is unavoidable. The remaining prefixes are now guaranteed to be in alphabetical order.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users).
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it). 