### PR TITLE
Backport "Set inProperties back to false when ending an object in it on complex level 0" to 34.x

### DIFF
--- a/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureTypeHandler.java
+++ b/modules/unsupported/geojson/src/main/java/org/geotools/geojson/feature/FeatureTypeHandler.java
@@ -157,6 +157,12 @@ public class FeatureTypeHandler extends DelegatingHandler<SimpleFeatureType>
         if (inProperties && currentProp != null) {
             --complexNestingLevel;
         }
+            
+        if (delegate == NULL && inProperties && complexNestingLevel == 0) {
+            inProperties = false;
+            return true;
+        }  
+            
         if (complexNestingLevel > 0) {
             return true;
         }


### PR DESCRIPTION
Backports the fix made in [this commit](https://github.com/geotools/geotools/commit/35ded1155b9f132620688bd2411ad0d21e39ffd9) on main to branch 34.x.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).