### PR TITLE
GEOT-7923: fix the wrong type of point in polygonlabeler

### DIFF
--- a/modules/unsupported/process-geometry/src/main/java/org/geotools/process/geometry/PolygonLabelFunction.java
+++ b/modules/unsupported/process-geometry/src/main/java/org/geotools/process/geometry/PolygonLabelFunction.java
@@ -26,13 +26,15 @@ import org.geotools.api.filter.expression.Function;
 import org.geotools.api.filter.expression.Literal;
 import org.geotools.filter.capability.FunctionNameImpl;
 import org.geotools.util.Converters;
-import org.locationtech.jts.awt.PointShapeFactory.Point;
+
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
 
 public class PolygonLabelFunction implements Function {
     static FunctionName NAME = new FunctionNameImpl(
             "labelPoint",
-            Point.class,
+
+        Point.class,
             FunctionNameImpl.parameter("polygon", Geometry.class),
             FunctionNameImpl.parameter("tolerance", Double.class));
 

--- a/modules/unsupported/process-geometry/src/main/java/org/geotools/process/geometry/PolygonLabelFunction.java
+++ b/modules/unsupported/process-geometry/src/main/java/org/geotools/process/geometry/PolygonLabelFunction.java
@@ -26,15 +26,13 @@ import org.geotools.api.filter.expression.Function;
 import org.geotools.api.filter.expression.Literal;
 import org.geotools.filter.capability.FunctionNameImpl;
 import org.geotools.util.Converters;
-
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 
 public class PolygonLabelFunction implements Function {
     static FunctionName NAME = new FunctionNameImpl(
             "labelPoint",
-
-        Point.class,
+            Point.class,
             FunctionNameImpl.parameter("polygon", Geometry.class),
             FunctionNameImpl.parameter("tolerance", Double.class));
 

--- a/modules/unsupported/process-geometry/src/test/java/org/geotools/process/geometry/PolyLabellerTest.java
+++ b/modules/unsupported/process-geometry/src/test/java/org/geotools/process/geometry/PolyLabellerTest.java
@@ -102,28 +102,30 @@ public class PolyLabellerTest {
         double delta = point.distance(expected);
         Assert.assertTrue("close enough: " + delta, delta < 0.5);
     }
+
     @Test
     public void testPointType() throws ParseException {
-      SimpleFeatureTypeBuilder type = new SimpleFeatureTypeBuilder();
-      type.setName("type");
-      type.add("geometry", Polygon.class);
-      type.setDefaultGeometry("geometry");
-      SimpleFeatureType typeSchema = type.buildFeatureType();
-      SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(typeSchema);
-      WKTReader reader = new WKTReader();
+        SimpleFeatureTypeBuilder type = new SimpleFeatureTypeBuilder();
+        type.setName("type");
+        type.add("geometry", Polygon.class);
+        type.setDefaultGeometry("geometry");
+        SimpleFeatureType typeSchema = type.buildFeatureType();
+        SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(typeSchema);
+        WKTReader reader = new WKTReader();
 
-      MultiPolygon p = (MultiPolygon)
-          reader.read(
-              "MultiPolygon (((0 5, 5 10, 10 5, 5 0, 0 5)),((11.74609375 1.6357421875, 11.7255859375 3.24609375, 13.9306640625 3.3076171875, 13.951171875 1.73828125, 11.74609375 1.6357421875)))");
+        MultiPolygon p = (MultiPolygon)
+                reader.read(
+                        "MultiPolygon (((0 5, 5 10, 10 5, 5 0, 0 5)),((11.74609375 1.6357421875, 11.7255859375 3.24609375, 13.9306640625 3.3076171875, 13.951171875 1.73828125, 11.74609375 1.6357421875)))");
 
-      featureBuilder.set("geometry",p );
-      SimpleFeature feature = featureBuilder.buildFeature(null);
-      FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
-      Function labelPos = ff.function("labelPoint", ff.property("geometry"), ff.literal(1.0));
-      Object pos = labelPos.evaluate(feature);
-      Assert.assertNotNull(pos);
-      Assert.assertTrue("Wrong type returned: " + pos.getClass().getName(), pos instanceof Point);
+        featureBuilder.set("geometry", p);
+        SimpleFeature feature = featureBuilder.buildFeature(null);
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+        Function labelPos = ff.function("labelPoint", ff.property("geometry"), ff.literal(1.0));
+        Object pos = labelPos.evaluate(feature);
+        Assert.assertNotNull(pos);
+        Assert.assertTrue("Wrong type returned: " + pos.getClass().getName(), pos instanceof Point);
     }
+
     @Test
     public void testBadInput() {
 

--- a/modules/unsupported/process-geometry/src/test/java/org/geotools/process/geometry/PolyLabellerTest.java
+++ b/modules/unsupported/process-geometry/src/test/java/org/geotools/process/geometry/PolyLabellerTest.java
@@ -18,6 +18,13 @@
 
 package org.geotools.process.geometry;
 
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Function;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.geometry.jts.GeometryBuilder;
 import org.junit.Assert;
 import org.junit.Test;
@@ -95,7 +102,28 @@ public class PolyLabellerTest {
         double delta = point.distance(expected);
         Assert.assertTrue("close enough: " + delta, delta < 0.5);
     }
+    @Test
+    public void testPointType() throws ParseException {
+      SimpleFeatureTypeBuilder type = new SimpleFeatureTypeBuilder();
+      type.setName("type");
+      type.add("geometry", Polygon.class);
+      type.setDefaultGeometry("geometry");
+      SimpleFeatureType typeSchema = type.buildFeatureType();
+      SimpleFeatureBuilder featureBuilder = new SimpleFeatureBuilder(typeSchema);
+      WKTReader reader = new WKTReader();
 
+      MultiPolygon p = (MultiPolygon)
+          reader.read(
+              "MultiPolygon (((0 5, 5 10, 10 5, 5 0, 0 5)),((11.74609375 1.6357421875, 11.7255859375 3.24609375, 13.9306640625 3.3076171875, 13.951171875 1.73828125, 11.74609375 1.6357421875)))");
+
+      featureBuilder.set("geometry",p );
+      SimpleFeature feature = featureBuilder.buildFeature(null);
+      FilterFactory ff = CommonFactoryFinder.getFilterFactory(null);
+      Function labelPos = ff.function("labelPoint", ff.property("geometry"), ff.literal(1.0));
+      Object pos = labelPos.evaluate(feature);
+      Assert.assertNotNull(pos);
+      Assert.assertTrue("Wrong type returned: " + pos.getClass().getName(), pos instanceof Point);
+    }
     @Test
     public void testBadInput() {
 


### PR DESCRIPTION
[![GEOT-7923](https://badgen.net/badge/JIRA/GEOT-7923/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7923) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->
  PolygonLabeler function was trying to return a type of point with no convertor, meaning `evaluate` failed.
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allo wed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 