### PR TITLE
[GEOT-7919]: duckdb upgrade to 1.5.3.0

### DIFF
--- a/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
+++ b/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
@@ -131,7 +131,10 @@ public class DuckDBDialect extends BasicSQLDialect {
     //    }
 
     public List<String> getDatabaseInitSql() {
-        return List.of("install spatial", "load spatial");
+        // DuckDB 1.5 warns unless users explicitly choose the old or new axis-order behavior for affected
+        // spatial functions. The dialect does not currently emit those functions, but opt into X/Y order
+        // now to align with common GIS longitude/latitude behavior and DuckDB's planned future default.
+        return List.of("install spatial", "load spatial", "SET geometry_always_xy = true");
     }
 
     @Override

--- a/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
+++ b/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/DuckDBDialect.java
@@ -131,7 +131,10 @@ public class DuckDBDialect extends BasicSQLDialect {
     //    }
 
     public List<String> getDatabaseInitSql() {
-        return List.of("install spatial", "load spatial");
+        // DuckDB 1.5 warns unless users explicitly choose the old or new axis-order behavior for affected
+        // spatial functions. The dialect does not currently emit those functions, but opt into X/Y order
+        // now to align with common GIS longitude/latitude behavior and DuckDB's planned future default.
+        return List.of("install spatial", "load spatial", "SET geometry_always_xy = true");
     }
 
     @Override
@@ -198,7 +201,7 @@ public class DuckDBDialect extends BasicSQLDialect {
         }
 
         // Check if it's a geometry column
-        if ("GEOMETRY".equalsIgnoreCase(typeName)) {
+        if (typeName != null && typeName.toUpperCase().startsWith("GEOMETRY")) {
             return Geometry.class;
         }
 

--- a/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/datasource/DuckdbConnectionFactory.java
+++ b/modules/unsupported/duckdb/src/main/java/org/geotools/data/duckdb/datasource/DuckdbConnectionFactory.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.sql.Connection;
 import java.sql.Driver;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
@@ -153,12 +155,35 @@ class DuckdbConnectionFactory extends DriverConnectionFactory {
                 if (!allowInstall && isInstallStatement(sql)) {
                     continue;
                 }
-                stmt.execute(sql);
+                executeInitSql(conn, stmt, sql);
             }
         }
     }
 
+    private void executeInitSql(Connection conn, Statement stmt, String sql) throws SQLException {
+        if (isGeometryAlwaysXySetStatement(sql) && !isDuckDbSettingAvailable(conn, "geometry_always_xy")) {
+            return;
+        }
+        stmt.execute(sql);
+    }
+
     private boolean isInstallStatement(String sql) {
         return sql != null && sql.trim().regionMatches(true, 0, "install", 0, "install".length());
+    }
+
+    private boolean isDuckDbSettingAvailable(Connection conn, String settingName) throws SQLException {
+        try (PreparedStatement ps =
+                conn.prepareStatement("SELECT 1 FROM duckdb_settings() WHERE lower(name) = lower(?) LIMIT 1")) {
+            ps.setString(1, settingName);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    static boolean isGeometryAlwaysXySetStatement(String sql) {
+        String trimmed = sql == null ? "" : sql.trim();
+        return trimmed.toLowerCase(java.util.Locale.ROOT)
+                .matches("set\\s+geometry_always_xy\\s*=\\s*(true|false)\\s*;?");
     }
 }

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTestSetup.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/DuckDBTestSetup.java
@@ -128,7 +128,8 @@ public class DuckDBTestSetup extends JDBCTestSetup {
         Properties db = fixture;
         ensureDatabaseDirectory(db);
 
-        DuckdbDataSource dataSource = new DuckdbDataSource(List.of("install spatial", "load spatial"));
+        DuckdbDataSource dataSource =
+                new DuckdbDataSource(List.of("install spatial", "load spatial", "SET geometry_always_xy = true"));
         dataSource.setDriverClassName(db.getProperty("driver"));
         dataSource.setUrl(db.getProperty("url"));
 

--- a/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/datasource/DuckdbConnectionFactoryTest.java
+++ b/modules/unsupported/duckdb/src/test/java/org/geotools/data/duckdb/datasource/DuckdbConnectionFactoryTest.java
@@ -19,6 +19,7 @@ package org.geotools.data.duckdb.datasource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -28,8 +29,10 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.DriverPropertyInfo;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -104,6 +107,60 @@ public class DuckdbConnectionFactoryTest {
         }
 
         assertEquals(1, driver.getConnectCount());
+    }
+
+    @Test
+    public void testUnavailableGeometryAlwaysXySettingIsSkipped() throws Exception {
+        Path database = createDatabasePath();
+        DuckdbConnectionFactory factory = new DuckdbConnectionFactory(
+                new DuckDBDriver(),
+                "jdbc:duckdb:" + database.toAbsolutePath(),
+                new Properties(),
+                List.of("SET geometry_always_xy=true"));
+
+        try (Connection connection = factory.createConnection()) {
+            assertNotNull(connection);
+        } finally {
+            factory.close();
+        }
+    }
+
+    @Test
+    public void testGeometryAlwaysXySetStatementMatchesSemicolonAndCase() {
+        assertTrue(DuckdbConnectionFactory.isGeometryAlwaysXySetStatement("SET geometry_always_xy=true;"));
+        assertTrue(DuckdbConnectionFactory.isGeometryAlwaysXySetStatement("set geometry_always_xy = false"));
+    }
+
+    @Test
+    public void testGeometryAlwaysXyIsAppliedWhenSpatialIsLoaded() throws Exception {
+        Path database = createDatabasePath();
+        DuckdbConnectionFactory factory = new DuckdbConnectionFactory(
+                new DuckDBDriver(),
+                "jdbc:duckdb:" + database.toAbsolutePath(),
+                new Properties(),
+                List.of("install spatial", "load spatial", "SET geometry_always_xy = true"));
+
+        try (Connection connection = factory.createConnection()) {
+            String value = geometryAlwaysXyValue(connection);
+            assertEquals(
+                    "SET geometry_always_xy = true was silently skipped: the availability probe ran "
+                            + "before 'load spatial', when duckdb_settings() does not list the setting yet",
+                    "true",
+                    value);
+        } finally {
+            factory.close();
+        }
+    }
+
+    private String geometryAlwaysXyValue(Connection connection) throws SQLException {
+        String query = "SELECT value FROM duckdb_settings() WHERE name = 'geometry_always_xy'";
+        try (Statement statement = connection.createStatement();
+                ResultSet rs = statement.executeQuery(query)) {
+            if (rs.next()) {
+                return rs.getString(1);
+            }
+            return "<setting does not exist in this DuckDB version>";
+        }
     }
 
     private Path createDatabasePath() throws IOException {

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDialect.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDialect.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.logging.Level;
@@ -431,7 +432,9 @@ public class GeoParquetDialect extends DuckDBDialect {
             if (!rs.next()) throw new RuntimeException("Could not compute bounds from bbox column, no result found");
             Geometry fullBounds = parseWKB(rs.getBlob(1));
             GeometryDescriptor geometryDescriptor = featureType.getGeometryDescriptor();
-            CoordinateReferenceSystem crs = geometryDescriptor.getCoordinateReferenceSystem();
+            CoordinateReferenceSystem crs = geometryDescriptor != null
+                    ? geometryDescriptor.getCoordinateReferenceSystem()
+                    : getGeoparquetMetadata(featureType.getTypeName(), cx).getCrs();
             return new ReferencedEnvelope(fullBounds.getEnvelopeInternal(), crs);
         }
     }
@@ -602,14 +605,33 @@ public class GeoParquetDialect extends DuckDBDialect {
      * @return A new feature type with more specific geometry types
      */
     private SimpleFeatureType buildTypeNarrowedGeometryFeatureType(SimpleFeatureType schema) {
+        GeoparquetDatasetMetadata metadata;
+        try {
+            metadata = getGeoparquetMetadata(schema.getTypeName());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        if (metadata.isEmpty()) {
+            // Metadata is not guaranteed to be present; leave DuckDB's reported schema unchanged.
+            return schema;
+        }
+        Set<String> geometryAttributes = metadata.getColumnNames();
+        if (geometryAttributes.isEmpty()) {
+            return schema;
+        }
+
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
         builder.init(schema);
-
-        schema.getAttributeDescriptors().stream()
-                .filter(GeometryDescriptor.class::isInstance)
-                .map(GeometryDescriptor.class::cast)
-                .map(d -> buildGeometryDescriptorOverride(schema.getTypeName(), d))
-                .forEach(overriding -> builder.set(overriding.getLocalName(), overriding));
+        geometryAttributes.forEach(geometryAttribute -> {
+            AttributeDescriptor descriptor = schema.getDescriptor(geometryAttribute);
+            GeometryDescriptor overriding =
+                    buildGeometryDescriptorOverride(schema.getTypeName(), geometryAttribute, descriptor);
+            if (descriptor == null) {
+                builder.add(overriding);
+            } else {
+                builder.set(geometryAttribute, overriding);
+            }
+        });
         return builder.buildFeatureType();
     }
 
@@ -633,17 +655,29 @@ public class GeoParquetDialect extends DuckDBDialect {
      * @param orig The original geometry descriptor with generic type
      * @return A new geometry descriptor with the specific geometry type, or the original if unchanged
      */
-    private GeometryDescriptor buildGeometryDescriptorOverride(String typeName, GeometryDescriptor orig) {
-        String geometryAttirbute = orig.getLocalName();
-        Class<? extends Geometry> narrowedGeomType = getNarrowedGeometryType(typeName, geometryAttirbute);
-        if (narrowedGeomType.equals(orig.getType().getBinding())) {
-            return orig;
+    private GeometryDescriptor buildGeometryDescriptorOverride(
+            String typeName, String geometryAttribute, AttributeDescriptor orig) {
+        Class<? extends Geometry> narrowedGeomType = getNarrowedGeometryType(typeName, geometryAttribute);
+        CoordinateReferenceSystem crs;
+        try {
+            crs = getGeoparquetMetadata(typeName).getCrs(geometryAttribute);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        if (orig instanceof GeometryDescriptor geometryOrig
+                && narrowedGeomType.equals(geometryOrig.getType().getBinding())) {
+            return geometryOrig;
         }
 
         AttributeTypeBuilder builder = new AttributeTypeBuilder();
-        builder.init(orig);
+        if (orig != null) {
+            builder.init(orig);
+        } else {
+            builder.setName(geometryAttribute);
+        }
         builder.setBinding(narrowedGeomType);
-        return (GeometryDescriptor) builder.buildDescriptor(geometryAttirbute);
+        builder.setCRS(crs);
+        return builder.buildDescriptor(geometryAttribute, builder.buildGeometryType());
     }
 
     /**
@@ -661,17 +695,17 @@ public class GeoParquetDialect extends DuckDBDialect {
      * buildGeometryDescriptorOverride and enforceMuliForCurrentTypeName.
      *
      * @param typeName The name of the feature type
-     * @param geometryAttirbute The name of the geometry column
+     * @param geometryAttribute The name of the geometry column
      * @return The most specific JTS geometry class for the column
      */
-    private Class<? extends Geometry> getNarrowedGeometryType(String typeName, String geometryAttirbute) {
+    private Class<? extends Geometry> getNarrowedGeometryType(String typeName, String geometryAttribute) {
         GeoparquetDatasetMetadata md;
         try {
             md = getGeoparquetMetadata(typeName);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        return md.getNarrowedGeometryType(geometryAttirbute);
+        return md.getNarrowedGeometryType(geometryAttribute);
     }
 
     /**

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDialect.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoParquetDialect.java
@@ -604,7 +604,6 @@ public class GeoParquetDialect extends DuckDBDialect {
     private SimpleFeatureType buildTypeNarrowedGeometryFeatureType(SimpleFeatureType schema) {
         SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
         builder.init(schema);
-
         schema.getAttributeDescriptors().stream()
                 .filter(GeometryDescriptor.class::isInstance)
                 .map(GeometryDescriptor.class::cast)
@@ -639,7 +638,6 @@ public class GeoParquetDialect extends DuckDBDialect {
         if (narrowedGeomType.equals(orig.getType().getBinding())) {
             return orig;
         }
-
         AttributeTypeBuilder builder = new AttributeTypeBuilder();
         builder.init(orig);
         builder.setBinding(narrowedGeomType);
@@ -661,17 +659,17 @@ public class GeoParquetDialect extends DuckDBDialect {
      * buildGeometryDescriptorOverride and enforceMuliForCurrentTypeName.
      *
      * @param typeName The name of the feature type
-     * @param geometryAttirbute The name of the geometry column
+     * @param geometryAttribute The name of the geometry column
      * @return The most specific JTS geometry class for the column
      */
-    private Class<? extends Geometry> getNarrowedGeometryType(String typeName, String geometryAttirbute) {
+    private Class<? extends Geometry> getNarrowedGeometryType(String typeName, String geometryAttribute) {
         GeoparquetDatasetMetadata md;
         try {
             md = getGeoparquetMetadata(typeName);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        return md.getNarrowedGeometryType(geometryAttirbute);
+        return md.getNarrowedGeometryType(geometryAttribute);
     }
 
     /**

--- a/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoparquetDatasetMetadata.java
+++ b/modules/unsupported/geoparquet/src/main/java/org/geotools/data/geoparquet/GeoparquetDatasetMetadata.java
@@ -116,6 +116,15 @@ public class GeoparquetDatasetMetadata {
         return sample().map(GeoParquetMetadata::getPrimaryColumn);
     }
 
+    /**
+     * Returns the set of geometry column names present in the dataset metadata.
+     *
+     * @return the geometry column names, or an empty set if the dataset has no metadata
+     */
+    public Set<String> getColumnNames() {
+        return sample().map(GeoParquetMetadata::getColumns).map(Map::keySet).orElse(Set.of());
+    }
+
     public Optional<Geometry> getPrimaryColumn() {
         return getPrimaryColumnName().flatMap(this::getColumn);
     }

--- a/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetTestSupportTest.java
+++ b/modules/unsupported/geoparquet/src/test/java/org/geotools/data/geoparquet/GeoParquetTestSupportTest.java
@@ -141,8 +141,8 @@ public class GeoParquetTestSupportTest {
                     "Geometry column should have 'geometry_types' field", geometryColumn.containsKey("geometry_types"));
             assertTrue("Geometry column should have 'bbox' field", geometryColumn.containsKey("bbox"));
 
-            // Note: CRS is currently not added by DuckDB 1.2.2, but we document its expected location
-            // in tests for when the DuckDB version is updated
+            // DuckDB may omit CRS metadata here; keep the assertion tolerant so the test remains
+            // valid across DuckDB 1.5.x updates.
             if (geometryColumn.containsKey("crs")) {
                 // If crs exists, verify it's structured correctly
                 Map<String, Object> crs = (Map<String, Object>) geometryColumn.get("crs");

--- a/modules/unsupported/geoparquet/src/test/resources/org/geotools/data/geoparquet/setup_test_data.sql
+++ b/modules/unsupported/geoparquet/src/test/resources/org/geotools/data/geoparquet/setup_test_data.sql
@@ -487,5 +487,5 @@ COPY (
 );
 
 SELECT 'Export complete.' AS status;
-SELECT 'NOTE: DuckDB version 1.2.2 does not add CRS information to GeoParquet metadata and does not provide API to modify it.' AS note;
+SELECT 'NOTE: DuckDB does not always add CRS information to GeoParquet metadata and may not provide an API to modify it directly.' AS note;
 SELECT 'The GeoParquetDataStore code handles missing CRS information by defaulting to EPSG:4326 (WGS 84).' AS note;

--- a/platform-dependencies/pom.xml
+++ b/platform-dependencies/pom.xml
@@ -31,7 +31,7 @@
     <commons-text.version>1.13.0</commons-text.version>
     <conversantmedia-disruptor.version>1.2.15</conversantmedia-disruptor.version>
     <db2.jdbc.version>12.1.0.0</db2.jdbc.version>
-    <duckdb-jdbc.version>1.4.2.0</duckdb-jdbc.version>
+    <duckdb-jdbc.version>1.5.3.0</duckdb-jdbc.version>
     <eastwood.version>1.1.1-20090908</eastwood.version>
     <eclipse.emf.version>2.15.0</eclipse.emf.version>
     <eclipse.xsd.version>2.12.0</eclipse.xsd.version>


### PR DESCRIPTION
[![GEOT-7919](https://badgen.net/badge/JIRA/GEOT-7919/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7919) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->
Update to newer DuckDB to fix an issue related to a false positive on ETAG check on DuckDB Driver when reading from geoparquet on S3.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 