### PR TITLE
[GEOT-7898] Increase XMLUtils restrictions with DTD off by default

### DIFF
--- a/docs/user/extension/app-schema.rst
+++ b/docs/user/extension/app-schema.rst
@@ -199,6 +199,20 @@ Once you have configured your ``SchemaResolver``, you can use it to build an ``A
 
 * For an example of how to determine which GML version to use, see ``EmfAppSchemaReader`` in ``gt-app-schema``.
 
+AppSchemaValidator
+^^^^^^^^^^^^^^^^^^
+
+Validation is available using ``AppSchemaValidator``:
+
+.. code-block:: java
+   
+   AppSchemaValidator validator = buildValidator(catalog);
+   validator.setSupportDTD(true);
+   validator.parse(input);
+   validator.checkForFailures();
+
+Be advised that DTD support is now disabled by default. You may enable directly in Java as shown above,
+or change the default using the system property ``org.geotools.appschema.resolver.xml.AppSchemaValidator.supportDTD=true``.
 
 Sample DataAccess
 ^^^^^^^^^^^^^^^^^

--- a/docs/user/library/metadata/geotools.rst
+++ b/docs/user/library/metadata/geotools.rst
@@ -82,17 +82,85 @@ To access the configured ``ENTITY_RESOLVER``:
    
    parser.setEntityResolver( GeoTools.getEntityResolver(hints) );
 
-GeoTools also includes several ``EntityResolver`` implementations:
-
-* ``DefaultEntityResolver``: For working with OGC and INSPIRE XML documents, only allows DTD and XML Schema references to Open Geospatial and INSPIRE registries.
-* ``PreventLocalEntityResolver``: For use when working with external XML documents, only allows DTD and XML Schema references to remote resources.
-* ``NullEntityResolver``: Placeholder allowing the default ``SAXParser`` access-anything behavior.
-
 The library uses ``DefaultEntityResolver`` by default, if you wish to work with a local XML file (referencing local DTD and XMLSchema) please use the following during application setup:
 
 .. code-block:: java
 
    Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
+
+GeoTools defines `EntityResolver3` interface providing the `EntityResolver3.getAccess()` method listing the protocols required for the Entity Resolver to function. This information is used by XMLUtils when configuring xml services for use by the library.
+
+GeoTools also includes several ``EntityResolver3`` implementations:
+
+.. list-table:: EntityResolver3
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Implementation
+     - Access
+     - Intended Use
+   * - ``DefaultEntityResolver.INSTANCE``
+     - ``"http,jar,jar:file,vfs"``
+     - For working with OGC and INSPIRE XML documents, only allows DTD and XML Schema references to Open Geospatial and INSPIRE registries.
+   * - ``PreventLocalEntityResolver.INSTANCE``
+     - ``"http,jar,jar:file,vfs"``
+     -  For use when working with external XML documents, only allows DTD and XML Schema references to remote resources.
+   * - ``NullEntityResolver.INSTANCE``
+     - ``"all"``
+     - Allowing the default ``SAXParser`` access-anything behavior.
+   * - ``PreventEntityResolver.INSTANCE``
+     - ``""``
+     - Any use results in SAXException blocking all entity resolution, does not allow any protocols.
+   * - ``InternalEntityResolver.INSTANCE``
+     - ``"http,jar,jar:file,vfs,file"``
+     - Supports IDE development where ``target/classe`` and ``target/test-classes`` may be used during testing.
+
+To use ``InternalEntityResolver`` during a test case to allow access to internal content during test (from IDE or maven) while limiting "http" locations to OGC and INSPIRE registries.
+
+.. code-block:: java
+
+   @Before
+   public void setup(){
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, InternalEntityResolver.INSTANCE);
+   }
+   @Before
+   public void setup(){
+        Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
+   }
+   @Test
+   public void test(){
+        EntityResolver entityResolver = GeoTools.getEntityResolver();
+        if (entityResolver instanceof EntityResolver3 entityResolver3) {
+             assertTrue(entityResolver3.getAccess().contains("file"));
+        }
+        
+        
+        DocumentBuilderFactory docFactory = XMLUtils.newDocumentBuilderFactory();
+        docFactory.setNamespaceAware(true);
+
+        InputStream gml = Example.class.getResourceAsStream("features.gml"))
+        document = docFactory.newDocumentBuilder().parse(gml);
+   }
+
+For a more general online test configure ``InternalEntityResolver.INSTANCE`` to delegate to 
+``PreventLocalEntityResolver`` which allows unrestricted "http" access:
+
+.. code-block:: java
+
+   @Before
+   public void setup(){
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, new InternalEntityResolver(PreventLocalEntityResolver.INSTANCE));
+   }
+
+To limit access to only internal content configure ``InternalEntityResolver.INSTANCE`` to delegate to ``PreventEntityResolver``:
+
+.. code-block:: java
+
+   @Before
+   public void setup(){
+        Hints.putSystemDefault(Hints.ENTITY_RESOLVER, new InternalEntityResolver(PreventEntityResolver.INSTANCE));
+   }
+
 
 Logging
 ^^^^^^^

--- a/docs/user/library/xml/xmlutils.rst
+++ b/docs/user/library/xml/xmlutils.rst
@@ -49,7 +49,7 @@ You may carefully relax settings as needed if working with local files:
 TransformerFactory and Transformer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The same approach is taken with TransformerFactory and Transformer.
+Use XMLUtils to create instances of TransformerFactory and Transformer.
 
 XMLTransformer:
 
@@ -100,3 +100,31 @@ Use Hints to provide factory configuration:
    
    SAXParser parser = XMLUtils.newSAXParser(parserFactory);
    parser.parse(file, contentHandler);
+
+XMLInputFactory and PullParsers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+XMLUtils supports XMLInputFactory for use with pull parsers such as XMLStreamReader:
+
+.. code-block:: java
+
+   XMLInputFactory factory = XMLUtils.newXMLInputFactory();
+   XMLStreamReader parser = factory.createXMLStreamReader(source.getCharacterStream());
+
+The XMLInputFactory is setup without DTD suppert (both ``SUPPORT_DTD`` and ``IS_COALESCING`` are disabled).
+DTD support is not required for the majority of OGC Standards.
+
+If you do need for any reason to work with DTD the factory can be configured after creation:
+
+.. code-block:: java
+   
+   XMLInputFactory factory = XMLUtils.newXMLInputFactory();
+   
+   if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
+       factory.setProperty(XMLInputFactory.SUPPORT_DTD, true);
+   }
+   if (factory.isPropertySupported(XMLInputFactory.IS_COALESCING)) {
+       factory.setProperty(XMLInputFactory.IS_COALESCING, true);
+   }
+   XMLStreamReader parser = factory.createXMLStreamReader(source.getCharacterStream());
+   

--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaValidator.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaValidator.java
@@ -29,7 +29,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import org.geotools.util.NullEntityResolver;
@@ -42,8 +41,6 @@ import org.geotools.xml.resolver.SchemaResolver;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.SAXParseException;
 import org.xml.sax.XMLReader;
 
@@ -68,6 +65,13 @@ public class AppSchemaValidator {
 
     /** Are validation warnings considered failures? The default is true. */
     private boolean failOnWarning = true;
+
+    /**
+     * Is DTD support required? The default is {@code false} and may be defined externally using the
+     * {@code org.geotools.appschema.resolver.xml.AppSchemaValidator.supportDTD} system property.
+     */
+    private boolean supportDTD = Boolean.valueOf(
+            System.getProperty("org.geotools.appschema.resolver.xml.AppSchemaValidator.supportDTD", "false"));
 
     /**
      * Construct an {@link AppSchemaValidator} that performs schema validation against schemas found on the classpath
@@ -113,6 +117,27 @@ public class AppSchemaValidator {
     }
 
     /**
+     * Used to configure a validation to allow / disallow DTD use.
+     *
+     * @param supportDTD {@code false} to disable DTD support, {@code true} to enable DTD support
+     */
+    public void setSupportDTD(boolean supportDTD) {
+        this.supportDTD = supportDTD;
+    }
+
+    /**
+     * Used to configure a validation to allow / disallow DTD use.
+     *
+     * <p>The default is {@code false} and may be defined externally using the
+     * {@code org.geotools.appschema.resolver.xml.AppSchemaValidator.supportDTD} system property.
+     *
+     * @preturn {@code false} to disable DTD support, {@code true} to enable DTD support
+     */
+    boolean isSupportDTD() {
+        return supportDTD;
+    }
+
+    /**
      * Parse an XML instance document read from an {@link InputStream}, recording any validation failures.
      *
      * @param input stream from which XML instance document is read
@@ -126,15 +151,18 @@ public class AppSchemaValidator {
         SAXParserFactory parserFactory = XMLUtils.newSAXParserFactory(hints);
         parserFactory.setNamespaceAware(true);
         parserFactory.setValidating(true);
-        try {
-            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-            LOGGER.fine(
-                    "Parser does not support feature " + XMLConstants.ACCESS_EXTERNAL_SCHEMA + ": " + e.getMessage());
-        }
+        XMLUtils.supportDTD(parserFactory, this.supportDTD, hints);
+        //        try {
+        //            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        //        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+        //            LOGGER.fine(
+        //                    "Parser does not support feature " + XMLConstants.ACCESS_EXTERNAL_SCHEMA + ": " +
+        // e.getMessage());
+        //        }
         XMLReader xmlReader;
         try {
             SAXParser parser = parserFactory.newSAXParser();
+            XMLUtils.supportDTD(parser, this.supportDTD, hints);
             // Validation is against XML Schema
             parser.setProperty(
                     "http://java.sun.com/xml/jaxp/properties/schemaLanguage", "http://www.w3.org/2001/XMLSchema");

--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaValidator.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaValidator.java
@@ -152,13 +152,6 @@ public class AppSchemaValidator {
         parserFactory.setNamespaceAware(true);
         parserFactory.setValidating(true);
         XMLUtils.supportDTD(parserFactory, this.supportDTD, hints);
-        //        try {
-        //            parserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        //        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-        //            LOGGER.fine(
-        //                    "Parser does not support feature " + XMLConstants.ACCESS_EXTERNAL_SCHEMA + ": " +
-        // e.getMessage());
-        //        }
         XMLReader xmlReader;
         try {
             SAXParser parser = parserFactory.newSAXParser();

--- a/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/appschema/resolver/xml/AppSchemaValidatorTest.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/test/java/org/geotools/appschema/resolver/xml/AppSchemaValidatorTest.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import org.geotools.util.DefaultEntityResolver;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.factory.Hints;
+import org.geotools.xml.resolver.SchemaCatalog;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,8 +54,13 @@ public class AppSchemaValidatorTest {
     /** Test that validation fails with an expected error message for a known-invalid XML instance document. */
     @Test
     public void validateErMineralOccurrenceWithErrors() {
-        try {
-            AppSchemaValidator.validateResource("/test-data/er_MineralOccurrence_with_errors.xml", null);
+        try (InputStream input =
+                AppSchemaValidatorTest.class.getResourceAsStream("/test-data/er_MineralOccurrence_with_errors.xml")) {
+            AppSchemaValidator validator = AppSchemaValidator.buildValidator((SchemaCatalog) null);
+            validator.setSupportDTD(true);
+            validator.parse(input);
+            validator.checkForFailures();
+
             Assert.fail("Unexpected schema validation success for known-invalid XML instance document");
         } catch (Exception e) {
             Assert.assertTrue(
@@ -69,7 +75,12 @@ public class AppSchemaValidatorTest {
      */
     @Test
     public void validateWfs20Example01() throws IOException {
-        AppSchemaValidator.validateResource("/test-data/Example01.xml", null);
+        try (InputStream input = AppSchemaValidatorTest.class.getResourceAsStream("/test-data/Example01.xml")) {
+            AppSchemaValidator validator = AppSchemaValidator.buildValidator((SchemaCatalog) null);
+            validator.setSupportDTD(true);
+            validator.parse(input);
+            validator.checkForFailures();
+        }
     }
 
     /** Tests for {@link AppSchemaValidator#getEncoding(String)}. */
@@ -135,8 +146,13 @@ public class AppSchemaValidatorTest {
      * specification. This version converts the resource to a string and back before validation.
      */
     @Test
-    public void validateWfs20Example01AsString() {
-        validateResourceAsString("/test-data/Example01.xml");
+    public void validateWfs20Example01AsString() throws IOException {
+        try (InputStream input = AppSchemaValidatorTest.class.getResourceAsStream("/test-data/Example01.xml")) {
+            AppSchemaValidator validator = AppSchemaValidator.buildValidator((SchemaCatalog) null);
+            validator.setSupportDTD(true);
+            validator.parse(input);
+            validator.checkForFailures();
+        }
     }
 
     /** Test that a GetFeature can be validated. */

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/WMS1_0_0.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/WMS1_0_0.java
@@ -81,6 +81,10 @@ public class WMS1_0_0 extends WMSSpecification {
     /** Public constructor creates the WMS1_0_0 object. */
     public WMS1_0_0() {}
 
+    @Override
+    public boolean supportsDTD() {
+        return true;
+    }
     /**
      * Expected version attribute for root element.
      *

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/WMS1_3_0.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/WMS1_3_0.java
@@ -32,6 +32,10 @@ public class WMS1_3_0 extends WMS1_1_1 {
         return "1.3.0";
     }
 
+    @Override
+    public boolean supportsDTD() {
+        return false;
+    }
     /* (non-Javadoc)
      * @see org.geotools.data.wms.Specification#createGetCapabilitiesRequest(java.net.URL)
      */

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/response/WMSGetCapabilitiesResponse.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/response/WMSGetCapabilitiesResponse.java
@@ -21,11 +21,13 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geotools.data.ows.Capabilities;
 import org.geotools.data.ows.GetCapabilitiesResponse;
 import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 import org.geotools.ows.wms.xml.WMSSchema;
+import org.geotools.util.logging.Logging;
 import org.geotools.xml.DocumentFactory;
 import org.geotools.xml.handlers.DocumentHandler;
 import org.xml.sax.SAXException;
@@ -36,6 +38,8 @@ import org.xml.sax.SAXException;
  * @author Richard Gould
  */
 public class WMSGetCapabilitiesResponse extends GetCapabilitiesResponse {
+
+    public static Logger LOGGER = Logging.getLogger(WMSGetCapabilitiesResponse.class);
 
     public WMSGetCapabilitiesResponse(HTTPResponse response) throws ServiceException, IOException {
         this(response, null);
@@ -51,17 +55,18 @@ public class WMSGetCapabilitiesResponse extends GetCapabilitiesResponse {
             if (!hints.containsKey(DocumentFactory.VALIDATION_HINT)) {
                 hints.put(DocumentFactory.VALIDATION_HINT, Boolean.FALSE);
             }
+            if (!hints.containsKey(DocumentFactory.ENABLE_DTD)) {
+                hints.put(DocumentFactory.ENABLE_DTD, Boolean.FALSE);
+            }
             Object object;
             try (InputStream inputStream = response.getResponseStream()) {
                 object = DocumentFactory.getInstance(inputStream, hints, Level.WARNING);
             } catch (SAXException e) {
                 throw (ServiceException) new ServiceException("Error while parsing XML.").initCause(e);
             }
-
             if (object instanceof ServiceException exception) {
                 throw exception;
             }
-
             this.capabilities = (Capabilities) object;
         } finally {
             response.dispose();

--- a/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/WMSSchema.java
+++ b/modules/extension/wms/src/main/java/org/geotools/ows/wms/xml/WMSSchema.java
@@ -111,9 +111,9 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
 /**
+ * Public portion of Web Map Service Schema.
+ *
  * @author Richard Gould
- *     <p>TODO To change the template for this generated type comment go to Window - Preferences - Java - Code Style -
- *     Code Templates
  */
 public class WMSSchema implements Schema {
 
@@ -348,6 +348,16 @@ public class WMSSchema implements Schema {
     @Override
     public boolean isElementFormDefault() {
         return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("WMSSchema[version=");
+        builder.append(getVersion());
+        builder.append(", id=");
+        builder.append(getId());
+        builder.append("]");
+        return builder.toString();
     }
 
     public static Schema getInstance() {

--- a/modules/extension/wms/src/test/java/org/geotools/ows/test/LayerInheritanceTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/test/LayerInheritanceTest.java
@@ -43,6 +43,7 @@ public class LayerInheritanceTest {
 
         Map<String, Object> hints = new HashMap<>();
         hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
         Object object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
 
         SchemaFactory.getInstance(WMSSchema.NAMESPACE);

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/map/WMSCoverageReaderTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/map/WMSCoverageReaderTest.java
@@ -277,8 +277,8 @@ public class WMSCoverageReaderTest {
             @Override
             public HTTPResponse get(URL url) throws IOException {
                 if (url.getQuery().contains("GetCapabilities")) {
-                    URL caps130 = WMSCoverageReaderTest.class.getResource("caps110.xml");
-                    return new MockHttpResponse(caps130, "text/xml");
+                    URL caps110 = WMSCoverageReaderTest.class.getResource("caps110.xml");
+                    return new MockHttpResponse(caps110, "text/xml");
                 } else if (url.getQuery().contains("GetMap") && url.getQuery().contains("world4326")) {
                     Map<String, String> params = WMSTestUtils.parseParams(url.getQuery());
                     assertEquals("1.1.0", params.get("VERSION"));

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/test/WMS1_1_0_Test.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/test/WMS1_1_0_Test.java
@@ -183,6 +183,7 @@ public class WMS1_1_0_Test {
             URL getCapsURL = getCaps.toURI().toURL();
             Map<String, Object> hints = new HashMap<>();
             hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+            hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
             Object object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
 
             SchemaFactory.getInstance(WMSSchema.NAMESPACE);

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/test/WMS1_1_1_Test.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/test/WMS1_1_1_Test.java
@@ -269,6 +269,7 @@ public class WMS1_1_1_Test {
             URL getCapsURL = getCaps.toURI().toURL();
             Map<String, Object> hints = new HashMap<>();
             hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+            hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
             Object object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
 
             SchemaFactory.getInstance(WMSSchema.NAMESPACE);

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/test/WMSParserTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/test/WMSParserTest.java
@@ -64,6 +64,7 @@ public class WMSParserTest {
     public void testWMS111EntityResolver() throws Exception {
         Map<String, Object> hints = new HashMap<>();
         hints.put(XMLHandlerHints.ENTITY_RESOLVER, PreventLocalEntityResolver.INSTANCE);
+        hints.put(DocumentFactory.DISABLE_EXTERNAL_ENTITIES, Boolean.FALSE);
 
         WebMapServer wms =
                 new WebMapServer(new URL("http://test.org"), new CapsMockClient("1.1.1Capabilities.xml"), hints);
@@ -100,6 +101,7 @@ public class WMSParserTest {
     public void testWMS130EntityResolver() throws Exception {
         Map<String, Object> hints = new HashMap<>();
         hints.put(XMLHandlerHints.ENTITY_RESOLVER, PreventLocalEntityResolver.INSTANCE);
+        hints.put(DocumentFactory.DISABLE_EXTERNAL_ENTITIES, Boolean.FALSE);
 
         WebMapServer wms =
                 new WebMapServer(new URL("http://test.org"), new CapsMockClient("1.3.0Capabilities.xml"), hints);

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSComplexTypesTest.java
@@ -45,6 +45,7 @@ public class WMSComplexTypesTest {
         URL getCapsURL = getCaps.toURI().toURL();
         Map<String, Object> hints = new HashMap<>();
         hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
         Object object = null;
 
         try {
@@ -119,6 +120,7 @@ public class WMSComplexTypesTest {
         URL getCapsURL = getCaps.toURI().toURL();
         Map<String, Object> hints = new HashMap<>();
         hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
         if (!hints.containsKey(DocumentFactory.VALIDATION_HINT)) {
             // Removing validation to match WMSGetCapabilitiesResponse behavior
             hints.put(DocumentFactory.VALIDATION_HINT, Boolean.FALSE);

--- a/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSSchemaTest.java
+++ b/modules/extension/wms/src/test/java/org/geotools/ows/wms/xml/test/WMSSchemaTest.java
@@ -250,6 +250,7 @@ public class WMSSchemaTest {
         URL getCapsURL = getCaps.toURI().toURL();
         Map<String, Object> hints = new HashMap<>();
         hints.put(DocumentHandler.DEFAULT_NAMESPACE_HINT_KEY, WMSSchema.getInstance());
+        hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
         Object object = DocumentFactory.getInstance(getCapsURL.openStream(), hints, Level.WARNING);
 
         Assert.assertTrue("Capabilities failed to parse", object instanceof WMSCapabilities);

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/DOMParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/DOMParser.java
@@ -83,7 +83,7 @@ public class DOMParser {
         if (entityResolver != null) {
             fake.setEntityResolver(entityResolver);
         } else {
-            fake.setEntityResolver(GeoTools.getEntityResolver(null));
+            fake.setEntityResolver(GeoTools.getEntityResolver());
         }
 
         // Create the handler to handle the SAX events

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -24,7 +24,6 @@ import java.io.Reader;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
-import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
@@ -81,8 +80,10 @@ public class Parser {
     /** sax handler which maintains the element stack */
     private ParserHandler handler;
 
-    /** Entity expansion limit configuration, set to null by default */
+    /** Entity expansion limit configuration, set to {@code null} by default */
     private Integer entityExpansionLimit;
+    /** Allow DTD configuration, set to {@code false} by default */
+    private boolean allowDTD = false;
 
     /**
      * Creates a new instance of the parser.
@@ -181,7 +182,7 @@ public class Parser {
         if (handler.getEntityResolver() == null) {
             LOGGER.warning("Parsing with no entity resolver configured");
         } else {
-            LOGGER.info("Parsing with entity resolver: " + handler.getEntityResolver());
+            LOGGER.fine("Parsing with entity resolver: " + handler.getEntityResolver());
         }
         parser.parse(source, handler);
 
@@ -436,24 +437,28 @@ public class Parser {
             pFactory.setFeature("http://apache.org/xml/features/validation/schema", true);
             pFactory.setFeature("http://apache.org/xml/features/validation/schema-full-checking", true);
         }
-        SAXParser parser = pFactory.newSAXParser();
+        if (allowDTD) {
+            XMLUtils.supportDTD(pFactory, true, hints);
+        }
+        SAXParser parser = XMLUtils.newSAXParser(pFactory, hints);
         if (parser.getXMLReader().getEntityResolver() != getEntityResolver()) {
             LOGGER.fine("Force entity resolver if required:" + getEntityResolver());
             parser.getXMLReader().setEntityResolver(getEntityResolver());
         }
 
-        if (parser.getXMLReader().getEntityResolver() != null) {
-            try {
-                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
-            } catch (IllegalArgumentException notSupported) {
-                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
-            }
-            try {
-                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-            } catch (IllegalArgumentException notSupported) {
-                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
-            }
-        }
+        //        if (parser.getXMLReader().getEntityResolver() != null) {
+        //            String access = XMLUtils.getAccess(parser.getXMLReader().getEntityResolver(), "all");
+        //            try {
+        //                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, access);
+        //            } catch (IllegalArgumentException notSupported) {
+        //                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+        //            }
+        //            try {
+        //                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, access);
+        //            } catch (IllegalArgumentException notSupported) {
+        //                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
+        //            }
+        //        }
 
         // set the schema sources of this configuration, and all dependent ones
         StringBuffer schemaLocation = new StringBuffer();
@@ -480,8 +485,12 @@ public class Parser {
                 "http://apache.org/xml/properties/schema/external-schemaLocation", schemaLocation.toString());
         // add the handler as a LexicalHandler too.
         parser.setProperty(SAX_PROPERTY_PREFIX + LEXICAL_HANDLER_PROPERTY, handler);
+
         // set Entity expansion limit
         setupEntityExpansionLimit(parser);
+
+        // Set allow DTD
+        if (this.allowDTD) XMLUtils.supportDTD(parser, true, hints);
 
         // return built parser
         return parser;
@@ -506,5 +515,9 @@ public class Parser {
 
     public void setEntityExpansionLimit(Integer entityExpansionLimit) {
         this.entityExpansionLimit = entityExpansionLimit;
+    }
+
+    public void setAllowDTD(boolean allowDTD) {
+        this.allowDTD = allowDTD;
     }
 }

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -80,7 +80,7 @@ public class Parser {
     /** sax handler which maintains the element stack */
     private ParserHandler handler;
 
-    /** Entity expansion limit configuration, set to {@code null} by default */
+    /** Entity expansion limit configuration, set to {@code null} for default {@code DEFAULT_ENTITY_EXPANSION_LIMIT}. */
     private Integer entityExpansionLimit;
     /** Allow DTD configuration, set to {@code false} by default */
     private boolean allowDTD = false;
@@ -445,20 +445,6 @@ public class Parser {
             LOGGER.fine("Force entity resolver if required:" + getEntityResolver());
             parser.getXMLReader().setEntityResolver(getEntityResolver());
         }
-
-        //        if (parser.getXMLReader().getEntityResolver() != null) {
-        //            String access = XMLUtils.getAccess(parser.getXMLReader().getEntityResolver(), "all");
-        //            try {
-        //                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, access);
-        //            } catch (IllegalArgumentException notSupported) {
-        //                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
-        //            }
-        //            try {
-        //                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, access);
-        //            } catch (IllegalArgumentException notSupported) {
-        //                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
-        //            }
-        //        }
 
         // set the schema sources of this configuration, and all dependent ones
         StringBuffer schemaLocation = new StringBuffer();

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Parser.java
@@ -91,7 +91,7 @@ public class Parser {
      *     </code>.
      */
     public Parser(Configuration configuration) {
-        this(configuration, GeoTools.getEntityResolver(null));
+        this(configuration, GeoTools.getEntityResolver());
     }
     /**
      * Creates a new instance of the parser.

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/PullParser.java
@@ -62,7 +62,7 @@ public class PullParser {
 
     public PullParser(Configuration config, InputStream input, PullParserHandler handler) {
         this.handler = handler;
-        this.handler.setEntityResolver(GeoTools.getEntityResolver(null));
+        this.handler.setEntityResolver(GeoTools.getEntityResolver());
         pp = createPullParser(input);
     }
 

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/Schemas.java
@@ -128,7 +128,7 @@ public class Schemas {
      * @return a {@link SchemaIndex} holding the schemas related to <code>configuration</code>
      */
     public static final SchemaIndex findSchemas(Configuration configuration) {
-        return findSchemas(configuration, GeoTools.getEntityResolver(null));
+        return findSchemas(configuration, GeoTools.getEntityResolver());
     }
     /**
      * Finds all the XSDSchemas used by the {@link Configuration configuration} by looking at the configuration's schema
@@ -241,7 +241,7 @@ public class Schemas {
     public static final XSDSchema parse(
             String location, List<XSDSchemaLocator> locators, List<XSDSchemaLocationResolver> resolvers)
             throws IOException {
-        return parse(location, locators, resolvers, emptyList(), GeoTools.getEntityResolver(null));
+        return parse(location, locators, resolvers, emptyList(), GeoTools.getEntityResolver());
     }
 
     /**

--- a/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/impl/ValidatorHandler.java
+++ b/modules/extension/xsd/xsd-core/src/main/java/org/geotools/xsd/impl/ValidatorHandler.java
@@ -19,6 +19,7 @@ package org.geotools.xsd.impl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.geotools.util.EntityResolver3;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -33,7 +34,7 @@ import org.xml.sax.ext.EntityResolver2;
  *
  * @author Justin Deoliveira, OpenGeo
  */
-public class ValidatorHandler extends DefaultHandler2 {
+public class ValidatorHandler extends DefaultHandler2 implements EntityResolver3 {
 
     /** flag to control if an exception is thrown on a validation error */
     boolean failOnValidationError = false;
@@ -95,5 +96,10 @@ public class ValidatorHandler extends DefaultHandler2 {
 
     public List<Exception> getErrors() {
         return errors;
+    }
+
+    @Override
+    public String getAccess() {
+        return "all";
     }
 }

--- a/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/ParserTest.java
+++ b/modules/extension/xsd/xsd-core/src/test/java/org/geotools/xsd/ParserTest.java
@@ -29,6 +29,7 @@ import javax.xml.namespace.QName;
 import org.geotools.ml.MLConfiguration;
 import org.geotools.ml.Mail;
 import org.geotools.ml.bindings.MLSchemaLocationResolver;
+import org.geotools.util.EntityResolver3;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.xsd.impl.Handler;
 import org.junit.Assert;
@@ -294,8 +295,8 @@ public class ParserTest {
     @Test
     public void testParseWithEntityResolver() throws Exception {
         Parser parser = new Parser(new MLConfiguration());
-
         parser.setEntityResolver(NullEntityResolver.INSTANCE);
+        parser.setAllowDTD(true);
         try {
             parser.parse(MLSchemaLocationResolver.class.getResourceAsStream("mails-external-entities.xml"));
             Assert.fail("parsing should throw an exception since referenced file does not exist");
@@ -310,7 +311,12 @@ public class ParserTest {
         // Set an EntityResolver implementation to prevent usage of external entities.
         // When parsing an XML entity, the empty InputSource returned by this resolver provokes
         // a java.net.MalformedURLException
-        parser.setEntityResolver(new EntityResolver2() {
+        parser.setEntityResolver(new EntityResolver3() {
+            @Override
+            public String getAccess() {
+                return "all";
+            }
+
             @Override
             public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
                 return new InputSource();
@@ -340,7 +346,12 @@ public class ParserTest {
         }
 
         // Set another EntityResolver
-        parser.setEntityResolver(new EntityResolver2() {
+        parser.setEntityResolver(new EntityResolver3() {
+            @Override
+            public String getAccess() {
+                return "all";
+            }
+
             @Override
             public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
                 if ("file:///this/file/does/not/exist".equals(systemId)) {
@@ -401,6 +412,7 @@ public class ParserTest {
         Parser p = new Parser(cfg);
         p.setEntityResolver(NullEntityResolver.INSTANCE);
         p.setEntityExpansionLimit(1);
+        p.setAllowDTD(true);
         SAXParseException expected = null;
         try {
             p.parse(getClass().getResourceAsStream("entityExpansionLimit.xml"));
@@ -442,6 +454,7 @@ public class ParserTest {
         Parser p = new Parser(cfg);
         p.setEntityResolver(NullEntityResolver.INSTANCE);
         p.setEntityExpansionLimit(100);
+        p.setAllowDTD(true);
         SAXParseException unexpected = null;
         try {
             p.parse(getClass().getResourceAsStream("entityExpansionLimit.xml"));

--- a/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/v1_1/SLDExampleTest.java
+++ b/modules/extension/xsd/xsd-sld/src/test/java/org/geotools/sld/v1_1/SLDExampleTest.java
@@ -153,6 +153,7 @@ public class SLDExampleTest {
 
         Parser parser = new Parser(new SLDConfiguration());
         parser.setEntityResolver(NullEntityResolver.INSTANCE);
+        parser.setAllowDTD(true);
         try (InputStream location = getClass().getResourceAsStream(file)) {
             parser.parse(location);
             Assert.fail("parsing should fail with a FileNotFoundException because the parser try to "

--- a/modules/library/main/src/main/java/org/geotools/data/ows/AbstractOpenWebService.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/AbstractOpenWebService.java
@@ -266,15 +266,26 @@ public abstract class AbstractOpenWebService<C extends Capabilities, R> {
             String clientVersion = tempSpecification.getVersion();
 
             GetCapabilitiesRequest request = tempSpecification.createGetCapabilitiesRequest(serverURL);
-            request.setRequestHints(hints);
+            Map<String, Object> specificationHints = hints != null ? new HashMap<>(hints) : new HashMap<>();
+            if (tempSpecification.supportsDTD()) {
+                specificationHints.put("DocumentFactory_ENABLE_DTD", Boolean.TRUE);
+            }
+            // Suppress warnings and failures during version negotiation
+            // (WMS1.0 DTD support will trigger failures when parsed with newer specifications)
+            specificationHints.put("DocumentFactory_Level", Level.OFF);
+            request.setRequestHints(specificationHints);
 
             // Grab document
             C tempCapabilities;
+            Level tempLevel = LOGGER.getLevel();
             try {
+                LOGGER.setLevel(Level.OFF);
                 tempCapabilities = (C) issueRequest(request).getCapabilities();
             } catch (ServiceException e) {
                 tempCapabilities = null;
                 exception = e;
+            } finally {
+                LOGGER.setLevel(tempLevel);
             }
 
             int compare = -1;
@@ -455,7 +466,8 @@ public abstract class AbstractOpenWebService<C extends Capabilities, R> {
             return response;
         } finally {
             if (!success) {
-                LOGGER.log(Level.SEVERE, "Failed to execute request " + finalURL);
+                Logger logger = Logging.getLogger(getClass());
+                logger.log(Level.FINE, "Failed to execute request " + finalURL);
             }
         }
     }

--- a/modules/library/main/src/main/java/org/geotools/data/ows/Specification.java
+++ b/modules/library/main/src/main/java/org/geotools/data/ows/Specification.java
@@ -59,4 +59,14 @@ public abstract class Specification {
      * @return a configured GetCapabilitiesRequest that can be used to access the Document
      */
     public abstract GetCapabilitiesRequest createGetCapabilitiesRequest(URL server);
+
+    /**
+     * Older specifications that require DTD support may override this method to return {@code true}. By default, DTD
+     * support is disabled for all specifications.
+     *
+     * @return {@code true} if DTD support is required for this specification, {@code false} otherwise
+     */
+    public boolean supportsDTD() {
+        return false;
+    }
 }

--- a/modules/library/metadata/src/main/java/org/geotools/util/InternalEntityResolver.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/InternalEntityResolver.java
@@ -81,12 +81,21 @@ public class InternalEntityResolver implements EntityResolver3 {
         if (delegate instanceof EntityResolver3 entityResolver3) {
             if (entityResolver3.getAccess() != null
                     && !entityResolver3.getAccess().isEmpty()) {
+                boolean hasFile = false;
+                boolean hasJarFile = false;
+                for (String protocol : entityResolver3.getAccess().split(",")) {
+                    if (protocol.trim().equalsIgnoreCase("file")) {
+                        hasFile = true;
+                    } else if (protocol.trim().equalsIgnoreCase("jar:file")) {
+                        hasJarFile = true;
+                    }
+                }
                 StringBuilder access = new StringBuilder();
                 access.append(entityResolver3.getAccess());
-                if (access.indexOf("file") == -1) {
+                if (!hasFile) {
                     access.append(",file");
                 }
-                if (access.indexOf("jar:file") == -1) {
+                if (!hasJarFile) {
                     access.append(",jar:file");
                 }
                 return access.toString();
@@ -121,7 +130,7 @@ public class InternalEntityResolver implements EntityResolver3 {
             }
             throw new SAXException("External entity systemId not provided");
         }
-        String uri = DefaultEntityResolver.toURI(null, baseURI);
+        String uri = DefaultEntityResolver.toURI(baseURI, systemId);
         uri = DefaultEntityResolver.normalize(uri);
         if (INTERNAL_URIS.matcher(uri).matches()) {
             return null;

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/GeoTools.java
@@ -899,6 +899,14 @@ public final class GeoTools {
     /**
      * Returns the default entity resolver, used to configure {@link SAXParser}.
      *
+     * @return An entity resolver (never {@code null})
+     */
+    public static EntityResolver getEntityResolver() {
+        return getEntityResolver(null);
+    }
+    /**
+     * Returns the default entity resolver, used to configure {@link SAXParser}.
+     *
      * @param hints An optional set of hints, or {@code null} if none, see {@link Hints#ENTITY_RESOLVER}.
      * @return An entity resolver (never {@code null})
      */

--- a/modules/library/metadata/src/test/java/org/geotools/util/factory/GeoToolsTest.java
+++ b/modules/library/metadata/src/test/java/org/geotools/util/factory/GeoToolsTest.java
@@ -228,22 +228,22 @@ public final class GeoToolsTest {
         // confirm system hints work
         try {
             Hints.putSystemDefault(Hints.ENTITY_RESOLVER, NullEntityResolver.INSTANCE);
-            assertSame(NullEntityResolver.INSTANCE, GeoTools.getEntityResolver(null));
+            assertSame(NullEntityResolver.INSTANCE, GeoTools.getEntityResolver());
 
             // test default behavor
             Hints.removeSystemDefault(Hints.ENTITY_RESOLVER);
-            assertSame(DefaultEntityResolver.INSTANCE, GeoTools.getEntityResolver(null));
+            assertSame(DefaultEntityResolver.INSTANCE, GeoTools.getEntityResolver());
 
             // test system property functions with default constructor
             System.getProperties().put(GeoTools.ENTITY_RESOLVER, "org.geotools.util.factory.PlaceholderEntityResolver");
             Hints.scanSystemProperties();
-            EntityResolver entityResolver = GeoTools.getEntityResolver(null);
+            EntityResolver entityResolver = GeoTools.getEntityResolver();
             assertTrue(entityResolver instanceof PlaceholderEntityResolver);
 
             // test system property functions with INSTANCE field constructor
             System.getProperties().put(GeoTools.ENTITY_RESOLVER, "org.geotools.util.NullEntityResolver");
             Hints.scanSystemProperties();
-            entityResolver = GeoTools.getEntityResolver(null);
+            entityResolver = GeoTools.getEntityResolver();
             assertTrue(entityResolver instanceof NullEntityResolver);
         } finally {
             System.clearProperty(GeoTools.ENTITY_RESOLVER);

--- a/modules/library/sample-data/src/main/java/org/geotools/test/xml/XmlTestSupport.java
+++ b/modules/library/sample-data/src/main/java/org/geotools/test/xml/XmlTestSupport.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.hamcrest.Matcher;
+import org.junit.Assert;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
 import org.xmlunit.matchers.EvaluateXPathMatcher;
@@ -95,5 +96,22 @@ public abstract class XmlTestSupport {
                 .checkForSimilar()
                 .withNamespaceContext(getNamespaces())
                 .build();
+    }
+
+    /**
+     * Assert throwable message contains expected string.
+     *
+     * <p>Intended to search for fragments when testing the contents of Locale or platform specific error messages.
+     *
+     * @param throwable Throwable
+     * @param expected Expected string
+     */
+    public static void assertMessageContains(Throwable throwable, String... expected) {
+        String message = (throwable != null && throwable.getMessage() != null) ? throwable.getMessage() : "";
+        for (String fragment : expected) {
+            if (!message.contains(fragment)) {
+                Assert.fail("Expected " + String.join(",", expected) + ": " + message);
+            }
+        }
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
@@ -58,18 +58,30 @@ import org.xml.sax.SAXException;
 public class DocumentFactory {
 
     /**
-     * When this hint is contained and set to Boolean.FALSE, element ordering will not be validated. This key may also
-     * affect data validation within the parse routines. The inherent safety of the resulting objects is weekend by
-     * turning this param to false.
+     * When this hint is contained and set to {@code Boolean.FALSE}, element ordering will not be validated. This key
+     * may also affect data validation within the parse routines.
+     *
+     * <p>The inherent safety of the resulting objects is weekend by turning this param to false.
      */
     public static final String VALIDATION_HINT = "DocumentFactory_VALIDATION_HINT";
 
     /**
-     * When this hint is contained and set to Boolean.TRUE, external entities will be disabled. This setting is used to
-     * alleviate XXE attacks, preventing both {@link #VALIDATION_HINT} and {@link XMLHandlerHints#ENTITY_RESOLVER} from
-     * being effective.
+     * When this hint is contained and set to {@code Boolean.TRUE} (the default value), external entities will be
+     * disabled.
+     *
+     * <p>This setting is used to alleviate XXE attacks, preventing both {@link #VALIDATION_HINT} and
+     * {@link XMLHandlerHints#ENTITY_RESOLVER} from being effective.
      */
     public static final String DISABLE_EXTERNAL_ENTITIES = "DocumentFactory_DISABLE_EXTERNAL_ENTITIES";
+
+    /**
+     * When this hint is contained and set to {@code Boolean.TRUE}, parsing and validation supports use of DTD.
+     *
+     * <p>A few standards such as SLD1.0 and WMS1.1 make use of DTD support and require this hint to be set to true.
+     */
+    public static final String ENABLE_DTD = "DocumentFactory_ENABLE_DTD";
+
+    public static final String LOG_LEVEL = "DocumentFactory_LOG_LEVEL";
 
     /**
      * calls getInstance(URI,Level) with Level.WARNING
@@ -88,14 +100,15 @@ public class DocumentFactory {
      *
      * @param hints May be null.
      * @return Object
-     * @see DocumentFactory#getInstance(URI, Map, Level, boolean)
      */
-    public static Object getInstance(URI desiredDocument, Map<String, Object> hints, Level level) throws SAXException {
+    public static Object getInstance(URI desiredDocument, Map<String, Object> hints, Level defaultLevel)
+            throws SAXException {
         SAXParser parser = getParser(hints);
 
         XMLSAXHandler xmlContentHandler = new XMLSAXHandler(desiredDocument, hints);
-        XMLSAXHandler.setLogLevel(level);
 
+        Level level = hint(Level.class, hints, LOG_LEVEL, defaultLevel);
+        XMLSAXHandler.setLogLevel(level);
         try {
             parser.parse(desiredDocument.toString(), xmlContentHandler);
         } catch (IOException e) {
@@ -109,23 +122,24 @@ public class DocumentFactory {
      * Parses the instance data provided. This method assumes that the XML document is fully described using XML
      * Schemas. Failure to be fully described as Schemas will result in errors, as opposed to a vid parse.
      *
-     * @param hints May be null.
-     * @return Object
-     * @see DocumentFactory#getInstance(InputStream, Map, Level, boolean)
+     * @param is InputStream to parse, will be closed by this method.
+     * @param hints DocumentFactory parsing hints
+     * @param defaultLevel Log level to use for logging during parsing, may be null (defaults to Level.WARNING).
+     * @return Parsed
+     * @throws SAXException If an error occurs during parsing, or if the provided InputStream cannot be read.
      */
-    public static Object getInstance(InputStream is, Map<String, Object> hints, Level level) throws SAXException {
+    public static Object getInstance(InputStream is, Map<String, Object> hints, Level defaultLevel)
+            throws SAXException {
         SAXParser parser = getParser(hints);
 
         XMLSAXHandler xmlContentHandler = new XMLSAXHandler(hints);
+        Level level = hint(Level.class, hints, LOG_LEVEL, defaultLevel);
         XMLSAXHandler.setLogLevel(level);
-
         try {
             parser.parse(is, xmlContentHandler);
         } catch (IOException e) {
-            XMLSAXHandler.logger.warning(e.toString());
             throw new SAXException(e);
         }
-
         return xmlContentHandler.getDocument();
     }
 
@@ -155,24 +169,69 @@ public class DocumentFactory {
             // For more info: https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Processing
             // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet
 
+            boolean enableDTD = hint(hints, ENABLE_DTD, false);
+
             // Step 1 distable DTD support - not needed for schema driven parser
             //
             // Note: XMLSaxHandler will reject all DTD references - but we may as well avoid early
-            // spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", !enableDTD);
+
+            if (enableDTD) {
+                XMLUtils.supportDTD(saxParserFactory, true, factoryConfig);
+            }
+            saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", enableDTD);
 
             // Step 2 optionally disable external entities
             //
-            if (hints != null
-                    && hints.containsKey(DISABLE_EXTERNAL_ENTITIES)
-                    && Boolean.TRUE.equals(hints.get(DISABLE_EXTERNAL_ENTITIES))) {
+            if (hint(hints, DISABLE_EXTERNAL_ENTITIES, true)) {
                 saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
                 saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             }
-            SAXParser sp = XMLUtils.newSAXParser(saxParserFactory, factoryConfig);
-            return sp;
+
+            SAXParser parser = XMLUtils.newSAXParser(saxParserFactory, factoryConfig);
+            if (enableDTD) {
+                XMLUtils.supportDTD(parser, enableDTD, factoryConfig);
+            }
+
+            return parser;
         } catch (ParserConfigurationException e) {
             throw new SAXException(e);
         }
+    }
+
+    /**
+     * Safely check hints for provided key.
+     *
+     * @param hints Map of hints, may be {@null} if not provided.
+     * @param key Key to look up hint value
+     * @param defaultValue Default value returned if value is not available, or not a {@code Boolean}.
+     * @return Value of hint if available and a {@code Boolean}, otherwise {@code defaultValue}.
+     */
+    public static <T> T hint(Class<T> type, Map<String, Object> hints, String key, T defaultValue) {
+        if (key != null && hints != null && hints.containsKey(key)) {
+            Object value = hints.get(key);
+            if (type.isInstance(value)) {
+                return type.cast(value);
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Safely check hints for provided key.
+     *
+     * @param hints Map of hints, may be {@null} if not provided.
+     * @param key Key to look up hint value
+     * @param defaultValue Default value returned if value is not available, or not a {@code Boolean}.
+     * @return Value of hint if available and a {@code Boolean}, otherwise {@code defaultValue}.
+     */
+    public static boolean hint(Map<String, Object> hints, String key, boolean defaultValue) {
+        if (key != null && hints != null && hints.containsKey(key)) {
+            Object value = hints.get(key);
+            if (value instanceof Boolean) {
+                return (Boolean) value;
+            }
+        }
+        return defaultValue;
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
@@ -61,7 +61,7 @@ public class DocumentFactory {
      * When this hint is contained and set to {@code Boolean.FALSE}, element ordering will not be validated. This key
      * may also affect data validation within the parse routines.
      *
-     * <p>The inherent safety of the resulting objects is weekend by turning this param to false.
+     * <p>The inherent safety of the resulting objects is weakened by turning this param to {@code false}.
      */
     public static final String VALIDATION_HINT = "DocumentFactory_VALIDATION_HINT";
 
@@ -84,7 +84,7 @@ public class DocumentFactory {
     public static final String LOG_LEVEL = "DocumentFactory_LOG_LEVEL";
 
     /**
-     * calls getInstance(URI,Level) with Level.WARNING
+     * Calls getInstance(URI,Level) with Level.WARNING.
      *
      * @param hints May be null.
      * @return Object

--- a/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/DocumentFactory.java
@@ -145,6 +145,9 @@ public class DocumentFactory {
 
     /*
      * Convenience method to create an instance of a SAXParser if it is null.
+     *
+     * Tests can request SAXParser configuration using hints {@code ENTITY_RESOLVER}, {@code SAX_PARSER_FACTORY},
+     * {@code ENABLE_DTD}, {@code DISABLE_EXTERNAL_ENTITIES}.
      */
     private static SAXParser getParser(Map<String, Object> hints) throws SAXException {
 
@@ -162,7 +165,6 @@ public class DocumentFactory {
         }
         saxParserFactory.setNamespaceAware(true);
         saxParserFactory.setValidating(false);
-
         try {
             // Extra precaution to reduce/prevent XXE attacks
             //
@@ -171,27 +173,21 @@ public class DocumentFactory {
 
             boolean enableDTD = hint(hints, ENABLE_DTD, false);
 
-            // Step 1 distable DTD support - not needed for schema driven parser
+            // Step 1 Factory Disable/enable DTD support - not needed for schema driven parser
             //
             // Note: XMLSaxHandler will reject all DTD references - but we may as well avoid early
-            saxParserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", !enableDTD);
+            XMLUtils.supportDTD(saxParserFactory, enableDTD, factoryConfig);
 
-            if (enableDTD) {
-                XMLUtils.supportDTD(saxParserFactory, true, factoryConfig);
-            }
-            saxParserFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", enableDTD);
+            // Step 2 Factory optionally disable external entities
+            boolean disableExternalEntities = hint(hints, DISABLE_EXTERNAL_ENTITIES, enableDTD);
+            saxParserFactory.setFeature(
+                    "http://xml.org/sax/features/external-general-entities", !disableExternalEntities);
+            saxParserFactory.setFeature(
+                    "http://xml.org/sax/features/external-parameter-entities", !disableExternalEntities);
 
-            // Step 2 optionally disable external entities
-            //
-            if (hint(hints, DISABLE_EXTERNAL_ENTITIES, true)) {
-                saxParserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-                saxParserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            }
-
+            // Step 3 Parser external access based on entityResolver used
             SAXParser parser = XMLUtils.newSAXParser(saxParserFactory, factoryConfig);
-            if (enableDTD) {
-                XMLUtils.supportDTD(parser, enableDTD, factoryConfig);
-            }
+            XMLUtils.supportDTD(parser, enableDTD, factoryConfig);
 
             return parser;
         } catch (ParserConfigurationException e) {

--- a/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
@@ -413,8 +413,10 @@ public class SchemaFactory {
             SAXParserFactory saxParserFactory = XMLUtils.newSAXParserFactory();
             saxParserFactory.setNamespaceAware(true);
             saxParserFactory.setValidating(false);
+            XMLUtils.supportDTD(saxParserFactory, true, null);
             try {
                 parser = XMLUtils.newSAXParser(saxParserFactory);
+                XMLUtils.supportDTD(parser, true, null);
                 parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver());
                 parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
                 parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");

--- a/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/SchemaFactory.java
@@ -415,7 +415,7 @@ public class SchemaFactory {
             saxParserFactory.setValidating(false);
             try {
                 parser = XMLUtils.newSAXParser(saxParserFactory);
-                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(null));
+                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver());
                 parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "all");
                 parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
             } catch (ParserConfigurationException | SAXException e) {

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLHandlerHints.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLHandlerHints.java
@@ -204,6 +204,6 @@ public class XMLHandlerHints implements Map<String, Object> {
                 return entityResolver;
             }
         }
-        return GeoTools.getEntityResolver(null);
+        return GeoTools.getEntityResolver();
     }
 }

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLSAXHandler.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLSAXHandler.java
@@ -57,7 +57,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * @see XMLElementHandler
  */
 public class XMLSAXHandler extends DefaultHandler {
-    /** the logger -- should be used for debugging (assuming there are bugs LOL) */
+    /** the logger -- should be used for debugging and tracing parsing errors */
     protected static final Logger logger = org.geotools.util.logging.Logging.getLogger(XMLSAXHandler.class);
 
     protected static Level level = Level.FINE;

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -647,9 +647,7 @@ public class XMLUtils {
 
         DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD AvoidDocumentBuilder
         builder.setEntityResolver(GeoTools.getEntityResolver(hints));
-        if (factory.isValidating()) {
-            builder.setErrorHandler(new SAXErrorHandler());
-        }
+        builder.setErrorHandler(new SAXErrorHandler());
         return builder;
     }
 
@@ -683,12 +681,6 @@ public class XMLUtils {
         } catch (ParserConfigurationException e) {
             // Xerces specific feature, so not required to be supported
             LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
-                    + factory.getClass().getName());
-        }
-        try {
-            if (factory.isXIncludeAware() != supportDTD) factory.setXIncludeAware(supportDTD);
-        } catch (UnsupportedOperationException e) {
-            LOGGER.fine("setXIncludeAware setting not supported: "
                     + factory.getClass().getName());
         }
 
@@ -1060,6 +1052,9 @@ public class XMLUtils {
                 LOGGER.fine("Parser does not support secure processing feature: "
                         + this.factory.getClass().getName());
             }
+            supportDTD(this.factory, false, hints);
+
+            // Expand Entity References disabled by default, as it requires DTD support
             try {
                 factory.setExpandEntityReferences(false);
             } catch (UnsupportedOperationException e) {
@@ -1067,9 +1062,13 @@ public class XMLUtils {
                         + factory.getClass().getName());
             }
 
-            supportDTD(this.factory, false, hints);
-
             // Sensible XSD factory defaults based on EntityResolver3
+            try {
+                if (factory.isXIncludeAware() != false) factory.setXIncludeAware(false);
+            } catch (UnsupportedOperationException e) {
+                LOGGER.fine("setXIncludeAware setting not supported: "
+                        + factory.getClass().getName());
+            }
             EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
             final String ACCESS = getAccess(entityResolver, "");
             try {
@@ -1145,6 +1144,36 @@ public class XMLUtils {
         @Override
         public boolean getFeature(String name) throws ParserConfigurationException {
             return this.factory.getFeature(name);
+        }
+
+        @Override
+        public void setIgnoringComments(boolean ignoreComments) {
+            this.factory.setIgnoringComments(ignoreComments);
+        }
+
+        @Override
+        public boolean isIgnoringComments() {
+            return this.factory.isIgnoringComments();
+        }
+
+        @Override
+        public void setSchema(Schema schema) {
+            this.factory.setSchema(schema);
+        }
+
+        @Override
+        public Schema getSchema() {
+            return this.factory.getSchema();
+        }
+
+        @Override
+        public void setCoalescing(boolean coalescing) {
+            this.factory.setCoalescing(coalescing);
+        }
+
+        @Override
+        public boolean isCoalescing() {
+            return this.factory.isCoalescing();
         }
 
         @Override

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -262,6 +262,98 @@ public class XMLUtils {
         return toSAXParserFactory(factory, hints).newSAXParser();
     }
 
+    /**
+     * Used to configure a SAXParserFactory to allow / disallow DTD use.
+     *
+     * <p>DTD support requires both SAXParser parser to be configured:
+     *
+     * <pre>{@literal
+     * SAXParserFactory factory = XMLUtils.newSAXParserFactory(hints);
+     * XMLUtils.supportDTD(factory,true,hints);
+     * SAXParser parser = factory.newSAXParser();
+     * XMLUtils.supportDTD(parser,true,hints);
+     * XMLReader reader = parser.getXMLReader();
+     * }</pre>
+     *
+     * @param factory SAXParserFactory to configure
+     * @param supportDTD {@code false} to disable DTD support, {@code true} to enable DTD support
+     * @param hints Factory configuration
+     * @return SAXParser with DTD support configured according to {@code supportDTD} and GeoTools configuration
+     */
+    public static SAXParserFactory supportDTD(SAXParserFactory factory, boolean supportDTD, Hints hints) {
+        // Recommended: Disable Xerces
+        try {
+            if (factory.getFeature(DISALLOW_DOCTYPE_DECL) != !supportDTD)
+                factory.setFeature(DISALLOW_DOCTYPE_DECL, !supportDTD);
+        } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+            // Xerces specific feature, so not required to be supported
+            LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        try {
+            factory.setXIncludeAware(!supportDTD);
+        } catch (UnsupportedOperationException e) {
+            LOGGER.fine("setXIncludeAware setting not supported: "
+                    + factory.getClass().getName());
+        }
+
+        // For non Xerces parser, try another way...
+        // Both EXTERNAL_GENERAL_ENTITIES and EXTERNAL_PARAMETER_ENTITIES need to be disabled/enabled together
+        try {
+            if (factory.getFeature(EXTERNAL_GENERAL_ENTITIES) != supportDTD)
+                factory.setFeature(EXTERNAL_GENERAL_ENTITIES, supportDTD);
+        } catch (SAXNotSupportedException | ParserConfigurationException | SAXNotRecognizedException e) {
+            LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        try {
+            if (factory.getFeature(EXTERNAL_PARAMETER_ENTITIES) != supportDTD)
+                factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, supportDTD);
+        } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException e) {
+            LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        // Disable/enable external DTDs as well
+        try {
+            if (factory.getFeature(LOAD_EXTERNAL_DTD) != supportDTD) factory.setFeature(LOAD_EXTERNAL_DTD, supportDTD);
+        } catch (SAXNotSupportedException | ParserConfigurationException | SAXNotRecognizedException e) {
+            LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        return factory;
+    }
+
+    /**
+     * Used to configure SAXParser to allow / disallow DTD use.
+     *
+     * <p>When {@code false} the setting ACCESS_EXTERNAL_DTD is set to {@code ""}, however when {@code true} a value is
+     * determined using the parsers EntityResolver (if present), or provided factory Hints.
+     *
+     * <p>For more information see {@link XMLUtils#getAllow(EntityResolver,Stirng)}.
+     *
+     * @param parser SAXParser
+     * @param supportDTD {@code false} to disallow DTD support, or {@code true} to allow.
+     * @param hints Factory configuration hints
+     * @return SAXParser configured
+     */
+    public static SAXParser supportDTD(SAXParser parser, boolean supportDTD, Hints hints) {
+        EntityResolver entityResolver;
+        try {
+            if (parser.getXMLReader() != null && parser.getXMLReader().getEntityResolver() != null)
+                entityResolver = parser.getXMLReader().getEntityResolver();
+            else entityResolver = GeoTools.getEntityResolver(hints);
+        } catch (SAXException e) {
+            entityResolver = GeoTools.getEntityResolver(hints);
+        }
+        String allow = supportDTD ? XMLUtils.getAccess(entityResolver, "all") : "";
+        try {
+            parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, allow);
+        } catch (IllegalArgumentException | SAXNotRecognizedException | SAXNotSupportedException notSupported) {
+            LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
+        }
+        return parser;
+    }
+
     //
     // TransformerFactory and Transformer utility methods
     //
@@ -575,6 +667,77 @@ public class XMLUtils {
         return new GTDocumentBuilderFactory(hints);
     }
 
+    /**
+     * Used to configure a DocumentBuilderFactory to allow / disallow DTD use.
+     *
+     * @param factory DocumentBuilderFactory to configure
+     * @param supportDTD {@code false} to disable DTD support, {@code true} to enable DTD support
+     * @param hints Factory configuration
+     * @return SAXParser with DTD support configured according to {@code supportDTD} and GeoTools configuration
+     */
+    public static DocumentBuilderFactory supportDTD(DocumentBuilderFactory factory, boolean supportDTD, Hints hints) {
+        // Recommended: Disable Xerces only
+        try {
+            if (factory.getFeature(DISALLOW_DOCTYPE_DECL) != !supportDTD)
+                factory.setFeature(DISALLOW_DOCTYPE_DECL, !supportDTD);
+        } catch (ParserConfigurationException e) {
+            // Xerces specific feature, so not required to be supported
+            LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        try {
+            factory.setXIncludeAware(false);
+        } catch (UnsupportedOperationException e) {
+            LOGGER.fine("setXIncludeAware setting not supported: "
+                    + factory.getClass().getName());
+        }
+
+        // Both EXTERNAL_GENERAL_ENTITIES and EXTERNAL_PARAMETER_ENTITIES need to be disabled together
+        try {
+            if (factory.getFeature(EXTERNAL_PARAMETER_ENTITIES) != supportDTD)
+                factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, supportDTD);
+        } catch (ParserConfigurationException e) {
+            LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        try {
+            if (factory.getFeature(EXTERNAL_GENERAL_ENTITIES) != supportDTD)
+                factory.setFeature(EXTERNAL_GENERAL_ENTITIES, supportDTD);
+        } catch (ParserConfigurationException e) {
+            LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+
+        // disable external DTDs as well
+        try {
+            if (factory.getFeature(LOAD_EXTERNAL_DTD) != supportDTD) factory.setFeature(LOAD_EXTERNAL_DTD, supportDTD);
+        } catch (ParserConfigurationException e) {
+            LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
+                    + factory.getClass().getName());
+        }
+        try {
+            factory.setExpandEntityReferences(false);
+        } catch (UnsupportedOperationException e) {
+            LOGGER.fine("setExpandEntityReferences setting not supported: "
+                    + factory.getClass().getName());
+        }
+
+        try {
+            if (supportDTD) {
+                // If EntityResolver3 is used to provide access information,
+                // external entity facilities will be relaxed accordingly
+                EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+                String allow = getAccess(entityResolver, "all");
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, allow);
+            } else {
+                // Do not allow DTD access on any protocol
+                factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            }
+        } catch (IllegalArgumentException notSupported) {
+            LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
+        }
+        return factory;
+    }
     //
     // SchemaFactory
     //
@@ -626,7 +789,7 @@ public class XMLUtils {
      * @param protocol Default protocol to use if entityResolver is not recognized
      * @return Entity resolution protocol: {@code "all"}, {@code "http"}, or {@code ""} based on provided entityResolver
      */
-    private static String getAccess(EntityResolver entityResolver, String protocol) {
+    public static String getAccess(EntityResolver entityResolver, String protocol) {
         if (entityResolver == null) {
             return "";
         }
@@ -795,59 +958,7 @@ public class XMLUtils {
                 LOGGER.fine("Parser does not support secure processing feature: "
                         + this.factory.getClass().getName());
             }
-            // Disable DTD Use
-            boolean disabledDTD = false;
-
-            // Recommended: Disable Xerces only
-            try {
-                this.factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
-                this.factory.setXIncludeAware(false);
-                disabledDTD = true;
-            } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-                // Xerces specific feature, so not required to be supported
-                LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
-                        + this.factory.getClass().getName());
-            } catch (UnsupportedOperationException e) {
-                LOGGER.fine("setXIncludeAware setting not supported: "
-                        + this.factory.getClass().getName());
-            }
-
-            if (!disabledDTD) {
-                // Xerces disable not supported, try another way...
-
-                // Both EXTERNAL_GENERAL_ENTITIES and EXTERNAL_PARAMETER_ENTITIES need to be disabled together
-                try {
-                    this.factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
-                } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException e) {
-                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                try {
-                    this.factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
-                } catch (SAXNotSupportedException | ParserConfigurationException | SAXNotRecognizedException e) {
-                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                // disable external DTDs as well
-                try {
-                    this.factory.setFeature(LOAD_EXTERNAL_DTD, false);
-                } catch (SAXNotSupportedException | ParserConfigurationException | SAXNotRecognizedException e) {
-                    LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                try {
-                    this.factory.setXIncludeAware(false);
-                } catch (UnsupportedOperationException e) {
-                    LOGGER.fine("setXIncludeAware setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                disabledDTD = true;
-            }
-
-            if (!disabledDTD) {
-                LOGGER.warning("Unable to ensure DTD support is disabled: "
-                        + this.factory.getClass().getName());
-            }
+            XMLUtils.supportDTD(this, false, hints);
         }
 
         @Override
@@ -910,13 +1021,8 @@ public class XMLUtils {
             if (parser.getXMLReader() != null) {
                 parser.getXMLReader().setEntityResolver(entityResolver);
             }
+            XMLUtils.supportDTD(parser, false, hints);
 
-            // Do not allow DTD access on any protocol
-            try {
-                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            } catch (IllegalArgumentException notSupported) {
-                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
-            }
             // Sensible XSD factory defaults based on EntityResolver3
             final String ACCESS = getAccess(entityResolver, "");
             try {
@@ -959,72 +1065,7 @@ public class XMLUtils {
                 LOGGER.fine("Parser does not support secure processing feature: "
                         + this.factory.getClass().getName());
             }
-            // Disable DTD Use
-            boolean disabledDTD = false;
-
-            // Recommended: Disable Xerces only
-            try {
-                this.factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
-                this.factory.setXIncludeAware(false);
-                disabledDTD = true;
-            } catch (ParserConfigurationException e) {
-                // Xerces specific feature, so not required to be supported
-                LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
-                        + this.factory.getClass().getName());
-            } catch (UnsupportedOperationException e) {
-                LOGGER.fine("setXIncludeAware setting not supported: "
-                        + this.factory.getClass().getName());
-            }
-
-            if (!disabledDTD) {
-                // Xerces disable not supported, try another way...
-
-                // Both EXTERNAL_GENERAL_ENTITIES and EXTERNAL_PARAMETER_ENTITIES need to be disabled together
-                try {
-                    this.factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
-                } catch (ParserConfigurationException e) {
-                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                try {
-                    this.factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
-                } catch (ParserConfigurationException e) {
-                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                // disable external DTDs as well
-                try {
-                    this.factory.setFeature(LOAD_EXTERNAL_DTD, false);
-                } catch (ParserConfigurationException e) {
-                    LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                try {
-                    this.factory.setXIncludeAware(false);
-                } catch (UnsupportedOperationException e) {
-                    LOGGER.fine("setXIncludeAware setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                try {
-                    this.factory.setExpandEntityReferences(false);
-                } catch (UnsupportedOperationException e) {
-                    LOGGER.fine("setExpandEntityReferences setting not supported: "
-                            + this.factory.getClass().getName());
-                }
-                disabledDTD = true;
-            }
-
-            if (!disabledDTD) {
-                LOGGER.warning("Unable to ensure DTD support is disabled: "
-                        + this.factory.getClass().getName());
-            }
-
-            // Do not allow DTD access on any protocol
-            try {
-                this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            } catch (IllegalArgumentException notSupported) {
-                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
-            }
+            supportDTD(this.factory, false, hints);
 
             // Sensible XSD factory defaults based on EntityResolver3
             EntityResolver entityResolver = GeoTools.getEntityResolver(hints);

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -109,6 +109,17 @@ public class XMLUtils {
         // Used to determine sensible defaults based on entity resolver selected
         EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
         String access = getAccess(entityResolver, "");
+
+        // We are disabling DTD by default since it is not often used by OGC Standards
+        // (only WMS1.1 and GML1 and SLD1.0 standards make use of DTD)
+        if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
+            factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+        }
+        if (factory.isPropertySupported(XMLInputFactory.IS_COALESCING)) {
+            // coalescing needs to be false to disable resolving of external DTD entities
+            factory.setProperty(XMLInputFactory.IS_COALESCING, false);
+        }
+
         if (access.isEmpty()) {
             // GeoTools locks down all external entity facilities by default
             if (factory.isPropertySupported(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES)) {
@@ -126,8 +137,7 @@ public class XMLUtils {
             if (factory.isPropertySupported(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES)) {
                 factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
             }
-        }
-        if (!access.isEmpty()) {
+        } else {
             // If EntityResolver3 is used to provide access information,
             // external entity facilities will be relaxed accordingly
             boolean all = access.contains("all");
@@ -142,13 +152,6 @@ public class XMLUtils {
             }
             if (factory.isPropertySupported(XMLConstants.ACCESS_EXTERNAL_SCHEMA)) {
                 factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, access);
-            }
-            if (factory.isPropertySupported(XMLInputFactory.SUPPORT_DTD)) {
-                factory.setProperty(XMLInputFactory.SUPPORT_DTD, internal || external);
-            }
-            if (factory.isPropertySupported(XMLInputFactory.IS_COALESCING)) {
-                // coalescing needs to be false to disable resolving of external DTD entities
-                factory.setProperty(XMLInputFactory.IS_COALESCING, internal || external);
             }
             if (factory.isPropertySupported(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES)) {
                 factory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, all);

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -786,10 +786,66 @@ public class XMLUtils {
         public GTSAXParserFactory(SAXParserFactory factory, Hints hints) {
             this.hints = hints;
             this.factory = factory != null ? factory : SAXParserFactory.newInstance(); // NOPMD AvoidParserFactory
+
+            // DocumentBuilderFactory and SAXParserFactory can be protected with the same techniques
             try {
                 this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-                LOGGER.finer("Parser does not support secure processing feature: "
+                // feature secure processing recommended, but not supported
+                LOGGER.fine("Parser does not support secure processing feature: "
+                        + this.factory.getClass().getName());
+            }
+            // Disable DTD Use
+            boolean disabledDTD = false;
+
+            // Recommended: Disable Xerces only
+            try {
+                this.factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+                this.factory.setXIncludeAware(false);
+                disabledDTD = true;
+            } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
+                // Xerces specific feature, so not required to be supported
+                LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
+                        + this.factory.getClass().getName());
+            } catch (UnsupportedOperationException e) {
+                LOGGER.fine("setXIncludeAware setting not supported: "
+                        + this.factory.getClass().getName());
+            }
+
+            if (!disabledDTD) {
+                // Xerces disable not supported, try another way...
+
+                // Both EXTERNAL_GENERAL_ENTITIES and EXTERNAL_PARAMETER_ENTITIES need to be disabled together
+                try {
+                    this.factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+                } catch (SAXNotRecognizedException | SAXNotSupportedException | ParserConfigurationException e) {
+                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                try {
+                    this.factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+                } catch (SAXNotSupportedException | ParserConfigurationException | SAXNotRecognizedException e) {
+                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                // disable external DTDs as well
+                try {
+                    this.factory.setFeature(LOAD_EXTERNAL_DTD, false);
+                } catch (SAXNotSupportedException | ParserConfigurationException | SAXNotRecognizedException e) {
+                    LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                try {
+                    this.factory.setXIncludeAware(false);
+                } catch (UnsupportedOperationException e) {
+                    LOGGER.fine("setXIncludeAware setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                disabledDTD = true;
+            }
+
+            if (!disabledDTD) {
+                LOGGER.warning("Unable to ensure DTD support is disabled: "
                         + this.factory.getClass().getName());
             }
         }
@@ -849,8 +905,24 @@ public class XMLUtils {
         @Override
         public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
             SAXParser parser = factory.newSAXParser();
+
+            EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
             if (parser.getXMLReader() != null) {
-                parser.getXMLReader().setEntityResolver(GeoTools.getEntityResolver(hints));
+                parser.getXMLReader().setEntityResolver(entityResolver);
+            }
+
+            // Do not allow DTD access on any protocol
+            try {
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
+            }
+            // Sensible XSD factory defaults based on EntityResolver3
+            final String ACCESS = getAccess(entityResolver, "");
+            try {
+                parser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ACCESS);
+            } catch (IllegalArgumentException notSupported) {
+                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_SCHEMA: " + notSupported.getMessage());
             }
             return parser;
         }
@@ -878,6 +950,8 @@ public class XMLUtils {
         public GTDocumentBuilderFactory(Hints hints) {
             this.hints = hints != null ? hints : GeoTools.getDefaultHints();
             this.factory = DocumentBuilderFactory.newInstance(); // NOPMD AvoidDocumentBuilderFactory
+
+            // DocumentBuilderFactory and SAXParserFactory can be protected with the same techniques
             try {
                 this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException e) {

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -686,7 +686,7 @@ public class XMLUtils {
                     + factory.getClass().getName());
         }
         try {
-            factory.setXIncludeAware(false);
+            if (factory.isXIncludeAware() != supportDTD) factory.setXIncludeAware(supportDTD);
         } catch (UnsupportedOperationException e) {
             LOGGER.fine("setXIncludeAware setting not supported: "
                     + factory.getClass().getName());
@@ -713,12 +713,6 @@ public class XMLUtils {
             if (factory.getFeature(LOAD_EXTERNAL_DTD) != supportDTD) factory.setFeature(LOAD_EXTERNAL_DTD, supportDTD);
         } catch (ParserConfigurationException e) {
             LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
-                    + factory.getClass().getName());
-        }
-        try {
-            factory.setExpandEntityReferences(false);
-        } catch (UnsupportedOperationException e) {
-            LOGGER.fine("setExpandEntityReferences setting not supported: "
                     + factory.getClass().getName());
         }
 
@@ -1057,7 +1051,8 @@ public class XMLUtils {
             this.hints = hints != null ? hints : GeoTools.getDefaultHints();
             this.factory = DocumentBuilderFactory.newInstance(); // NOPMD AvoidDocumentBuilderFactory
 
-            // DocumentBuilderFactory and SAXParserFactory can be protected with the same techniques
+            // choosing sensible defaults for document builder factory
+            // see: https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html
             try {
                 this.factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             } catch (ParserConfigurationException e) {
@@ -1065,6 +1060,13 @@ public class XMLUtils {
                 LOGGER.fine("Parser does not support secure processing feature: "
                         + this.factory.getClass().getName());
             }
+            try {
+                factory.setExpandEntityReferences(false);
+            } catch (UnsupportedOperationException e) {
+                LOGGER.fine("setExpandEntityReferences setting not supported: "
+                        + factory.getClass().getName());
+            }
+
             supportDTD(this.factory, false, hints);
 
             // Sensible XSD factory defaults based on EntityResolver3
@@ -1083,6 +1085,26 @@ public class XMLUtils {
             builder.setEntityResolver(GeoTools.getEntityResolver(hints));
 
             return builder;
+        }
+
+        @Override
+        public boolean isExpandEntityReferences() {
+            return factory.isExpandEntityReferences();
+        }
+
+        @Override
+        public void setExpandEntityReferences(boolean expandEntityReferences) {
+            factory.setExpandEntityReferences(expandEntityReferences);
+        }
+
+        @Override
+        public boolean isXIncludeAware() {
+            return this.factory.isXIncludeAware();
+        }
+
+        @Override
+        public void setXIncludeAware(boolean state) {
+            this.factory.setXIncludeAware(state);
         }
 
         @Override

--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -77,7 +77,16 @@ import org.xml.sax.helpers.NamespaceSupport;
  * @author Andrea Aime - GeoSolutions
  */
 public class XMLUtils {
+
     static final Logger LOGGER = Logging.getLogger(XMLUtils.class);
+
+    // Apache Xerces Features
+    static final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+    static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+    // SAX Features
+    static final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+    static final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
 
     //
     // XMLInputFactory
@@ -876,15 +885,76 @@ public class XMLUtils {
                 LOGGER.fine("Parser does not support secure processing feature: "
                         + this.factory.getClass().getName());
             }
-            // Sensible factory defaults based on EntityResolver
-            EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
-            final String ACCESS = getAccess(entityResolver, "");
+            // Disable DTD Use
+            boolean disabledDTD = false;
 
+            // Recommended: Disable Xerces only
             try {
-                this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, ACCESS);
+                this.factory.setFeature(DISALLOW_DOCTYPE_DECL, true);
+                this.factory.setXIncludeAware(false);
+                disabledDTD = true;
+            } catch (ParserConfigurationException e) {
+                // Xerces specific feature, so not required to be supported
+                LOGGER.fine("Xerces `" + DISALLOW_DOCTYPE_DECL + "` setting not supported: "
+                        + this.factory.getClass().getName());
+            } catch (UnsupportedOperationException e) {
+                LOGGER.fine("setXIncludeAware setting not supported: "
+                        + this.factory.getClass().getName());
+            }
+
+            if (!disabledDTD) {
+                // Xerces disable not supported, try another way...
+
+                // Both EXTERNAL_GENERAL_ENTITIES and EXTERNAL_PARAMETER_ENTITIES need to be disabled together
+                try {
+                    this.factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+                } catch (ParserConfigurationException e) {
+                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                try {
+                    this.factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+                } catch (ParserConfigurationException e) {
+                    LOGGER.fine("Sax `" + EXTERNAL_PARAMETER_ENTITIES + "` setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                // disable external DTDs as well
+                try {
+                    this.factory.setFeature(LOAD_EXTERNAL_DTD, false);
+                } catch (ParserConfigurationException e) {
+                    LOGGER.fine("Xerces `" + LOAD_EXTERNAL_DTD + "` setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                try {
+                    this.factory.setXIncludeAware(false);
+                } catch (UnsupportedOperationException e) {
+                    LOGGER.fine("setXIncludeAware setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                try {
+                    this.factory.setExpandEntityReferences(false);
+                } catch (UnsupportedOperationException e) {
+                    LOGGER.fine("setExpandEntityReferences setting not supported: "
+                            + this.factory.getClass().getName());
+                }
+                disabledDTD = true;
+            }
+
+            if (!disabledDTD) {
+                LOGGER.warning("Unable to ensure DTD support is disabled: "
+                        + this.factory.getClass().getName());
+            }
+
+            // Do not allow DTD access on any protocol
+            try {
+                this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
             } catch (IllegalArgumentException notSupported) {
                 LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
             }
+
+            // Sensible XSD factory defaults based on EntityResolver3
+            EntityResolver entityResolver = GeoTools.getEntityResolver(hints);
+            final String ACCESS = getAccess(entityResolver, "");
             try {
                 this.factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, ACCESS);
             } catch (IllegalArgumentException notSupported) {

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -105,9 +105,8 @@ import org.geotools.styling.ShadedReliefImpl;
 import org.geotools.styling.UomOgcMapping;
 import org.geotools.styling.UserLayerImpl;
 import org.geotools.util.Base64;
-import org.geotools.util.DefaultEntityResolver;
+import org.geotools.util.EntityResolver3;
 import org.geotools.util.GrowableInternationalString;
-import org.geotools.util.NullEntityResolver;
 import org.geotools.util.SimpleInternationalString;
 import org.geotools.util.factory.GeoTools;
 import org.geotools.xml.XMLUtils;
@@ -195,9 +194,12 @@ public class SLDParser {
 
     protected StyleFactory factory;
 
+    protected boolean supportsDTD = false;
+
     /** provides complete control for detecting relative onlineresources */
     private ResourceLocator onlineResourceLocator;
 
+    /** Provide control of entity resolution, yse EntityResolver3 to limit protocols supported. */
     private EntityResolver entityResolver;
 
     private boolean disposeInputSource;
@@ -352,6 +354,25 @@ public class SLDParser {
         this.entityResolver = entityResolver;
     }
 
+    /**
+     * Use of DTD is not recommended, and is {@code false} by default. May be set to true {@cpde true} if required for
+     * XML using DOCTYPE.
+     *
+     * @return {@code false} to prevent support of DTD.
+     */
+    public boolean isSupportsDTD() {
+        return supportsDTD;
+    }
+
+    /**
+     * Use of DTD is not recommended, and is {@code false} by default.
+     *
+     * @param supportsDTD {@code false} to prevent support of DTD, {@cpde true} if required for XML using DOCTYPE.
+     */
+    public void setSupportsDTD(boolean supportsDTD) {
+        this.supportsDTD = supportsDTD;
+    }
+
     /** Internal setter for source url. */
     void setSourceUrl(URL sourceUrl) {
         if (onlineResourceLocator instanceof DefaultResourceLocator locator) {
@@ -371,29 +392,64 @@ public class SLDParser {
         javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
         dbf.setNamespaceAware(namespaceAware);
 
-        if (entityResolver != null) {
+        if (this.supportsDTD) {
+            // DTD access restricted by XMLUtils, provided limited DTD access using entityResolver guidance
+            String access;
+            if (entityResolver != null && entityResolver instanceof EntityResolver3 entityResolver3)
+                access = entityResolver3.getAccess();
+            else access = "";
             try {
-                if (entityResolver == DefaultEntityResolver.INSTANCE) {
-                    dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "http");
-                } else if (entityResolver == NullEntityResolver.INSTANCE) {
-                    dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "all");
-                } else {
-                    dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "file,http");
-                }
+                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, access);
             } catch (IllegalArgumentException notSupported) {
                 LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
             }
-            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        }
 
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", true);
+        // First use xerces settings
+        final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+        try {
+            if (dbf.getFeature(DISALLOW_DOCTYPE_DECL) != !this.supportsDTD)
+                dbf.setFeature(DISALLOW_DOCTYPE_DECL, !this.supportsDTD);
+        } catch (ParserConfigurationException notSupported) {
+            LOGGER.fine("Parser does not support '" + DISALLOW_DOCTYPE_DECL + "': " + notSupported.getMessage());
+        }
+
+        try {
+            dbf.setXIncludeAware(this.supportsDTD);
+        } catch (UnsupportedOperationException e) {
+            LOGGER.fine("setXIncludeAware setting not supported: "
+                    + this.factory.getClass().getName());
+        }
+
+        // Disable DTD (although this is now the default from XMLUtils
+        final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+        final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+        final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+
+        try {
+            if (dbf.getFeature(LOAD_EXTERNAL_DTD) != this.supportsDTD)
+                dbf.setFeature(LOAD_EXTERNAL_DTD, this.supportsDTD);
+        } catch (ParserConfigurationException notSupported) {
+            LOGGER.fine("Parser does not support '" + LOAD_EXTERNAL_DTD + "': " + notSupported.getMessage());
+        }
+        try {
+            if (dbf.getFeature(EXTERNAL_GENERAL_ENTITIES) != this.supportsDTD)
+                dbf.setFeature(EXTERNAL_GENERAL_ENTITIES, this.supportsDTD);
+        } catch (ParserConfigurationException notSupported) {
+            LOGGER.fine("Parser does not support '" + EXTERNAL_GENERAL_ENTITIES + "': " + notSupported.getMessage());
+        }
+        try {
+            if (dbf.getFeature(EXTERNAL_PARAMETER_ENTITIES) != this.supportsDTD)
+                dbf.setFeature(EXTERNAL_PARAMETER_ENTITIES, this.supportsDTD);
+        } catch (ParserConfigurationException notSupported) {
+            LOGGER.fine("Parser does not support '" + EXTERNAL_PARAMETER_ENTITIES + "': " + notSupported.getMessage());
         }
 
         javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
         if (entityResolver != null) {
             db.setEntityResolver(entityResolver);
         } else {
-            db.setEntityResolver(GeoTools.getEntityResolver(null));
+            db.setEntityResolver(GeoTools.getEntityResolver());
         }
 
         return db;

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -35,6 +35,8 @@ import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.api.filter.Filter;
@@ -199,14 +201,17 @@ public class SLDParser {
     /** Support entity resolution expansion, default {@code false}. */
     protected boolean expandEntityReferences = false;
 
+    /** Support XInclude , default {@code false}. */
+    protected boolean xinclude = false;
+
+    /** Support validating , default {@code false}. */
+    protected boolean validating = false;
+
     /** provides complete control for detecting relative onlineresources */
     private ResourceLocator onlineResourceLocator;
 
     /** Provide control of entity resolution, yse EntityResolver3 to limit protocols supported. */
     private EntityResolver entityResolver;
-
-    /** Provide control over factory use and parsing */
-    private Hints hints = null;
 
     private boolean disposeInputSource;
 
@@ -390,14 +395,52 @@ public class SLDParser {
     }
 
     /**
-     * Use of expand entity references is not recommended, and is {@code false} by default. May be set to true
-     * {@cpde true} DOCTYPE is used to define injected entities.
+     * Use of expand entity references is not recommended, and is {@code false} by default. May be set to {@code true}
+     * if DOCTYPE is used to to define references.
      *
      * @param expandEntityReferences Use {@code false} to prevent support of expanding entity references, or
      *     {@code true} if required.
      */
     public void setExpandEntityReferences(boolean expandEntityReferences) {
         this.expandEntityReferences = expandEntityReferences;
+    }
+
+    /**
+     * Use of XInclude is not recommended, and is {@code false} by default. May be set to {@code true} to support
+     * inclusion of xsd content.
+     *
+     * @param xinclude Use {@code false} to prevent use of XInclude, or {@code true} if required.
+     */
+    public void setXInclude(boolean xinclude) {
+        this.xinclude = xinclude;
+    }
+
+    /**
+     * Use of XInclude is not recommended, and is {@code false} by default. May be set to {@code true} to support
+     * inclusion of xsd content.
+     *
+     * @return Use {@code false} to prevent use of XInclude, or {@code true} if required.
+     */
+    public boolean getXInclude() {
+        return this.xinclude;
+    }
+
+    /**
+     * Use of XInclude is not recommended, and is {@code false} by default.
+     *
+     * @param validating Use {@code false} to parse document without validation.
+     */
+    public void setValidating(boolean validating) {
+        this.validating = validating;
+    }
+
+    /**
+     * Use of validating is not required, and is {@code false} by default.
+     *
+     * @return Use {@code false} to parse document without validation.
+     */
+    public boolean getValidating() {
+        return this.validating;
     }
 
     /** Internal setter for source url. */
@@ -423,71 +466,33 @@ public class SLDParser {
 
         javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory(hints);
         dbf.setNamespaceAware(namespaceAware);
-
-        XMLUtils.supportDTD(dbf, this.supportDTD, hints);
-
+        if (validating) {
+            dbf.setValidating(true);
+            dbf.setAttribute(
+                    "http://java.sun.com/xml/jaxp/properties/schemaLanguage", XMLConstants.W3C_XML_SCHEMA_NS_URI);
+        }
+        // XSD configuration
         try {
-            if (dbf.isExpandEntityReferences() != this.expandEntityReferences)
-                dbf.setExpandEntityReferences(this.expandEntityReferences);
+            if (dbf.isXIncludeAware() != xinclude) dbf.setXIncludeAware(xinclude);
+        } catch (UnsupportedOperationException e) {
+            LOGGER.fine("setXIncludeAware setting not supported: "
+                    + factory.getClass().getName());
+        }
+
+        // DTD configuration
+        XMLUtils.supportDTD(dbf, this.supportDTD, hints);
+        try {
+            if (this.expandEntityReferences && !this.supportDTD) {
+                throw new IllegalStateException(
+                        "SLDParser expandEntityReferences is set to true, but supportDTD is false.");
+            }
+            // Expand entity references also requires Document Type Definition to define declaration
+            if (dbf.isExpandEntityReferences() != (this.expandEntityReferences && this.supportDTD))
+                dbf.setExpandEntityReferences(this.expandEntityReferences && this.supportDTD);
         } catch (UnsupportedOperationException e) {
             LOGGER.fine("setExpandEntityReferences setting not supported: "
                     + factory.getClass().getName());
         }
-        //        if (this.supportsDTD) {
-        //            // DTD access restricted by XMLUtils, provided limited DTD access using entityResolver guidance
-        //            String access;
-        //            if (entityResolver != null && entityResolver instanceof EntityResolver3 entityResolver3)
-        //                access = entityResolver3.getAccess();
-        //            else access = "";
-        //            try {
-        //                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, access);
-        //            } catch (IllegalArgumentException notSupported) {
-        //                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
-        //            }
-        //        }
-        //
-        //        // First use xerces settings
-        //        final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
-        //        try {
-        //            if (dbf.getFeature(DISALLOW_DOCTYPE_DECL) != !this.supportsDTD)
-        //                dbf.setFeature(DISALLOW_DOCTYPE_DECL, !this.supportsDTD);
-        //        } catch (ParserConfigurationException notSupported) {
-        //            LOGGER.fine("Parser does not support '" + DISALLOW_DOCTYPE_DECL + "': " +
-        // notSupported.getMessage());
-        //        }
-        //
-        //        try {
-        //            dbf.setXIncludeAware(this.supportsDTD);
-        //        } catch (UnsupportedOperationException e) {
-        //            LOGGER.fine("setXIncludeAware setting not supported: "
-        //                    + this.factory.getClass().getName());
-        //        }
-
-        //        // Disable DTD (although this is now the default from XMLUtils
-        //        final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-        //        final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
-        //        final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
-        //
-        //        try {
-        //            if (dbf.getFeature(LOAD_EXTERNAL_DTD) != this.supportsDTD)
-        //                dbf.setFeature(LOAD_EXTERNAL_DTD, this.supportsDTD);
-        //        } catch (ParserConfigurationException notSupported) {
-        //            LOGGER.fine("Parser does not support '" + LOAD_EXTERNAL_DTD + "': " + notSupported.getMessage());
-        //        }
-        //        try {
-        //            if (dbf.getFeature(EXTERNAL_GENERAL_ENTITIES) != this.supportsDTD)
-        //                dbf.setFeature(EXTERNAL_GENERAL_ENTITIES, this.supportsDTD);
-        //        } catch (ParserConfigurationException notSupported) {
-        //            LOGGER.fine("Parser does not support '" + EXTERNAL_GENERAL_ENTITIES + "': " +
-        // notSupported.getMessage());
-        //        }
-        //        try {
-        //            if (dbf.getFeature(EXTERNAL_PARAMETER_ENTITIES) != this.supportsDTD)
-        //                dbf.setFeature(EXTERNAL_PARAMETER_ENTITIES, this.supportsDTD);
-        //        } catch (ParserConfigurationException notSupported) {
-        //            LOGGER.fine("Parser does not support '" + EXTERNAL_PARAMETER_ENTITIES + "': " +
-        // notSupported.getMessage());
-        //        }
 
         javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf, hints);
 
@@ -502,7 +507,8 @@ public class SLDParser {
      */
     public Style[] readXML() {
         try {
-            dom = newDocumentBuilder(true).parse(source);
+            DocumentBuilder documentBuilder = newDocumentBuilder(true);
+            dom = documentBuilder.parse(source);
         } catch (ParserConfigurationException | IOException | SAXException pce) {
             throw new RuntimeException(pce);
         } finally {

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -35,7 +35,6 @@ import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.api.filter.Filter;
@@ -105,10 +104,10 @@ import org.geotools.styling.ShadedReliefImpl;
 import org.geotools.styling.UomOgcMapping;
 import org.geotools.styling.UserLayerImpl;
 import org.geotools.util.Base64;
-import org.geotools.util.EntityResolver3;
 import org.geotools.util.GrowableInternationalString;
 import org.geotools.util.SimpleInternationalString;
 import org.geotools.util.factory.GeoTools;
+import org.geotools.util.factory.Hints;
 import org.geotools.xml.XMLUtils;
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
@@ -120,7 +119,7 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * TODO: This really needs to be container ready
+ * Utility methods for working with SLD content.
  *
  * @author jgarnett
  */
@@ -194,7 +193,11 @@ public class SLDParser {
 
     protected StyleFactory factory;
 
-    protected boolean supportsDTD = false;
+    /** Support use of DOCTYPE DTD references, default {@code false}. */
+    protected boolean supportDTD = false;
+
+    /** Support entity resolution expansion, default {@code false}. */
+    protected boolean expandEntityReferences = false;
 
     /** provides complete control for detecting relative onlineresources */
     private ResourceLocator onlineResourceLocator;
@@ -202,12 +205,15 @@ public class SLDParser {
     /** Provide control of entity resolution, yse EntityResolver3 to limit protocols supported. */
     private EntityResolver entityResolver;
 
+    /** Provide control over factory use and parsing */
+    private Hints hints = null;
+
     private boolean disposeInputSource;
 
     private final ExpressionDOMParser expressionDOMParser = new ExpressionDOMParser(FF);
 
     /**
-     * Create a Stylereader - use if you already have a dom to parse.
+     * Create a SLDParser - use if you already have a dom to parse.
      *
      * @param factory The StyleFactory to use to build the style
      */
@@ -222,7 +228,7 @@ public class SLDParser {
     }
 
     /**
-     * Creates a new instance of SLDStyler
+     * Creates a new instance of SLDParser.
      *
      * @param factory The StyleFactory to use to read the file
      * @param filename The file to be read.
@@ -358,19 +364,40 @@ public class SLDParser {
      * Use of DTD is not recommended, and is {@code false} by default. May be set to true {@cpde true} if required for
      * XML using DOCTYPE.
      *
-     * @return {@code false} to prevent support of DTD.
+     * @return {@code false} to prevent support of DTD, or {@code true} if required.
      */
-    public boolean isSupportsDTD() {
-        return supportsDTD;
+    public boolean isSupportDTD() {
+        return supportDTD;
     }
 
     /**
      * Use of DTD is not recommended, and is {@code false} by default.
      *
-     * @param supportsDTD {@code false} to prevent support of DTD, {@cpde true} if required for XML using DOCTYPE.
+     * @param supportDTD {@code false} to prevent support of DTD, {@cpde true} if required for XML using DOCTYPE.
      */
-    public void setSupportsDTD(boolean supportsDTD) {
-        this.supportsDTD = supportsDTD;
+    public void setSupportDTD(boolean supportDTD) {
+        this.supportDTD = supportDTD;
+    }
+
+    /**
+     * Use of expand entity references is not recommended, and is {@code false} by default. May be set to true
+     * {@cpde true} DOCTYPE is used to define injected entities.
+     *
+     * @return {@code false} to prevent support of expanding entity references, or {@code true} if required.
+     */
+    public boolean isExpandEntityReferences() {
+        return expandEntityReferences;
+    }
+
+    /**
+     * Use of expand entity references is not recommended, and is {@code false} by default. May be set to true
+     * {@cpde true} DOCTYPE is used to define injected entities.
+     *
+     * @param expandEntityReferences Use {@code false} to prevent support of expanding entity references, or
+     *     {@code true} if required.
+     */
+    public void setExpandEntityReferences(boolean expandEntityReferences) {
+        this.expandEntityReferences = expandEntityReferences;
     }
 
     /** Internal setter for source url. */
@@ -389,68 +416,80 @@ public class SLDParser {
      */
     protected javax.xml.parsers.DocumentBuilder newDocumentBuilder(boolean namespaceAware)
             throws ParserConfigurationException {
-        javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory();
+        Hints hints = GeoTools.getDefaultHints();
+        if (entityResolver != null) {
+            hints.put(Hints.ENTITY_RESOLVER, entityResolver);
+        }
+
+        javax.xml.parsers.DocumentBuilderFactory dbf = XMLUtils.newDocumentBuilderFactory(hints);
         dbf.setNamespaceAware(namespaceAware);
 
-        if (this.supportsDTD) {
-            // DTD access restricted by XMLUtils, provided limited DTD access using entityResolver guidance
-            String access;
-            if (entityResolver != null && entityResolver instanceof EntityResolver3 entityResolver3)
-                access = entityResolver3.getAccess();
-            else access = "";
-            try {
-                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, access);
-            } catch (IllegalArgumentException notSupported) {
-                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
-            }
-        }
-
-        // First use xerces settings
-        final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
-        try {
-            if (dbf.getFeature(DISALLOW_DOCTYPE_DECL) != !this.supportsDTD)
-                dbf.setFeature(DISALLOW_DOCTYPE_DECL, !this.supportsDTD);
-        } catch (ParserConfigurationException notSupported) {
-            LOGGER.fine("Parser does not support '" + DISALLOW_DOCTYPE_DECL + "': " + notSupported.getMessage());
-        }
+        XMLUtils.supportDTD(dbf, this.supportDTD, hints);
 
         try {
-            dbf.setXIncludeAware(this.supportsDTD);
+            if (dbf.isExpandEntityReferences() != this.expandEntityReferences)
+                dbf.setExpandEntityReferences(this.expandEntityReferences);
         } catch (UnsupportedOperationException e) {
-            LOGGER.fine("setXIncludeAware setting not supported: "
-                    + this.factory.getClass().getName());
+            LOGGER.fine("setExpandEntityReferences setting not supported: "
+                    + factory.getClass().getName());
         }
+        //        if (this.supportsDTD) {
+        //            // DTD access restricted by XMLUtils, provided limited DTD access using entityResolver guidance
+        //            String access;
+        //            if (entityResolver != null && entityResolver instanceof EntityResolver3 entityResolver3)
+        //                access = entityResolver3.getAccess();
+        //            else access = "";
+        //            try {
+        //                dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, access);
+        //            } catch (IllegalArgumentException notSupported) {
+        //                LOGGER.fine("Parser does not support ACCESS_EXTERNAL_DTD: " + notSupported.getMessage());
+        //            }
+        //        }
+        //
+        //        // First use xerces settings
+        //        final String DISALLOW_DOCTYPE_DECL = "http://apache.org/xml/features/disallow-doctype-decl";
+        //        try {
+        //            if (dbf.getFeature(DISALLOW_DOCTYPE_DECL) != !this.supportsDTD)
+        //                dbf.setFeature(DISALLOW_DOCTYPE_DECL, !this.supportsDTD);
+        //        } catch (ParserConfigurationException notSupported) {
+        //            LOGGER.fine("Parser does not support '" + DISALLOW_DOCTYPE_DECL + "': " +
+        // notSupported.getMessage());
+        //        }
+        //
+        //        try {
+        //            dbf.setXIncludeAware(this.supportsDTD);
+        //        } catch (UnsupportedOperationException e) {
+        //            LOGGER.fine("setXIncludeAware setting not supported: "
+        //                    + this.factory.getClass().getName());
+        //        }
 
-        // Disable DTD (although this is now the default from XMLUtils
-        final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
-        final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
-        final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+        //        // Disable DTD (although this is now the default from XMLUtils
+        //        final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+        //        final String EXTERNAL_GENERAL_ENTITIES = "http://xml.org/sax/features/external-general-entities";
+        //        final String EXTERNAL_PARAMETER_ENTITIES = "http://xml.org/sax/features/external-parameter-entities";
+        //
+        //        try {
+        //            if (dbf.getFeature(LOAD_EXTERNAL_DTD) != this.supportsDTD)
+        //                dbf.setFeature(LOAD_EXTERNAL_DTD, this.supportsDTD);
+        //        } catch (ParserConfigurationException notSupported) {
+        //            LOGGER.fine("Parser does not support '" + LOAD_EXTERNAL_DTD + "': " + notSupported.getMessage());
+        //        }
+        //        try {
+        //            if (dbf.getFeature(EXTERNAL_GENERAL_ENTITIES) != this.supportsDTD)
+        //                dbf.setFeature(EXTERNAL_GENERAL_ENTITIES, this.supportsDTD);
+        //        } catch (ParserConfigurationException notSupported) {
+        //            LOGGER.fine("Parser does not support '" + EXTERNAL_GENERAL_ENTITIES + "': " +
+        // notSupported.getMessage());
+        //        }
+        //        try {
+        //            if (dbf.getFeature(EXTERNAL_PARAMETER_ENTITIES) != this.supportsDTD)
+        //                dbf.setFeature(EXTERNAL_PARAMETER_ENTITIES, this.supportsDTD);
+        //        } catch (ParserConfigurationException notSupported) {
+        //            LOGGER.fine("Parser does not support '" + EXTERNAL_PARAMETER_ENTITIES + "': " +
+        // notSupported.getMessage());
+        //        }
 
-        try {
-            if (dbf.getFeature(LOAD_EXTERNAL_DTD) != this.supportsDTD)
-                dbf.setFeature(LOAD_EXTERNAL_DTD, this.supportsDTD);
-        } catch (ParserConfigurationException notSupported) {
-            LOGGER.fine("Parser does not support '" + LOAD_EXTERNAL_DTD + "': " + notSupported.getMessage());
-        }
-        try {
-            if (dbf.getFeature(EXTERNAL_GENERAL_ENTITIES) != this.supportsDTD)
-                dbf.setFeature(EXTERNAL_GENERAL_ENTITIES, this.supportsDTD);
-        } catch (ParserConfigurationException notSupported) {
-            LOGGER.fine("Parser does not support '" + EXTERNAL_GENERAL_ENTITIES + "': " + notSupported.getMessage());
-        }
-        try {
-            if (dbf.getFeature(EXTERNAL_PARAMETER_ENTITIES) != this.supportsDTD)
-                dbf.setFeature(EXTERNAL_PARAMETER_ENTITIES, this.supportsDTD);
-        } catch (ParserConfigurationException notSupported) {
-            LOGGER.fine("Parser does not support '" + EXTERNAL_PARAMETER_ENTITIES + "': " + notSupported.getMessage());
-        }
-
-        javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf);
-        if (entityResolver != null) {
-            db.setEntityResolver(entityResolver);
-        } else {
-            db.setEntityResolver(GeoTools.getEntityResolver());
-        }
+        javax.xml.parsers.DocumentBuilder db = XMLUtils.newDocumentBuilder(dbf, hints);
 
         return db;
     }

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -210,7 +210,7 @@ public class SLDParser {
     /** provides complete control for detecting relative onlineresources */
     private ResourceLocator onlineResourceLocator;
 
-    /** Provide control of entity resolution, yse EntityResolver3 to limit protocols supported. */
+    /** Provide control of entity resolution, use EntityResolver3 to limit protocols supported. */
     private EntityResolver entityResolver;
 
     private boolean disposeInputSource;

--- a/modules/library/xml/src/test/java/org/geotools/xml/DocumentFactoryTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/DocumentFactoryTest.java
@@ -12,12 +12,13 @@
  */
 package org.geotools.xml;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -61,6 +62,8 @@ public class DocumentFactoryTest {
     @Mock
     private SAXParserFactory mockSaxParserFactory;
 
+    private final Map<String, Boolean> features = new HashMap<>();
+
     @Mock
     private SAXParser mockSaxParser;
 
@@ -69,11 +72,13 @@ public class DocumentFactoryTest {
 
     @Before
     public void before() throws Exception {
-        uri = new URI("http://geotools.org");
-        hints = new HashMap<>();
+        this.uri = new URI("http://geotools.org");
+        this.hints = new HashMap<>();
 
         MockitoAnnotations.openMocks(this);
         hints.put(XMLHandlerHints.SAX_PARSER_FACTORY, mockSaxParserFactory);
+
+        // mock factory parser
         when(mockSaxParserFactory.newSAXParser()).thenReturn(mockSaxParser);
 
         Answer<Void> startDocumentAnswer = invocationOnMock -> {
@@ -83,6 +88,21 @@ public class DocumentFactoryTest {
         };
         doAnswer(startDocumentAnswer).when(mockSaxParser).parse(anyString(), any(XMLSAXHandler.class));
         doAnswer(startDocumentAnswer).when(mockSaxParser).parse(any(InputStream.class), any(XMLSAXHandler.class));
+
+        // mock factory features (stateful which is annoying)
+        Answer<Void> setFeatureAnswer = invocationOnMock -> {
+            String name = invocationOnMock.getArgument(0);
+            Boolean value = invocationOnMock.getArgument(1);
+            features.put(name, value);
+            return null;
+        };
+
+        Answer<Boolean> getFeatureAnswer = invocationOnMock -> {
+            String name = invocationOnMock.getArgument(0);
+            return features.getOrDefault(name, Boolean.FALSE);
+        };
+        doAnswer(setFeatureAnswer).when(mockSaxParserFactory).setFeature(anyString(), anyBoolean());
+        when(mockSaxParserFactory.getFeature(anyString())).thenAnswer(getFeatureAnswer);
     }
 
     @Test
@@ -94,6 +114,7 @@ public class DocumentFactoryTest {
     @Test
     public void testGetInstanceFromURIWithSpecifiedLevelAndDisableExternalEntitiesTrue() throws Exception {
         hints.put(DocumentFactory.DISABLE_EXTERNAL_ENTITIES, Boolean.TRUE);
+        hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
         DocumentFactory.getInstance(uri, hints, Level.WARNING);
 
         verifyDisableExternalEntities(true);
@@ -135,6 +156,7 @@ public class DocumentFactoryTest {
     @Test
     public void testGetInstanceFromInputStreamWithSpecifiedLevelAndDisableExternalEntitiesTrue() throws Exception {
         hints.put(DocumentFactory.DISABLE_EXTERNAL_ENTITIES, Boolean.TRUE);
+        hints.put(DocumentFactory.ENABLE_DTD, Boolean.TRUE);
         DocumentFactory.getInstance(inputStream, hints, Level.WARNING);
 
         verifyDisableExternalEntities(true);
@@ -167,16 +189,20 @@ public class DocumentFactoryTest {
     void verifyDisableExternalEntities(boolean disabledExternalEntities)
             throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
 
-        verify(mockSaxParserFactory, atLeastOnce()).setFeature(LOAD_EXTERNAL_DTD, false);
-        verify(mockSaxParserFactory, atLeastOnce()).setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        assertTrue(XMLConstants.FEATURE_SECURE_PROCESSING, features.get(XMLConstants.FEATURE_SECURE_PROCESSING));
 
-        verify(mockSaxParserFactory, atLeastOnce()).setFeature(XMLUtils.LOAD_EXTERNAL_DTD, false);
-
-        // double check DTD support disabled
+        // double external entity support disabled
         if (disabledExternalEntities) {
-            verify(mockSaxParserFactory, atLeastOnce()).setFeature(DISALLOW_DOCTYPE_DECLAIRATION, true);
-            verify(mockSaxParserFactory, atLeastOnce()).setFeature(EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
-            verify(mockSaxParserFactory, atLeastOnce()).setFeature(EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
+            // DTD support is used for force use of external entities
+            assertFalse(DISALLOW_DOCTYPE_DECLAIRATION, features.get(DISALLOW_DOCTYPE_DECLAIRATION));
+
+            assertFalse(EXTERNAL_GENERAL_ENTITIES_FEATURE, features.get(EXTERNAL_GENERAL_ENTITIES_FEATURE));
+            assertFalse(EXTERNAL_PARAMETER_ENTITIES_FEATURE, features.get(EXTERNAL_PARAMETER_ENTITIES_FEATURE));
+        } else {
+            assertTrue(DISALLOW_DOCTYPE_DECLAIRATION, features.get(DISALLOW_DOCTYPE_DECLAIRATION));
+
+            assertTrue(EXTERNAL_GENERAL_ENTITIES_FEATURE, features.get(EXTERNAL_GENERAL_ENTITIES_FEATURE));
+            assertTrue(EXTERNAL_PARAMETER_ENTITIES_FEATURE, features.get(EXTERNAL_PARAMETER_ENTITIES_FEATURE));
         }
     }
 }

--- a/modules/library/xml/src/test/java/org/geotools/xml/DocumentFactoryTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/DocumentFactoryTest.java
@@ -47,7 +47,6 @@ import org.xml.sax.SAXNotSupportedException;
  */
 public class DocumentFactoryTest {
     private static final String DISALLOW_DOCTYPE_DECLAIRATION = "http://apache.org/xml/features/disallow-doctype-decl";
-    private static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
     private static final String EXTERNAL_GENERAL_ENTITIES_FEATURE =
             "http://xml.org/sax/features/external-general-entities";

--- a/modules/library/xml/src/test/java/org/geotools/xml/DocumentFactoryTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/DocumentFactoryTest.java
@@ -14,9 +14,9 @@ package org.geotools.xml;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -44,11 +45,13 @@ import org.xml.sax.SAXNotSupportedException;
  * @author Aaron Waddell
  */
 public class DocumentFactoryTest {
-    private final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
+    private static final String DISALLOW_DOCTYPE_DECLAIRATION = "http://apache.org/xml/features/disallow-doctype-decl";
+    private static final String LOAD_EXTERNAL_DTD = "http://apache.org/xml/features/nonvalidating/load-external-dtd";
 
-    private final String EXTERNAL_GENERAL_ENTITIES_FEATURE = "http://xml.org/sax/features/external-general-entities";
+    private static final String EXTERNAL_GENERAL_ENTITIES_FEATURE =
+            "http://xml.org/sax/features/external-general-entities";
 
-    private final String EXTERNAL_PARAMETER_ENTITIES_FEATURE =
+    private static final String EXTERNAL_PARAMETER_ENTITIES_FEATURE =
             "http://xml.org/sax/features/external-parameter-entities";
 
     private URI uri;
@@ -164,17 +167,16 @@ public class DocumentFactoryTest {
     void verifyDisableExternalEntities(boolean disabledExternalEntities)
             throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException {
 
-        // double check DTD support disabled
-        // verify(mockSaxParserFactory).setFeature(DISALLOW_DOCTYPE_DECLAIRATION, true);
-        verify(mockSaxParserFactory).setFeature(LOAD_EXTERNAL_DTD, false);
+        verify(mockSaxParserFactory, atLeastOnce()).setFeature(LOAD_EXTERNAL_DTD, false);
+        verify(mockSaxParserFactory, atLeastOnce()).setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
-        // check optional eternal entity disabled
+        verify(mockSaxParserFactory, atLeastOnce()).setFeature(XMLUtils.LOAD_EXTERNAL_DTD, false);
+
+        // double check DTD support disabled
         if (disabledExternalEntities) {
-            verify(mockSaxParserFactory).setFeature(EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
-            verify(mockSaxParserFactory).setFeature(EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
-        } else {
-            verify(mockSaxParserFactory, never()).setFeature(EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
-            verify(mockSaxParserFactory, never()).setFeature(EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
+            verify(mockSaxParserFactory, atLeastOnce()).setFeature(DISALLOW_DOCTYPE_DECLAIRATION, true);
+            verify(mockSaxParserFactory, atLeastOnce()).setFeature(EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
+            verify(mockSaxParserFactory, atLeastOnce()).setFeature(EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
         }
     }
 }

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -34,7 +34,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Level;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.style.ContrastEnhancement;
 import org.geotools.api.style.ContrastMethod;
@@ -53,10 +57,14 @@ import org.geotools.api.style.Symbolizer;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.util.EntityResolver3;
 import org.geotools.util.NullEntityResolver;
+import org.geotools.util.PreventLocalEntityResolver;
+import org.geotools.util.logging.Logging;
 import org.geotools.xml.XMLUtils;
 import org.junit.Test;
+import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 public class SLDParserTest {
 
@@ -246,7 +254,7 @@ public class SLDParserTest {
                 </UserStyle>
             </StyledLayerDescriptor>""";
 
-    static String SLD_EXTERNALENTITY =
+    static String SLD_DTD_EXTERNALENTITY =
             """
             <?xml version="1.0" encoding="UTF-8"?>
             <!DOCTYPE StyledLayerDescriptor [
@@ -325,6 +333,44 @@ public class SLDParserTest {
                   </FeatureTypeStyle>
                 </UserStyle>
               </NamedLayer>
+            </StyledLayerDescriptor>""";
+
+    static String XSD_EXTERNALENTITY =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <root xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="file:///this/file/is/top/secret.xsd">
+              <data>Hello World</data>
+            </root>
+            """;
+
+    static String SLD_XSD_EXTERNALENTITY =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <StyledLayerDescriptor version="1.0.0"\s
+                    xsi:schemaLocation="http://www.opengis.net/sld file:///this/file/is/top/secret.xsd"\s
+                    xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"\s
+                    xmlns:xlink="http://www.w3.org/1999/xlink"\s
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                <UserStyle>
+                    <Name>Default Styler</Name>
+                    <Title>Default Styler</Title>
+                    <Abstract></Abstract>
+                    <FeatureTypeStyle>
+                        <FeatureTypeName>Feature</FeatureTypeName>
+                        <Rule>
+                            <PointSymbolizer>
+                                <Graphic>
+                                   <Mark>
+                                      <WellKnownName>file://foo.svg</WellKnownName>\
+                                      <Fill/>\
+                                      <Stroke/>\
+                                   </Mark>\
+                                </Graphic>
+                            </PointSymbolizer>
+                        </Rule>
+                    </FeatureTypeStyle>
+                </UserStyle>
             </StyledLayerDescriptor>""";
 
     static String SLD_EXTERNAL_GRAPHIC =
@@ -698,9 +744,12 @@ public class SLDParserTest {
         assertStyles(styles);
 
         try {
+            Logging.getLogger(XMLUtils.class).setLevel(Level.OFF);
             parser.readXML();
             fail("Parsing again Should have thrown exception");
         } catch (Exception e) {
+        } finally {
+            Logging.getLogger(XMLUtils.class).setLevel(Level.INFO);
         }
     }
 
@@ -785,23 +834,77 @@ public class SLDParserTest {
     }
 
     @Test
-    public void testExternalEntitiesDisabled() {
+    public void testXSDExternalEntitiesDisabled() throws ParserConfigurationException {
+        // Test entity resolver against SLD_XSD_EXTERNALENTITY requires validation enabled
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance(); // NOPMD AvoidDocumentBuilderFactory
+        factory.setNamespaceAware(true);
+        factory.setValidating(true);
+        factory.setAttribute(
+                "http://java.sun.com/xml/jaxp/properties/schemaLanguage", XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+        // 2. Create the DocumentBuilder
+        DocumentBuilder builder = factory.newDocumentBuilder(); // NOPMD AvoidDocumentBuilderFactory
+        builder.setEntityResolver(NullEntityResolver.INSTANCE);
+        builder.setErrorHandler(new ErrorHandler() {
+            @Override
+            public void warning(SAXParseException exception) throws SAXException {}
+
+            @Override
+            public void error(SAXParseException exception) throws SAXException {}
+
+            @Override
+            public void fatalError(SAXParseException exception) throws SAXException {}
+        });
+        try {
+            builder.parse(input(SLD_XSD_EXTERNALENTITY));
+        } catch (SAXException | IOException e) {
+            assertTrue(e.getMessage().contains("Entity resolution disallowed"));
+        }
+
+        // Test SLDParser against SLD_XSD_EXTERNALENTITY requires validation enabled
+        SLDParser parser;
+        parser = new SLDParser(styleFactory, input(SLD_XSD_EXTERNALENTITY));
+        parser.setValidating(true);
+        parser.setEntityResolver(PreventLocalEntityResolver.INSTANCE);
+        try {
+            Logging.getLogger(XMLUtils.class).setLevel(Level.OFF);
+            parser.readXML();
+            fail("parsing should thrown an error");
+        } catch (RuntimeException e) {
+            assertTrue(
+                    "SAXException expected, was " + e.getCause().getClass().getSimpleName(),
+                    e.getCause() instanceof SAXException);
+            assertTrue(e.getMessage().contains("Entity resolution disallowed"));
+            assertTrue(e.getMessage().contains("/this/file/is/top/secret"));
+        } finally {
+            Logging.getLogger(XMLUtils.class).setLevel(Level.INFO);
+        }
+    }
+
+    @Test
+    public void testDTDExternalEntitiesDisabled() {
         // this SLD file references as external entity a file on the local filesystem
         SLDParser parser;
-        parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+        parser = new SLDParser(styleFactory, input(SLD_DTD_EXTERNALENTITY));
         parser.setEntityResolver(NullEntityResolver.INSTANCE);
         // With NullEntityResolver, the parser can try and read the entity file on the local file system
         try {
+            // Suppress logging to expected the error message about the disallowed DOCTYPE being logged
+            Logging.getLogger(XMLUtils.class).setLevel(Level.OFF);
             parser.readXML();
             fail("parsing should thrown an error");
         } catch (RuntimeException e) {
             // Parsing now returns a proper SAXException due to restrictions on parsing preventing
             // DTD access early so the entityResolver is never called
-            assertTrue(e.getMessage(), e.getCause() instanceof SAXException);
+            assertTrue(
+                    "SAXException expected, was " + e.getCause().getClass().getSimpleName(),
+                    e.getCause() instanceof SAXException);
             assertTrue(e.getMessage().contains("DOCTYPE is disallowed"));
+        } finally {
+            Logging.getLogger(XMLUtils.class).setLevel(Level.INFO);
         }
 
-        parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+        parser = new SLDParser(styleFactory, input(SLD_DTD_EXTERNALENTITY));
 
         // If we allow DTDs we can restore turn off the parser protections
         // and rely on the entityResolver (which will in this case produce FileNotFound)
@@ -813,10 +916,14 @@ public class SLDParserTest {
             assertNotNull("We do not expect any output", obj);
             fail("parsing should thrown an error");
         } catch (RuntimeException e) {
-            assertTrue(e.getMessage(), e.getCause() instanceof FileNotFoundException);
+            assertTrue(
+                    "FileNotFoundException expected, was "
+                            + e.getCause().getClass().getSimpleName(),
+                    e.getCause() instanceof FileNotFoundException);
+            assertTrue(e.getMessage().contains("/this/file/is/top/secret"));
         }
 
-        parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+        parser = new SLDParser(styleFactory, input(SLD_DTD_EXTERNALENTITY));
 
         // Set an EntityResolver implementation to prevent reading entities from the local file
         // system. When resolving an XML entity, the empty InputSource returned by this resolver provokes
@@ -854,7 +961,7 @@ public class SLDParserTest {
             assertTrue(e.getMessage(), e.getCause() instanceof MalformedURLException);
         }
 
-        parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+        parser = new SLDParser(styleFactory, input(SLD_DTD_EXTERNALENTITY));
 
         // Set another EntityResolver
         parser.setEntityResolver((publicId, systemId) -> {

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -55,6 +55,7 @@ import org.geotools.api.style.Style;
 import org.geotools.api.style.StyleFactory;
 import org.geotools.api.style.Symbolizer;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.test.xml.XmlTestSupport;
 import org.geotools.util.EntityResolver3;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.PreventLocalEntityResolver;
@@ -858,7 +859,7 @@ public class SLDParserTest {
         try {
             builder.parse(input(SLD_XSD_EXTERNALENTITY));
         } catch (SAXException | IOException e) {
-            assertTrue(e.getMessage().contains("Entity resolution disallowed"));
+            XmlTestSupport.assertMessageContains(e, "Entity resolution disallowed");
         }
 
         // Test SLDParser against SLD_XSD_EXTERNALENTITY requires validation enabled
@@ -874,8 +875,8 @@ public class SLDParserTest {
             assertTrue(
                     "SAXException expected, was " + e.getCause().getClass().getSimpleName(),
                     e.getCause() instanceof SAXException);
-            assertTrue(e.getMessage().contains("Entity resolution disallowed"));
-            assertTrue(e.getMessage().contains("/this/file/is/top/secret"));
+            XmlTestSupport.assertMessageContains(e, "Entity resolution disallowed");
+            XmlTestSupport.assertMessageContains(e, "top", "secret");
         } finally {
             Logging.getLogger(XMLUtils.class).setLevel(Level.INFO);
         }
@@ -899,7 +900,8 @@ public class SLDParserTest {
             assertTrue(
                     "SAXException expected, was " + e.getCause().getClass().getSimpleName(),
                     e.getCause() instanceof SAXException);
-            assertTrue(e.getMessage().contains("DOCTYPE is disallowed"));
+            // DOCTYPE disallowed message, is locale dependent: DOCTYPE non consentito in it_IT.UTF-8
+            XmlTestSupport.assertMessageContains(e, "DOCTYPE");
         } finally {
             Logging.getLogger(XMLUtils.class).setLevel(Level.INFO);
         }
@@ -920,7 +922,8 @@ public class SLDParserTest {
                     "FileNotFoundException expected, was "
                             + e.getCause().getClass().getSimpleName(),
                     e.getCause() instanceof FileNotFoundException);
-            assertTrue(e.getMessage().contains("/this/file/is/top/secret"));
+            // Windows may not preserve /this/file/is/top/secret path
+            XmlTestSupport.assertMessageContains(e, "top", "secret");
         }
 
         parser = new SLDParser(styleFactory, input(SLD_DTD_EXTERNALENTITY));

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.fail;
 import java.awt.Color;
 import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.net.MalformedURLException;
@@ -50,6 +51,7 @@ import org.geotools.api.style.Style;
 import org.geotools.api.style.StyleFactory;
 import org.geotools.api.style.Symbolizer;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.util.EntityResolver3;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.xml.XMLUtils;
 import org.junit.Test;
@@ -785,10 +787,10 @@ public class SLDParserTest {
     @Test
     public void testExternalEntitiesDisabled() {
         // this SLD file references as external entity a file on the local filesystem
-        SLDParser parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+        SLDParser parser;
+        parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
         parser.setEntityResolver(NullEntityResolver.INSTANCE);
-        // With NullEntityResolver EntityResolver, the parser be able to read the entity file on the local
-        // file system
+        // With NullEntityResolver, the parser can try and read the entity file on the local file system
         try {
             parser.readXML();
             fail("parsing should thrown an error");
@@ -800,12 +802,15 @@ public class SLDParserTest {
         }
 
         parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
-        parser.setEntityResolver(NullEntityResolver.INSTANCE);
-        parser.setSupportsDTD(true);
-        // If we allow DTDs (bad idea) we can restore turn off the parser protections
+
+        // If we allow DTDs we can restore turn off the parser protections
         // and rely on the entityResolver (which will in this case produce FileNotFound)
+        parser.setSupportDTD(true);
+        parser.setExpandEntityReferences(true);
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
         try {
-            parser.readXML();
+            Object obj = parser.readXML();
+            assertNotNull("We do not expect any output", obj);
             fail("parsing should thrown an error");
         } catch (RuntimeException e) {
             assertTrue(e.getMessage(), e.getCause() instanceof FileNotFoundException);
@@ -816,8 +821,30 @@ public class SLDParserTest {
         // Set an EntityResolver implementation to prevent reading entities from the local file
         // system. When resolving an XML entity, the empty InputSource returned by this resolver provokes
         // a MalformedURLException
-        parser.setSupportsDTD(true);
-        parser.setEntityResolver((publicId, systemId) -> new InputSource());
+        parser.setSupportDTD(true);
+        parser.setExpandEntityReferences(true);
+        parser.setEntityResolver(new EntityResolver3() {
+            @Override
+            public String getAccess() {
+                return "all";
+            }
+
+            @Override
+            public InputSource getExternalSubset(String name, String baseURI) throws SAXException, IOException {
+                return new InputSource();
+            }
+
+            @Override
+            public InputSource resolveEntity(String name, String publicId, String baseURI, String systemId)
+                    throws SAXException, IOException {
+                return new InputSource();
+            }
+
+            @Override
+            public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+                return new InputSource();
+            }
+        });
 
         try {
             parser.readXML();
@@ -838,7 +865,7 @@ public class SLDParserTest {
             }
         });
         // and allow DTD access
-        parser.setSupportsDTD(true);
+        parser.setSupportDTD(true);
 
         // now parsing shouldn't throw an exception
         parser.readXML();

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -870,7 +870,7 @@ public class SLDParserTest {
         try {
             Logging.getLogger(XMLUtils.class).setLevel(Level.OFF);
             parser.readXML();
-            fail("parsing should thrown an error");
+            fail("parsing should have thrown an error");
         } catch (RuntimeException e) {
             assertTrue(
                     "SAXException expected, was " + e.getCause().getClass().getSimpleName(),

--- a/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/styling/SLDParserTest.java
@@ -54,6 +54,7 @@ import org.geotools.util.NullEntityResolver;
 import org.geotools.xml.XMLUtils;
 import org.junit.Test;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 public class SLDParserTest {
 
@@ -792,24 +793,42 @@ public class SLDParserTest {
             parser.readXML();
             fail("parsing should thrown an error");
         } catch (RuntimeException e) {
+            // Parsing now returns a proper SAXException due to restrictions on parsing preventing
+            // DTD access early so the entityResolver is never called
+            assertTrue(e.getMessage(), e.getCause() instanceof SAXException);
+            assertTrue(e.getMessage().contains("DOCTYPE is disallowed"));
+        }
+
+        parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+        parser.setEntityResolver(NullEntityResolver.INSTANCE);
+        parser.setSupportsDTD(true);
+        // If we allow DTDs (bad idea) we can restore turn off the parser protections
+        // and rely on the entityResolver (which will in this case produce FileNotFound)
+        try {
+            parser.readXML();
+            fail("parsing should thrown an error");
+        } catch (RuntimeException e) {
             assertTrue(e.getMessage(), e.getCause() instanceof FileNotFoundException);
         }
 
         parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+
         // Set an EntityResolver implementation to prevent reading entities from the local file
-        // system.
-        // When resolving an XML entity, the empty InputSource returned by this resolver provokes
+        // system. When resolving an XML entity, the empty InputSource returned by this resolver provokes
         // a MalformedURLException
+        parser.setSupportsDTD(true);
         parser.setEntityResolver((publicId, systemId) -> new InputSource());
 
         try {
             parser.readXML();
             fail("parsing should thrown an error");
         } catch (RuntimeException e) {
-            assertTrue(e.getCause() instanceof MalformedURLException);
+            // DTD access is allowed early so the entityResolver called to produce a MalformedURLException
+            assertTrue(e.getMessage(), e.getCause() instanceof MalformedURLException);
         }
 
         parser = new SLDParser(styleFactory, input(SLD_EXTERNALENTITY));
+
         // Set another EntityResolver
         parser.setEntityResolver((publicId, systemId) -> {
             if ("file:///this/file/is/top/secret".equals(systemId)) {
@@ -818,6 +837,8 @@ public class SLDParserTest {
                 return new InputSource();
             }
         });
+        // and allow DTD access
+        parser.setSupportsDTD(true);
 
         // now parsing shouldn't throw an exception
         parser.readXML();

--- a/modules/unsupported/css/src/test/java/org/geotools/styling/css/AbstractIntegrationTest.java
+++ b/modules/unsupported/css/src/test/java/org/geotools/styling/css/AbstractIntegrationTest.java
@@ -37,6 +37,7 @@ import org.geotools.api.style.StyleFactory;
 import org.geotools.api.style.StyledLayerDescriptor;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.sld.SLDConfiguration;
+import org.geotools.util.InternalEntityResolver;
 import org.geotools.xml.styling.SLDParser;
 import org.geotools.xml.styling.SLDTransformer;
 import org.geotools.xsd.Parser;
@@ -170,6 +171,8 @@ public abstract class AbstractIntegrationTest extends CssBaseTest {
 
     private List validateSLD(String sld) throws IOException, SAXException, ParserConfigurationException {
         Parser parser = new Parser(new SLDConfiguration());
+        parser.setAllowDTD(true);
+        parser.setEntityResolver(InternalEntityResolver.INSTANCE);
         parser.validate(new StringReader(sld));
         return parser.getValidationErrors();
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/impl/WFSDataAccessFactory.java
@@ -436,7 +436,7 @@ public class WFSDataAccessFactory implements DataAccessFactory {
                         "program") {
                     @Override
                     public Object getDefaultValue() {
-                        return GeoTools.getEntityResolver(null);
+                        return GeoTools.getEntityResolver();
                     }
                 };
     }

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/DescribeFeatureTypeResponse.java
@@ -94,7 +94,7 @@ public class DescribeFeatureTypeResponse extends WFSResponse {
 
     private EntityResolver getTempFileEntityResolver(EntityResolver resolver, File tempSchema) {
         if (resolver == null) {
-            resolver = GeoTools.getEntityResolver(null);
+            resolver = GeoTools.getEntityResolver();
         }
 
         if (resolver instanceof EntityResolver2 resolver2) {

--- a/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlSimpleFeatureParser.java
+++ b/modules/unsupported/wfs-ng/src/main/java/org/geotools/data/wfs/internal/parsers/XmlSimpleFeatureParser.java
@@ -96,7 +96,7 @@ public class XmlSimpleFeatureParser implements GetParser<SimpleFeature> {
         this.builder = new SimpleFeatureBuilder(targetType);
 
         try {
-            final EntityResolver entityResolver = GeoTools.getEntityResolver(null);
+            final EntityResolver entityResolver = GeoTools.getEntityResolver();
             Hints hints = new Hints(Hints.ENTITY_RESOLVER, entityResolver);
             XMLInputFactory factory = XMLUtils.newXMLInputFactory(hints);
 

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/XXEProtectionTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/XXEProtectionTest.java
@@ -59,7 +59,9 @@ public class XXEProtectionTest {
         while (cause != null) {
             if (cause instanceof SAXException se) {
                 String message = se.getMessage();
-                if (message != null && message.contains("Entity resolution disallowed")) {
+                if (message != null
+                        && (message.contains("Entity resolution disallowed")
+                                || message.contains("DOCTYPE is disallowed when the feature"))) {
                     // fine, we found the message
                     return;
                 }

--- a/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/XXEProtectionTest.java
+++ b/modules/unsupported/wfs-ng/src/test/java/org/geotools/data/wfs/integration/v1_1/XXEProtectionTest.java
@@ -60,8 +60,7 @@ public class XXEProtectionTest {
             if (cause instanceof SAXException se) {
                 String message = se.getMessage();
                 if (message != null
-                        && (message.contains("Entity resolution disallowed")
-                                || message.contains("DOCTYPE is disallowed when the feature"))) {
+                        && (message.contains("Entity resolution disallowed") || message.contains("DOCTYPE"))) {
                     // fine, we found the message
                     return;
                 }


### PR DESCRIPTION
[![GEOT-7898](https://badgen.net/badge/JIRA/GEOT-7898/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7898) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

The great thing about gathering instance creation into XMLUtils is the opportunity review what is needed and disable features such as DTD that are only needed by a couple of the standards we use.

* [x] XMLInputFactory does not require DTD support by default
* [x] DocFactory does not require DTD by default
* [x] SaxParserFactory does not require DTD by default
* [x] DocumentBuilderFactory does not require DTD by default

Of interest is additional hints to allow DTD to be enabled for SLD 1.0 and WMS 1.0 that require this support.

Downstream:

* https://github.com/GeoWebCache/geowebcache/pull/1541
* https://github.com/geoserver/geoserver/pull/9585

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 