### PR TITLE
GEOT-7915: StreamingRenderer forcing 2D Geometries

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/StreamingRenderer.java
@@ -129,6 +129,7 @@ import org.geotools.geometry.jts.LiteCoordinateSequenceFactory;
 import org.geotools.geometry.jts.LiteShape2;
 import org.geotools.geometry.jts.OffsetCurveBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.geometry.jts.coordinatesequence.CoordinateSequences;
 import org.geotools.image.util.ImageUtilities;
 import org.geotools.map.DirectLayer;
 import org.geotools.map.Layer;
@@ -3367,9 +3368,12 @@ public class StreamingRenderer implements GTRenderer {
             // we need to clone if the clone flag is high or if the coordinate sequence is not the
             // one we asked for
             Geometry geom = originalGeom;
-            if (clone || !(geom.getFactory().getCoordinateSequenceFactory() instanceof LiteCoordinateSequenceFactory)) {
-                int dim = sa.crs != null ? sa.crs.getCoordinateSystem().getDimension() : 2;
-                geom = LiteCoordinateSequence.cloneGeometry(geom, dim);
+            boolean liteSequence =
+                    geom.getFactory().getCoordinateSequenceFactory() instanceof LiteCoordinateSequenceFactory;
+            boolean twoDimensional = CoordinateSequences.coordinateDimension(geom) <= 2;
+            // FEATURE_2D is only a hint and not all feature sources honor it, so enforce 2D before painting.
+            if (clone || !liteSequence || !twoDimensional) {
+                geom = LiteCoordinateSequence.cloneGeometry(geom, 2);
             }
 
             LiteShape2 shape;

--- a/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderableFeatureTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/lite/RenderableFeatureTest.java
@@ -18,6 +18,8 @@
 package org.geotools.renderer.lite;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.when;
 
 import java.awt.geom.AffineTransform;
@@ -29,10 +31,14 @@ import org.geotools.api.feature.type.Name;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.style.Symbolizer;
 import org.geotools.feature.NameImpl;
+import org.geotools.geometry.jts.LiteCoordinateSequence;
+import org.geotools.geometry.jts.LiteCoordinateSequenceFactory;
 import org.geotools.geometry.jts.LiteShape2;
+import org.geotools.geometry.jts.coordinatesequence.CoordinateSequences;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.mockito.Mockito;
 
@@ -69,5 +75,62 @@ public class RenderableFeatureTest {
         };
         rf.setFeature(feature);
         rf.getShape(symbolizer, null);
+    }
+
+    @Test
+    public void testLiteCoordinateSequenceIsForcedTo2D() throws FactoryException {
+        LiteCoordinateSequence cs = new LiteCoordinateSequence(new double[] {13, 10, 5, 13, 40, 7}, 3);
+        GeometryFactory liteGeometryFactory = new GeometryFactory(new LiteCoordinateSequenceFactory());
+        LineString lineString = liteGeometryFactory.createLineString(cs);
+        assertEquals(3, CoordinateSequences.coordinateDimension(lineString));
+
+        StreamingRenderer.RenderableFeature rf = new StreamingRenderer().new RenderableFeature("layerId", false);
+        LiteShape2 shape = rf.getShape(null, new AffineTransform(), lineString, false);
+
+        assertEquals(2, CoordinateSequences.coordinateDimension(shape.getGeometry()));
+        assertEquals(3, CoordinateSequences.coordinateDimension(lineString));
+    }
+
+    @Test
+    public void test2DLiteCoordinateSequenceIsReusedWhenCloneIsNotRequested() throws FactoryException {
+        LiteCoordinateSequence cs = new LiteCoordinateSequence(new double[] {13, 10, 13, 40}, 2);
+        GeometryFactory liteGeometryFactory = new GeometryFactory(new LiteCoordinateSequenceFactory());
+        LineString lineString = liteGeometryFactory.createLineString(cs);
+
+        StreamingRenderer.RenderableFeature rf = new StreamingRenderer().new RenderableFeature("layerId", false);
+        LiteShape2 shape = rf.getShape(null, new AffineTransform(), lineString, false);
+
+        assertSame(lineString, shape.getGeometry());
+        assertEquals(2, CoordinateSequences.coordinateDimension(shape.getGeometry()));
+    }
+
+    @Test
+    public void testNonLite3DCoordinateSequenceIsForcedTo2D() throws FactoryException {
+        LineString lineString = new GeometryFactory().createLineString(new org.locationtech.jts.geom.Coordinate[] {
+            new org.locationtech.jts.geom.Coordinate(13, 10, 5), new org.locationtech.jts.geom.Coordinate(13, 40, 7)
+        });
+        assertEquals(3, CoordinateSequences.coordinateDimension(lineString));
+
+        StreamingRenderer.RenderableFeature rf = new StreamingRenderer().new RenderableFeature("layerId", false);
+        LiteShape2 shape = rf.getShape(null, new AffineTransform(), lineString, false);
+
+        assertNotSame(lineString, shape.getGeometry());
+        assertEquals(2, CoordinateSequences.coordinateDimension(shape.getGeometry()));
+        assertEquals(3, CoordinateSequences.coordinateDimension(lineString));
+    }
+
+    @Test
+    public void testForced2DShapeIsCachedAgainstOriginalGeometry() throws FactoryException {
+        LiteCoordinateSequence cs = new LiteCoordinateSequence(new double[] {13, 10, 5, 13, 40, 7}, 3);
+        GeometryFactory liteGeometryFactory = new GeometryFactory(new LiteCoordinateSequenceFactory());
+        LineString lineString = liteGeometryFactory.createLineString(cs);
+
+        StreamingRenderer.RenderableFeature rf = new StreamingRenderer().new RenderableFeature("layerId", false);
+        LiteShape2 first = rf.getShape(null, new AffineTransform(), lineString, false);
+        LiteShape2 second = rf.getShape(null, new AffineTransform(), lineString, false);
+
+        assertSame(first, second);
+        assertEquals(2, CoordinateSequences.coordinateDimension(second.getGeometry()));
+        assertEquals(3, CoordinateSequences.coordinateDimension(lineString));
     }
 }


### PR DESCRIPTION
[![GEOT-7915](https://badgen.net/badge/JIRA/GEOT-7915/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7915) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 