### PR TITLE
[GEOT-7898] Update GTLSResourceResolver to delegate to EntityResolver2

### DIFF
--- a/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/XMLUtils.java
@@ -1744,6 +1744,12 @@ public class XMLUtils {
             if (XMLConstants.W3C_XML_SCHEMA_NS_URI.equals(type)) {
                 try {
                     InputSource source = entityResolver.resolveEntity(publicId, systemId);
+                    if (entityResolver instanceof EntityResolver2 entityResolver2) {
+                        // Note: order of arguments differs between LSResourceResolver and EntityResolver
+                        source = entityResolver2.resolveEntity(null, publicId, baseURI, systemId);
+                    } else {
+                        source = entityResolver.resolveEntity(publicId, systemId);
+                    }
                     if (source != null) {
                         return new GTLSInput(source);
                     }

--- a/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/styling/SLDParser.java
@@ -426,9 +426,10 @@ public class SLDParser {
     }
 
     /**
-     * Use of XInclude is not recommended, and is {@code false} by default.
+     * Use of validating is not required, and is {@code false} by default. Use of validating,
      *
-     * @param validating Use {@code false} to parse document without validation.
+     * @param validating Use {@code false} to parse document without validation, or {@code true} to validate using
+     *     {@code XMLConstants.W3C_XML_SCHEMA_NS_URI}.
      */
     public void setValidating(boolean validating) {
         this.validating = validating;
@@ -437,7 +438,8 @@ public class SLDParser {
     /**
      * Use of validating is not required, and is {@code false} by default.
      *
-     * @return Use {@code false} to parse document without validation.
+     * @return Use {@code false} to parse document without validation, or {@code true} to validate using
+     *     {@code XMLConstants.W3C_XML_SCHEMA_NS_URI}.
      */
     public boolean getValidating() {
         return this.validating;

--- a/modules/library/xml/src/test/java/org/geotools/xml/GMLParserTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/GMLParserTest.java
@@ -333,10 +333,10 @@ public class GMLParserTest {
             URI u = f.toURI();
 
             XMLSAXHandler xmlContentHandler = new XMLSAXHandler(u, null);
-            XMLSAXHandler.setLogLevel(Level.WARNING);
-            XSISAXHandler.setLogLevel(Level.WARNING);
-            XMLElementHandler.setLogLevel(Level.WARNING);
-            XSIElementHandler.setLogLevel(Level.WARNING);
+            XMLSAXHandler.setLogLevel(Level.OFF);
+            XSISAXHandler.setLogLevel(Level.OFF);
+            XMLElementHandler.setLogLevel(Level.OFF);
+            XSIElementHandler.setLogLevel(Level.OFF);
 
             parser.parse(f, xmlContentHandler);
 


### PR DESCRIPTION
[![GEOT-7898](https://badgen.net/badge/JIRA/GEOT-7898/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7898) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Was not correctly delegating to EntityResolver2, unable to validate against things like ``../xlink/1.0.0/xlinks.xsd`.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 