### PR TITLE
[Backport 33.x][GEOT-7909]:Improve PAM dataset merging on partial/inconsistent PAM inputs

### DIFF
--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/Utils.java
@@ -2227,25 +2227,52 @@ public class Utils {
 
     /** Merge statistics across datasets. */
     public static PAMDataset mergePamDatasets(PAMDataset[] pamDatasets) {
-        if (pamDatasets.length > 1 && Arrays.stream(pamDatasets).allMatch(Objects::nonNull)) {
-            PAMDataset merged = initRasterBands(pamDatasets[0]);
-            if (merged != null) {
-                for (PAMDataset pamDataset : pamDatasets) {
-                    updatePamDatasets(pamDataset, merged);
-                }
-            }
-            return merged;
+        if (pamDatasets == null || pamDatasets.length == 0) {
+            return null;
         }
-        return pamDatasets[0];
+        List<PAMDataset> validPamDatasets = Arrays.stream(pamDatasets)
+                .filter(Objects::nonNull)
+                .filter(p -> p.getPAMRasterBand() != null)
+                .filter(p -> !p.getPAMRasterBand().isEmpty())
+                .collect(Collectors.toList());
+
+        if (validPamDatasets.isEmpty()) {
+            return pamDatasets[0];
+        }
+
+        if (validPamDatasets.size() == 1) {
+            return validPamDatasets.get(0);
+        }
+
+        PAMDataset merged = initRasterBands(validPamDatasets.get(0));
+        if (merged != null) {
+            for (PAMDataset pamDataset : validPamDatasets) {
+                updatePamDatasets(pamDataset, merged);
+            }
+        }
+
+        return merged;
     }
 
-    /**
-     * Merge basic statistics on destination {@link PAMDataset} {@link PAMRasterBand}s need to have same size. No checks
-     * are performed here
-     */
     private static void updatePamDatasets(PAMDataset inputPamDataset, PAMDataset outputPamDataset) {
+        if (inputPamDataset == null || outputPamDataset == null) {
+            return;
+        }
+
         List<PAMRasterBand> inputRasterBands = inputPamDataset.getPAMRasterBand();
         List<PAMRasterBand> outputRasterBands = outputPamDataset.getPAMRasterBand();
+
+        if (inputRasterBands == null || outputRasterBands == null) {
+            return;
+        }
+
+        if (inputRasterBands.size() != outputRasterBands.size()) {
+            throw new IllegalStateException("PAM datasets have inconsistent band counts: input="
+                    + inputRasterBands.size()
+                    + ", output="
+                    + outputRasterBands.size());
+        }
+
         for (int i = 0; i < inputRasterBands.size(); i++) {
             updateRasterBand(inputRasterBands.get(i), outputRasterBands.get(i));
         }
@@ -2256,12 +2283,29 @@ public class Utils {
      * {@link MDI}s need to have same size. No checks are performed here
      */
     private static void updateRasterBand(PAMRasterBand inputPamRasterBand, PAMRasterBand outputPamRasterBand) {
+        if (inputPamRasterBand == null || outputPamRasterBand == null) {
+            return;
+        }
+
+        if (inputPamRasterBand.getMetadata() == null || outputPamRasterBand.getMetadata() == null) {
+            return;
+        }
+
         List<MDI> mdiInputs = inputPamRasterBand.getMetadata().getMDI();
         List<MDI> mdiOutputs = outputPamRasterBand.getMetadata().getMDI();
-        for (int i = 0; i < mdiInputs.size(); i++) {
+
+        if (mdiInputs == null || mdiOutputs == null) {
+            return;
+        }
+
+        int numMetadata = Math.min(mdiInputs.size(), mdiOutputs.size());
+        for (int i = 0; i < numMetadata; i++) {
             MDI mdiInput = mdiInputs.get(i);
             MDI mdiOutput = mdiOutputs.get(i);
-            updateMDI(mdiInput, mdiOutput);
+
+            if (mdiInput != null && mdiOutput != null) {
+                updateMDI(mdiInput, mdiOutput);
+            }
         }
     }
 
@@ -2298,26 +2342,28 @@ public class Utils {
      * names.
      */
     private static PAMDataset initRasterBands(PAMDataset samplePam) {
-        PAMDataset merged = null;
-        if (samplePam != null) {
-            merged = new PAMDataset();
-            final List<PAMRasterBand> samplePamRasterBands = samplePam.getPAMRasterBand();
-            final int numBands = samplePamRasterBands.size();
-            List<PAMRasterBand> pamRasterBands = merged.getPAMRasterBand();
-            PAMRasterBand sampleBand = samplePamRasterBands.get(0);
-            List<MDI> sampleMetadata = sampleBand.getMetadata().getMDI();
-            for (int i = 0; i < numBands; i++) {
-                final PAMRasterBand band = new PAMRasterBand();
-                final Metadata metadata = new Metadata();
-                List<MDI> mdiList = metadata.getMDI();
-                for (MDI mdi : sampleMetadata) {
-                    MDI addedMdi = new MDI();
-                    addedMdi.setKey(mdi.getKey());
-                    mdiList.add(addedMdi);
-                }
-                band.setMetadata(metadata);
-                pamRasterBands.add(band);
+        List<PAMRasterBand> samplePamRasterBands = samplePam != null ? samplePam.getPAMRasterBand() : null;
+
+        if (samplePamRasterBands == null || samplePamRasterBands.isEmpty()) {
+            return null;
+        }
+
+        PAMDataset merged = new PAMDataset();
+        final int numBands = samplePamRasterBands.size();
+        List<PAMRasterBand> pamRasterBands = merged.getPAMRasterBand();
+        PAMRasterBand sampleBand = samplePamRasterBands.get(0);
+        List<MDI> sampleMetadata = sampleBand.getMetadata().getMDI();
+        for (int i = 0; i < numBands; i++) {
+            final PAMRasterBand band = new PAMRasterBand();
+            final Metadata metadata = new Metadata();
+            List<MDI> mdiList = metadata.getMDI();
+            for (MDI mdi : sampleMetadata) {
+                MDI addedMdi = new MDI();
+                addedMdi.setKey(mdi.getKey());
+                mdiList.add(addedMdi);
             }
+            band.setMetadata(metadata);
+            pamRasterBands.add(band);
         }
         return merged;
     }

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/UtilsTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/UtilsTest.java
@@ -16,13 +16,21 @@
  */
 package org.geotools.gce.imagemosaic;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
+import it.geosolutions.imageio.pam.PAMDataset;
+import it.geosolutions.imageio.pam.PAMDataset.PAMRasterBand;
+import it.geosolutions.imageio.pam.PAMDataset.PAMRasterBand.Metadata;
+import it.geosolutions.imageio.pam.PAMDataset.PAMRasterBand.Metadata.MDI;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.PriorityQueue;
 import javax.media.jai.Histogram;
 import javax.media.jai.remote.SerializableRenderedImage;
@@ -97,5 +105,64 @@ public class UtilsTest {
         System.clearProperty(Utils.SAMPLE_IMAGE_ALLOWLIST_KEY);
         assertNull(Utils.resetSampleImageAllowlist());
         assertNotNull(Utils.loadSampleImage(file));
+    }
+
+    @Test
+    public void testMergePamDatasetsSkipsNullAndEmptyDatasets() {
+        PAMDataset empty = new PAMDataset();
+        PAMDataset first = pamDataset(pamRasterBand(10, 100));
+        PAMDataset second = pamDataset(pamRasterBand(5, 120));
+
+        PAMDataset merged = Utils.mergePamDatasets(new PAMDataset[] {null, empty, first, second});
+
+        assertNotNull(merged);
+        assertEquals(1, merged.getPAMRasterBand().size());
+        List<MDI> metadata = merged.getPAMRasterBand().get(0).getMetadata().getMDI();
+        assertEquals("5.0", metadataValue(metadata, "STATISTICS_MINIMUM"));
+        assertEquals("120.0", metadataValue(metadata, "STATISTICS_MAXIMUM"));
+    }
+
+    @Test
+    public void testMergePamDatasetsReturnsSingleValidDataset() {
+        PAMDataset valid = pamDataset(pamRasterBand(10, 100));
+
+        assertSame(valid, Utils.mergePamDatasets(new PAMDataset[] {null, new PAMDataset(), valid}));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testMergePamDatasetsRejectsInconsistentBandCounts() {
+        Utils.mergePamDatasets(new PAMDataset[] {
+            pamDataset(pamRasterBand(10, 100)), pamDataset(pamRasterBand(5, 120), pamRasterBand(20, 200))
+        });
+    }
+
+    private static PAMDataset pamDataset(PAMRasterBand... bands) {
+        PAMDataset dataset = new PAMDataset();
+        dataset.getPAMRasterBand().addAll(Arrays.asList(bands));
+        return dataset;
+    }
+
+    private static PAMRasterBand pamRasterBand(double minimum, double maximum) {
+        PAMRasterBand band = new PAMRasterBand();
+        Metadata metadata = new Metadata();
+        metadata.getMDI().add(mdi("STATISTICS_MINIMUM", minimum));
+        metadata.getMDI().add(mdi("STATISTICS_MAXIMUM", maximum));
+        band.setMetadata(metadata);
+        return band;
+    }
+
+    private static MDI mdi(String key, double value) {
+        MDI mdi = new MDI();
+        mdi.setKey(key);
+        mdi.setValue(Double.toString(value));
+        return mdi;
+    }
+
+    private static String metadataValue(List<MDI> metadata, String key) {
+        return metadata.stream()
+                .filter(mdi -> key.equals(mdi.getKey()))
+                .findFirst()
+                .map(MDI::getValue)
+                .orElse(null);
     }
 }


### PR DESCRIPTION
[![GEOT-7909](https://badgen.net/badge/JIRA/GEOT-7909/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7909) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Backport to 33.x 