### PR TITLE
[GEOT-7924] Cascaded WMS regression on unencoded UTF-8 characters in the capabilities URLs

### DIFF
--- a/modules/library/http/src/main/java/org/geotools/http/AbstractHttpClient.java
+++ b/modules/library/http/src/main/java/org/geotools/http/AbstractHttpClient.java
@@ -131,6 +131,121 @@ public abstract class AbstractHttpClient implements HTTPClient {
         return new URL(oldUrl.getProtocol(), oldUrl.getHost(), oldUrl.getPort(), oldUrl.getPath() + "?" + newQuery);
     }
 
+    /**
+     * Percent-encodes the illegal characters (non ASCII and disallowed ASCII) in the path, query and fragment of the
+     * given URL, leaving legal characters and existing {@code %XX} escapes untouched (a stray {@code %} becomes
+     * {@code %25}). This restores the automatic request line encoding Apache HttpClient 4 did and that HttpClient 5 and
+     * {@link URLConnection} do not: without it a capabilities document exposing an online resource with raw UTF
+     * characters breaks cascading. The scheme and authority are kept verbatim: only the path, query and fragment are
+     * encoded. A raw non-ASCII host is left untouched: percent-encoding it would be wrong, a host needs IDNA/punycode
+     * (see RFC 5890) rather than percent escapes, but in practice capabilities hosts are already ASCII.
+     */
+    protected static URL encodeURL(URL url) throws MalformedURLException {
+        String file = url.getFile();
+        String ref = url.getRef();
+        String encFile = encodeIllegalCharacters(file);
+        String encRef = ref == null ? null : encodeIllegalCharacters(ref);
+        if (encFile.equals(file) && (ref == null || encRef.equals(ref))) {
+            return url;
+        }
+        StringBuilder sb = new StringBuilder(url.getProtocol()).append("://");
+        if (url.getAuthority() != null) {
+            sb.append(url.getAuthority());
+        }
+        sb.append(encFile);
+        if (encRef != null) {
+            // kept for a faithful transform only: clients strip the fragment before the wire (see RFC 9110 section 7.1)
+            sb.append('#').append(encRef);
+        }
+        return new URL(sb.toString());
+    }
+
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+
+    private static String encodeIllegalCharacters(String segment) {
+        // iterate by Unicode code point, not by char. A Java char is 16 bit, so characters above U+FFFF ("astral"
+        // characters, like most emoji) are stored as two chars, a "surrogate pair". codePointAt combines a valid pair
+        // into a single code point and charCount tells how many chars it spanned, so we advance past both.
+        StringBuilder sb = null; // allocated lazily, only once the first illegal char or stray '%' is found
+        int i = 0;
+        while (i < segment.length()) {
+            int cp = segment.codePointAt(i);
+            boolean legal;
+            if (cp == '%') {
+                // keep only a well formed %XX escape, a stray '%' becomes %25 (handled below) so it does not produce an
+                // invalid escape that the downstream URI parser would reject
+                legal = i + 2 < segment.length() && isHex(segment.charAt(i + 1)) && isHex(segment.charAt(i + 2));
+            } else {
+                legal = cp < 128 && isLegalUriChar((char) cp);
+            }
+            if (legal) {
+                if (sb != null) {
+                    sb.append((char) cp);
+                }
+            } else {
+                // first illegal char: materialize the legal prefix scanned so far, then encode from here on
+                if (sb == null) {
+                    sb = new StringBuilder(segment.length() + 8).append(segment, 0, i);
+                }
+                appendUtf8PercentEncoded(sb, cp);
+            }
+            i += Character.charCount(cp);
+        }
+        return sb == null ? segment : sb.toString();
+    }
+
+    private static boolean isHex(char c) {
+        return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+    }
+
+    /**
+     * Appends the UTF-8 bytes of the code point as {@code %XX} sequences, computing the encoding without allocating.
+     */
+    private static void appendUtf8PercentEncoded(StringBuilder sb, int cp) {
+        // if a surrogate reaches here it is unpaired (a dangling half of an astral pair, from malformed input):
+        // codePointAt returns its raw value in 0xD800..0xDFFF. That is not a real character, so encode it as the
+        // Unicode replacement character U+FFFD instead of emitting an invalid UTF-8 sequence the server could not
+        // decode
+        if (cp >= 0xD800 && cp <= 0xDFFF) {
+            cp = 0xFFFD;
+        }
+        if (cp <= 0x7F) {
+            appendPercentByte(sb, cp);
+        } else if (cp <= 0x7FF) {
+            appendPercentByte(sb, 0xC0 | (cp >> 6));
+            appendPercentByte(sb, 0x80 | (cp & 0x3F));
+        } else if (cp <= 0xFFFF) {
+            appendPercentByte(sb, 0xE0 | (cp >> 12));
+            appendPercentByte(sb, 0x80 | ((cp >> 6) & 0x3F));
+            appendPercentByte(sb, 0x80 | (cp & 0x3F));
+        } else {
+            appendPercentByte(sb, 0xF0 | (cp >> 18));
+            appendPercentByte(sb, 0x80 | ((cp >> 12) & 0x3F));
+            appendPercentByte(sb, 0x80 | ((cp >> 6) & 0x3F));
+            appendPercentByte(sb, 0x80 | (cp & 0x3F));
+        }
+    }
+
+    private static void appendPercentByte(StringBuilder sb, int b) {
+        // %XX: high nibble (top 4 bits) then low nibble (bottom 4 bits) as hex digits, e.g. 0xC3 -> "%C3"
+        sb.append('%').append(HEX[(b >> 4) & 0xF]).append(HEX[b & 0xF]);
+    }
+
+    /**
+     * The characters that may appear unescaped in a URI, per <a
+     * href="https://www.rfc-editor.org/rfc/rfc3986#section-2">RFC 3986 section 2</a> (unreserved plus the reserved
+     * gen-delims and sub-delims), minus {@code #}. {@code %} is absent too. Both are handled outside this set:
+     * {@code %} only survives as part of a valid {@code %XX} escape, and {@code #} is always encoded, so the only
+     * fragment delimiter is the one {@link #encodeURL(URL)} adds itself (this method sees the path+query and fragment
+     * already split, so a raw {@code #} in either would be a spurious delimiter).
+     */
+    private static boolean isLegalUriChar(char c) {
+        return (c >= 'A' && c <= 'Z')
+                || (c >= 'a' && c <= 'z')
+                || (c >= '0' && c <= '9')
+                || "-._~:/?[]@!$&'()*+,;=".indexOf(c) >= 0;
+    }
+
     protected boolean isFile(URL url) {
         return "file".equalsIgnoreCase(url.getProtocol());
     }

--- a/modules/library/http/src/main/java/org/geotools/http/SimpleHttpClient.java
+++ b/modules/library/http/src/main/java/org/geotools/http/SimpleHttpClient.java
@@ -140,7 +140,7 @@ public class SimpleHttpClient extends AbstractHttpClient implements HTTPProxy {
             finalURL = appendURL(finalURL, extraParams);
         }
 
-        URLConnection connection = finalURL.openConnection();
+        URLConnection connection = encodeURL(finalURL).openConnection();
         final boolean http = connection instanceof HttpURLConnection;
         if (headers == null) {
             headers = new HashMap<>();

--- a/modules/library/http/src/test/java/org/geotools/http/AbstractHttpClientTest.java
+++ b/modules/library/http/src/test/java/org/geotools/http/AbstractHttpClientTest.java
@@ -1,0 +1,103 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.http;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.Test;
+
+/** Unit tests for the {@link AbstractHttpClient#encodeURL(URL)} request line percent-encoding. */
+public class AbstractHttpClientTest {
+
+    @Test
+    public void testLeavesAlreadyEncoded() throws MalformedURLException {
+        // raw non-ASCII gets encoded, existing %XX and legal chars are preserved (no double encoding)
+        assertEquals(
+                "http://h/wms?a=citt%C3%A0&b=citt%C3%A0&c=1,2&d=a%20b",
+                AbstractHttpClient.encodeURL(new URL("http://h/wms?a=città&b=citt%C3%A0&c=1,2&d=a b"))
+                        .toExternalForm());
+    }
+
+    @Test
+    public void testStrayPercent() throws MalformedURLException {
+        // a valid %XX escape is kept, a stray '%' (percentage sign, %zz, trailing %) is encoded to %25 so the request
+        // line stays a parseable URI, something HttpClient 4 never handled
+        assertEquals(
+                "http://h/wms?d=50%25&e=%C3%A0&f=%25zz&g=abc%25",
+                AbstractHttpClient.encodeURL(new URL("http://h/wms?d=50%&e=%C3%A0&f=%zz&g=abc%"))
+                        .toExternalForm());
+    }
+
+    @Test
+    public void testFragmentAndStrayHash() throws MalformedURLException {
+        // a legit fragment is kept as a single delimiter; a stray '#' inside the fragment is encoded to %23 so the
+        // reconstructed URL cannot grow a second fragment marker (query/fragment boundary differential)
+        assertEquals(
+                "http://h/p?a=b#frag",
+                AbstractHttpClient.encodeURL(new URL("http://h/p?a=b#frag")).toExternalForm());
+        assertEquals(
+                "http://h/p?a=b#x%23y",
+                AbstractHttpClient.encodeURL(new URL("http://h/p?a=b#x#y")).toExternalForm());
+    }
+
+    @Test
+    public void testNonAsciiPath() throws MalformedURLException {
+        // encoding applies to the path, not just the query
+        assertEquals(
+                "http://h/citt%C3%A0/wms?a=b",
+                AbstractHttpClient.encodeURL(new URL("http://h/città/wms?a=b")).toExternalForm());
+    }
+
+    @Test
+    public void testNonAsciiFragment() throws MalformedURLException {
+        // fragment content is UTF-8 encoded as well (kept as a single delimiter)
+        assertEquals(
+                "http://h/wms?a=b#citt%C3%A0",
+                AbstractHttpClient.encodeURL(new URL("http://h/wms?a=b#città")).toExternalForm());
+    }
+
+    @Test
+    public void testAsciiUrlLeftUnchanged() throws MalformedURLException {
+        // a fully legal URL is returned as the same instance, no reconstruction
+        URL url = new URL("http://h:8080/geoserver/wms?service=WMS&request=GetMap&bbox=1,2,3,4");
+        assertSame(url, AbstractHttpClient.encodeURL(url));
+    }
+
+    @Test
+    public void testLoneSurrogateBecomesReplacementChar() throws MalformedURLException {
+        // an unpaired high or low surrogate is not a valid code point: it must encode as U+FFFD (%EF%BF%BD), not as an
+        // invalid UTF-8 (CESU-8) sequence like %ED%A0%80
+        assertEquals(
+                "http://h/wms?a=x%EF%BF%BDy",
+                AbstractHttpClient.encodeURL(new URL("http://h/wms?a=x\uD800y")).toExternalForm());
+        assertEquals(
+                "http://h/wms?a=%EF%BF%BD",
+                AbstractHttpClient.encodeURL(new URL("http://h/wms?a=\uDC00")).toExternalForm());
+    }
+
+    @Test
+    public void testMultiByteAndAstral() throws MalformedURLException {
+        // 3-byte CJK, 2-byte Cyrillic, and a 4-byte astral code point (emoji, encoded via a surrogate pair)
+        assertEquals(
+                "http://h/wms?cjk=%E5%8C%97%E4%BA%AC&cyr=%D0%9C&emoji=%F0%9F%98%80",
+                AbstractHttpClient.encodeURL(new URL("http://h/wms?cjk=北京&cyr=М&emoji=😀"))
+                        .toExternalForm());
+    }
+}

--- a/modules/library/http/src/test/java/org/geotools/http/SimpleHttpClientTest.java
+++ b/modules/library/http/src/test/java/org/geotools/http/SimpleHttpClientTest.java
@@ -151,6 +151,38 @@ public class SimpleHttpClientTest {
     }
 
     /**
+     * A capabilities document may expose an online resource with raw, non-ASCII characters. HttpClient 4 used to
+     * percent-encode them on the request line, HttpURLConnection does not, so the client must do it. WireMock decodes
+     * query parameters, so a correctly encoded request matches the expected decoded value.
+     */
+    @Test
+    public void testRawUnicodeQueryIsEncoded() throws IOException {
+        UrlPattern urlPattern = urlMatching("/wms.*");
+        service.stubFor(get(urlPattern).willReturn(aResponse().withStatus(200).withBody("<ok/>")));
+
+        SimpleHttpClient client = new SimpleHttpClient();
+        client.get(new URL("http://localhost:" + service.port() + "/wms?layers=città&x=y"));
+
+        service.verify(getRequestedFor(urlMatching("/wms.*"))
+                .withQueryParam("layers", equalTo("città"))
+                .withQueryParam("x", equalTo("y")));
+    }
+
+    @Test
+    public void testRawUnicodeQueryIsEncodedOnPost() throws IOException {
+        UrlPattern urlPattern = urlMatching("/wms.*");
+        service.stubFor(post(urlPattern).willReturn(aResponse().withStatus(200).withBody("<ok/>")));
+
+        SimpleHttpClient client = new SimpleHttpClient();
+        ByteArrayInputStream body = new ByteArrayInputStream("x".getBytes(StandardCharsets.UTF_8));
+        client.post(new URL("http://localhost:" + service.port() + "/wms?layers=città&x=y"), body, "text/plain");
+
+        service.verify(postRequestedFor(urlMatching("/wms.*"))
+                .withQueryParam("layers", equalTo("città"))
+                .withQueryParam("x", equalTo("y")));
+    }
+
+    /**
      * Tests if redirection (HTTP -> HTTPS) is followed
      *
      * @throws IOException

--- a/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
+++ b/modules/plugin/http-commons/src/main/java/org/geotools/http/commons/MultithreadedHttpClient.java
@@ -144,7 +144,7 @@ public class MultithreadedHttpClient extends AbstractHttpClient implements HTTPC
         } else {
             headers = new HashMap<>(headers); // avoid parameter modification
         }
-        HttpPost postMethod = new HttpPost(url.toExternalForm());
+        HttpPost postMethod = new HttpPost(encodeURL(url).toExternalForm());
         postMethod.setConfig(requestConfig);
         HttpEntity requestEntity;
         if (credsProvider != null) {
@@ -225,7 +225,7 @@ public class MultithreadedHttpClient extends AbstractHttpClient implements HTTPC
             url = appendURL(url, extraParams);
         }
 
-        HttpGet getMethod = new HttpGet(url.toExternalForm());
+        HttpGet getMethod = new HttpGet(encodeURL(url).toExternalForm());
         getMethod.setConfig(requestConfig);
 
         if (tryGzip) {

--- a/modules/plugin/http-commons/src/test/java/org/geotools/http/commons/MultithreadedHttpClientTest.java
+++ b/modules/plugin/http-commons/src/test/java/org/geotools/http/commons/MultithreadedHttpClientTest.java
@@ -23,6 +23,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -172,6 +173,53 @@ public class MultithreadedHttpClientTest {
         } else {
             System.setProperty(SYS_PROP_KEY_PORT, sysPropOriginalValue[2]);
         }
+    }
+
+    /**
+     * HttpClient 5 sends the request line verbatim, unlike HttpClient 4 which percent-encoded it. A capabilities
+     * document exposing an online resource with raw non-ASCII characters must still produce a valid request.
+     */
+    @Test
+    public void testRawUnicodeQueryIsEncoded() throws IOException {
+        service.stubFor(get(urlMatching("/wms.*"))
+                .willReturn(aResponse().withStatus(200).withBody("<ok/>")));
+        URL url = new URL("http://localhost:" + service.port() + "/wms?layers=città&x=y");
+        try (MultithreadedHttpClient sut = new MultithreadedHttpClient()) {
+            sut.get(url);
+        }
+        service.verify(getRequestedFor(urlMatching("/wms.*"))
+                .withQueryParam("layers", equalTo("città"))
+                .withQueryParam("x", equalTo("y")));
+    }
+
+    @Test
+    public void testRawUnicodeQueryIsEncodedOnPost() throws IOException {
+        service.stubFor(post(urlMatching("/wms.*"))
+                .willReturn(aResponse().withStatus(200).withBody("<ok/>")));
+        URL url = new URL("http://localhost:" + service.port() + "/wms?layers=città&x=y");
+        ByteArrayInputStream body = new ByteArrayInputStream("x".getBytes(StandardCharsets.UTF_8));
+        try (MultithreadedHttpClient sut = new MultithreadedHttpClient()) {
+            sut.post(url, body, "text/plain");
+        }
+        service.verify(postRequestedFor(urlMatching("/wms.*"))
+                .withQueryParam("layers", equalTo("città"))
+                .withQueryParam("x", equalTo("y")));
+    }
+
+    /**
+     * Multi-byte (CJK) and astral (emoji, surrogate pair) characters must round-trip through UTF-8 percent-encoding.
+     */
+    @Test
+    public void testMultiByteQueryIsEncoded() throws IOException {
+        service.stubFor(get(urlMatching("/wms.*"))
+                .willReturn(aResponse().withStatus(200).withBody("<ok/>")));
+        URL url = new URL("http://localhost:" + service.port() + "/wms?layers=北京&emoji=😀");
+        try (MultithreadedHttpClient sut = new MultithreadedHttpClient()) {
+            sut.get(url);
+        }
+        service.verify(getRequestedFor(urlMatching("/wms.*"))
+                .withQueryParam("layers", equalTo("北京"))
+                .withQueryParam("emoji", equalTo("😀")));
     }
 
     @Test


### PR DESCRIPTION
[![GEOT-7924](https://badgen.net/badge/JIRA/GEOT-7924/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7924) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

See ticket for details

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 