### PR TITLE
[GEOT-7921]: Fixing JsonMapper class name lookup for GeoJSONDataStoreFactory.isAvailable()

### DIFF
--- a/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONDataStoreFactory.java
+++ b/modules/unsupported/geojson-store/src/main/java/org/geotools/data/geojson/store/GeoJSONDataStoreFactory.java
@@ -144,7 +144,7 @@ public class GeoJSONDataStoreFactory implements FileDataStoreFactorySpi {
     public synchronized boolean isAvailable() {
         if (isAvailable == null) {
             try {
-                Class.forName("tools.jackson.databind.json.JSONMapper");
+                Class.forName("tools.jackson.databind.json.JsonMapper");
                 JsonMapper.builder().addModule(new JtsModule()).build();
                 isAvailable = true;
             } catch (ClassNotFoundException e) {

--- a/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONDataStoreFactoryTest.java
+++ b/modules/unsupported/geojson-store/src/test/java/org/geotools/data/geojson/store/GeoJSONDataStoreFactoryTest.java
@@ -19,6 +19,7 @@ package org.geotools.data.geojson.store;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -138,5 +139,10 @@ public class GeoJSONDataStoreFactoryTest {
             fail("Failed to get feature source with exception: " + e.getClass().getName() + " message: "
                     + e.getMessage());
         }
+    }
+
+    @Test
+    public void testIsAvailable() throws IOException, SchemaException {
+        assertTrue(fac.isAvailable());
     }
 }


### PR DESCRIPTION
[![GEOT-7921](https://badgen.net/badge/JIRA/GEOT-7921/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7921) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Simple class name typo mixing up some case, that is causing the GeoJson datastore to fail in it’s isAvailable method, despite it functioning just fine other than that. 
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)). 