### PR TITLE
Label rendering performance (reduced CPU usage in high conflict, and reduced allocation)

### DIFF
--- a/modules/library/render/src/main/java/org/geotools/renderer/label/GlyphProcessor.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/GlyphProcessor.java
@@ -102,6 +102,9 @@ abstract class GlyphProcessor {
     public static class IndexAdder extends GlyphProcessor {
 
         LabelIndex index;
+        // per-instance buffers for transformBounds; IndexAdder is used single-threaded per label
+        private final double[] cornerBuffer = new double[8];
+        private final Rectangle2D.Double boundsBuffer = new Rectangle2D.Double();
 
         public IndexAdder(LabelPainter painter, LabelIndex index) {
             super(painter);
@@ -111,8 +114,11 @@ abstract class GlyphProcessor {
         @Override
         public boolean process(GlyphVector glyphVector, int g, AffineTransform tx, char c) {
             if (Character.isWhitespace(c)) return false;
-            Rectangle2D labelEnvelope =
-                    tx.createTransformedShape(glyphVector.getGlyphOutline(g)).getBounds2D();
+            // visual bounds instead of the glyph outline: avoids a per-glyph Shape allocation. For
+            // rotated glyphs this over-estimates a bit (bounding box of the rotated box), never
+            // under, so conflict detection stays safe.
+            Rectangle2D labelEnvelope = LabelCacheImpl.transformBounds(
+                    tx, glyphVector.getGlyphVisualBounds(g).getBounds2D(), cornerBuffer, boundsBuffer);
             index.addLabel(labelItem, labelEnvelope);
             return true;
         }

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
@@ -65,6 +65,7 @@ import org.geotools.renderer.style.TextStyle2D;
 import org.geotools.util.NumberRange;
 import org.geotools.util.logging.Logging;
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.CoordinateSequence;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -97,6 +98,9 @@ import org.locationtech.jts.operation.linemerge.LineMerger;
  * <p>{@link TextSymbolizer#getPriority()} OGC Expression controls a label priority.
  *
  * <p>A label with high priority will be drawn before others, increasing its likeliness to appear on the screen
+ *
+ * <p>This class is <b>not thread safe</b>: a single instance is meant to serve one rendering at a time. To share a
+ * label cache across concurrent renderings wrap it in a {@link org.geotools.renderer.lite.SynchronizedLabelCache}.
  *
  * @author jeichar
  * @author dblasby
@@ -150,6 +154,10 @@ public class LabelCacheImpl implements LabelCache {
 
     /** List of reserved areas of the screen for which labels should fear to tread */
     private List<Rectangle2D> reserved = new ArrayList<>();
+
+    // Reused by transformBounds to avoid per-call allocation; safe because a LabelCacheImpl serves one rendering
+    private final double[] cornerBuffer = new double[8];
+    private final Rectangle2D.Double boundsBuffer = new Rectangle2D.Double();
 
     // Anchor candidate values used when looping to find a point label that can be drawn
     static final double[] RIGHT_ANCHOR_CANDIDATES = {0, 0.5, 0, 0, 0, 1};
@@ -1029,8 +1037,7 @@ public class LabelCacheImpl implements LabelCache {
                             // if label will be painted as straight, use the
                             // straight bounds
                             setupLineTransform(painter, cursor, centroid, tx, true);
-                            labelEnvelope =
-                                    tx.createTransformedShape(textBounds).getBounds2D();
+                            labelEnvelope = transformBounds(tx, textBounds);
                         } else {
                             // otherwise use curved bounds, more expensive to
                             // compute
@@ -1039,7 +1046,7 @@ public class LabelCacheImpl implements LabelCache {
                         }
                     } else {
                         setupLineTransform(painter, cursor, centroid, tx, false);
-                        labelEnvelope = tx.createTransformedShape(textBounds).getBounds2D();
+                        labelEnvelope = transformBounds(tx, textBounds);
                     }
 
                     // try to paint the label, the condition under which this
@@ -1200,7 +1207,8 @@ public class LabelCacheImpl implements LabelCache {
     private void setupPointTransform(
             AffineTransform tempTransform, Point centroid, TextStyle2D textStyle, LabelPainter painter) {
 
-        tempTransform.translate(centroid.getX(), centroid.getY());
+        CoordinateSequence cs = centroid.getCoordinateSequence();
+        tempTransform.translate(cs.getX(0), cs.getY(0));
 
         double rotation = textStyle.getRotation();
         if (Double.isNaN(rotation) || Double.isInfinite(rotation)) {
@@ -1223,6 +1231,35 @@ public class LabelCacheImpl implements LabelCache {
                         ? painter.getLineHeight()
                         : painter.getLineHeightForAnchorY(textStyle.getAnchorY()));
         tempTransform.translate(displacementX, displacementY);
+    }
+
+    /** Returns the bounding box of {@code rect} after applying {@code tx}. Reuses instance buffers — not reentrant. */
+    private Rectangle2D transformBounds(AffineTransform tx, Rectangle2D rect) {
+        return transformBounds(tx, rect, cornerBuffer, boundsBuffer);
+    }
+
+    /**
+     * Returns the bounding box of {@code rect} after applying {@code tx}, avoiding a {@code Path2D} allocation. Writes
+     * the corners into {@code corners} (length 8) and the result into {@code bounds}, both supplied by the caller so
+     * the buffers can be reused without sharing state across threads.
+     */
+    static Rectangle2D transformBounds(
+            AffineTransform tx, Rectangle2D rect, double[] corners, Rectangle2D.Double bounds) {
+        corners[0] = rect.getMinX();
+        corners[1] = rect.getMinY();
+        corners[2] = rect.getMaxX();
+        corners[3] = rect.getMinY();
+        corners[4] = rect.getMaxX();
+        corners[5] = rect.getMaxY();
+        corners[6] = rect.getMinX();
+        corners[7] = rect.getMaxY();
+        tx.transform(corners, 0, corners, 0, 4);
+        double minX = Math.min(Math.min(corners[0], corners[2]), Math.min(corners[4], corners[6]));
+        double minY = Math.min(Math.min(corners[1], corners[3]), Math.min(corners[5], corners[7]));
+        double maxX = Math.max(Math.max(corners[0], corners[2]), Math.max(corners[4], corners[6]));
+        double maxY = Math.max(Math.max(corners[1], corners[3]), Math.max(corners[5], corners[7]));
+        bounds.setRect(minX, minY, maxX - minX, maxY - minY);
+        return bounds;
     }
 
     /**
@@ -1422,15 +1459,20 @@ public class LabelCacheImpl implements LabelCache {
         setupPointTransform(tempTransform, point, textStyle, painter);
 
         // check for overlaps and paint
-        Rectangle2D transformed = tempTransform
-                .createTransformedShape(painter.getFullLabelBounds())
-                .getBounds2D();
+        Rectangle2D transformed = transformBounds(tempTransform, painter.getFullLabelBounds());
         if (!(displayArea.contains(transformed) || labelItem.isPartialsEnabled())
                 || labelItem.isConflictResolutionEnabled()
                         && glyphs.labelsWithinDistance(transformed, labelItem.getSpaceAround())) {
             return false;
         } else {
-            painter.paintStraightLabel(tempTransform, point.getCoordinate());
+            // labelPoint only needed when a graphic is placed independently of the label
+            Coordinate labelPoint = labelItem.getTextStyle().getGraphic() != null
+                            && labelItem.getGraphicPlacement() == GraphicPlacement.INDEPENDENT
+                    ? new Coordinate(
+                            point.getCoordinateSequence().getX(0),
+                            point.getCoordinateSequence().getY(0))
+                    : null;
+            painter.paintStraightLabel(tempTransform, labelPoint);
             if (DEBUG_CACHE_BOUNDS) {
                 painter.graphics.setStroke(new BasicStroke());
                 painter.graphics.setColor(Color.RED);
@@ -1564,16 +1606,17 @@ public class LabelCacheImpl implements LabelCache {
         // ... use at least a 2 pixel step, no matter what the label length is
         final double step = painter.getAscent() > 2 ? painter.getAscent() : 2;
         double radius = step;
-        Coordinate c = new Coordinate(centroid.getCoordinate());
-        Coordinate cc = centroid.getCoordinate();
+        CoordinateSequence centroidCS = centroid.getCoordinateSequence();
+        double ccX = centroidCS.getX(0), ccY = centroidCS.getY(0);
+        Coordinate c = new Coordinate(ccX, ccY);
         Point testPoint = centroid.getFactory().createPoint(c);
         while (radius < labelItem.getMaxDisplacement()) {
             for (int angle : displacementAngles) {
                 double dx = Math.cos(Math.toRadians(angle)) * radius;
                 double dy = Math.sin(Math.toRadians(angle)) * radius;
 
-                c.x = cc.x + dx;
-                c.y = cc.y + dy;
+                c.x = ccX + dx;
+                c.y = ccY + dy;
                 testPoint.geometryChanged();
                 if (!pg.contains(testPoint)) continue;
 
@@ -1608,9 +1651,7 @@ public class LabelCacheImpl implements LabelCache {
         AffineTransform original = new AffineTransform(tempTransform);
         setupPointTransform(tempTransform, centroid, textStyle, painter);
 
-        Rectangle2D transformed = tempTransform
-                .createTransformedShape(painter.getFullLabelBounds())
-                .getBounds2D();
+        Rectangle2D transformed = transformBounds(tempTransform, painter.getFullLabelBounds());
         if (!(displayArea.contains(transformed) || labelItem.isPartialsEnabled())
                 || labelItem.isConflictResolutionEnabled()
                         && glyphs.labelsWithinDistance(transformed, labelItem.getSpaceAround())
@@ -1621,9 +1662,7 @@ public class LabelCacheImpl implements LabelCache {
                 tempTransform.setTransform(original);
                 setupPointTransform(tempTransform, centroid, textStyle, painter);
 
-                transformed = tempTransform
-                        .createTransformedShape(painter.getFullLabelBounds())
-                        .getBounds2D();
+                transformed = transformBounds(tempTransform, painter.getFullLabelBounds());
                 if (!(displayArea.contains(transformed) || labelItem.isPartialsEnabled())
                         || labelItem.isConflictResolutionEnabled()
                                 && glyphs.labelsWithinDistance(transformed, labelItem.getSpaceAround())
@@ -1690,12 +1729,14 @@ public class LabelCacheImpl implements LabelCache {
                 // lines,polys, gc, etc..
                 g = g.getCentroid(); // will be point
             if (g instanceof Point point) {
-                if (displayArea.contains(point.getX(), point.getY()) || partialsEnabled) // this is robust!
+                CoordinateSequence pcs = point.getCoordinateSequence();
+                if (displayArea.contains(pcs.getX(0), pcs.getY(0)) || partialsEnabled) // this is robust!
                 pts.add(point); // possible label location
             } else if (g instanceof MultiPoint) {
                 for (int t = 0; t < g.getNumGeometries(); t++) {
                     Point gg = (Point) g.getGeometryN(t);
-                    if (displayArea.contains(gg.getX(), gg.getY()) || partialsEnabled)
+                    CoordinateSequence gcs = gg.getCoordinateSequence();
+                    if (displayArea.contains(gcs.getX(0), gcs.getY(0)) || partialsEnabled)
                         pts.add(gg); // possible label location
                 }
             }

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelCacheImpl.java
@@ -539,15 +539,17 @@ public class LabelCacheImpl implements LabelCache {
         }
     }
 
+    /** Index margin covering how far a label may be placed outside displayArea (floored to avoid a tiny tree). */
+    private static int labelIndexMargin(LabelCacheItem item) {
+        return Math.max(256, item.getMaxDisplacement() + item.getSpaceAround());
+    }
+
     void paintLabels(Graphics2D graphics, Rectangle displayArea) {
         if (!activeLayers.isEmpty()) {
             throw new IllegalStateException(activeLayers
                     + " are layers that started rendering but have not completed,"
                     + " stop() or endLayer() must be called before end() is called");
         }
-        LabelIndex glyphs = new LabelIndex();
-        glyphs.reserveArea(reserved);
-
         // Used to check the paintLineLabel function
         int paintedLineLabels = 0;
 
@@ -562,16 +564,23 @@ public class LabelCacheImpl implements LabelCache {
         displayArea.width -= 1;
         displayArea.height -= 1;
 
-        // prepare the geometry clipper
-        clipper = new GeometryClipper(new Envelope(
-                displayArea.getMinX(), displayArea.getMaxX(), displayArea.getMinY(), displayArea.getMaxY()));
-
         List<LabelCacheItem> items; // both grouped and non-grouped
         if (needsOrdering) {
             items = orderedLabels();
         } else {
             items = getActiveLabels();
         }
+
+        // size the index to cover labels placed outside displayArea by displacement + space-around;
+        // labels falling beyond the index bounds still match, but degrade to a root-level linear scan
+        int margin = 0;
+        for (LabelCacheItem item : items) margin = Math.max(margin, labelIndexMargin(item));
+        LabelIndex glyphs = new LabelIndex(displayArea, margin);
+        glyphs.reserveArea(reserved);
+
+        // prepare the geometry clipper
+        clipper = new GeometryClipper(new Envelope(
+                displayArea.getMinX(), displayArea.getMaxX(), displayArea.getMinY(), displayArea.getMaxY()));
         LabelPainter painter = constructPainter.apply(graphics, labelRenderingMode);
         for (LabelCacheItem labelItem : items) {
             if (stop) return;
@@ -739,7 +748,7 @@ public class LabelCacheImpl implements LabelCache {
             labelDistance += textBounds.getWidth();
         }
         // min distance, if any
-        LabelIndex groupLabels = new LabelIndex();
+        LabelIndex groupLabels = new LabelIndex(displayArea, labelIndexMargin(labelItem));
         // Max displacement for the current label
         double labelOffset = labelItem.getMaxDisplacement();
         boolean allowOverruns = labelItem.allowOverruns();
@@ -945,7 +954,7 @@ public class LabelCacheImpl implements LabelCache {
         int labelDistance = labelItem.getRepeat();
         // min distance, if any
         int minDistance = labelItem.getMinGroupDistance();
-        LabelIndex groupLabels = new LabelIndex();
+        LabelIndex groupLabels = new LabelIndex(displayArea, labelIndexMargin(labelItem));
         // Max displacement for the current label
         double labelOffset = labelItem.getMaxDisplacement();
         boolean allowOverruns = labelItem.allowOverruns();

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelIndex.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelIndex.java
@@ -34,6 +34,7 @@ public class LabelIndex {
 
     private final LabelQuadtree index;
     private Envelope lastHit;
+    private final Envelope queryEnv = new Envelope();
 
     /**
      * @param displayArea rendering area in screen coordinates
@@ -53,10 +54,11 @@ public class LabelIndex {
      */
     public boolean labelsWithinDistance(Rectangle2D bounds, double distance) {
         if (distance < 0) return false;
-        Envelope query = toEnvelope(bounds);
-        query.expandBy(distance);
-        if (lastHit != null && lastHit.intersects(query)) return true;
-        Envelope found = index.findFirst(query);
+        queryEnv.init(
+                bounds.getMinX() - distance, bounds.getMaxX() + distance,
+                bounds.getMinY() - distance, bounds.getMaxY() + distance);
+        if (lastHit != null && lastHit.intersects(queryEnv)) return true;
+        Envelope found = index.findFirst(queryEnv);
         if (found != null) {
             lastHit = found;
             return true;

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelIndex.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelIndex.java
@@ -2,7 +2,7 @@
  *    GeoTools - The Open Source Java GIS Toolkit
  *    http://geotools.org
  *
- *    (C) 2004-2008, Open Source Geospatial Foundation (OSGeo)
+ *    (C) 2004-2025, Open Source Geospatial Foundation (OSGeo)
  *
  *    This library is free software; you can redistribute it and/or
  *    modify it under the terms of the GNU Lesser General Public
@@ -16,77 +16,65 @@
  */
 package org.geotools.renderer.label;
 
+import java.awt.Rectangle;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.index.quadtree.Quadtree;
 
 /**
- * Stores label items and helps in finding the interferering ones, either by pure overlap or within a certain distance
- * from the specified bounds
+ * Stores label envelopes and detects interference by overlap or proximity.
+ *
+ * <p>Backed by {@link LabelQuadtree} for O(log n) spatial pruning with true early-exit on first hit. Pass
+ * {@code margin} large enough to contain any label that may be positioned outside the display area (e.g. with
+ * {@code partialsEnabled}).
  *
  * @author Andrea Aime
  */
 public class LabelIndex {
 
-    Quadtree index = new Quadtree();
+    private final LabelQuadtree index;
+    private Envelope lastHit;
 
     /**
-     * Returns true if there is any label in the index within the specified distance from the bounds. For speed reasons
-     * the bounds will be simply expanded by the distance, no curved buffer will be generated
+     * @param displayArea rendering area in screen coordinates
+     * @param margin extra space beyond displayArea to accommodate labels outside the display area
+     */
+    public LabelIndex(Rectangle displayArea, int margin) {
+        index = new LabelQuadtree(
+                displayArea.getMinX() - margin,
+                displayArea.getMinY() - margin,
+                displayArea.getMaxX() + margin,
+                displayArea.getMaxY() + margin);
+    }
+
+    /**
+     * Returns true if any label in the index is within {@code distance} of {@code bounds}. The bounds are expanded by
+     * the distance (no curved buffer).
      */
     public boolean labelsWithinDistance(Rectangle2D bounds, double distance) {
         if (distance < 0) return false;
-
-        Envelope e = toEnvelope(bounds);
-        e.expandBy(distance);
-        AtomicBoolean intersectionFound = new AtomicBoolean(false);
-        index.query(e, o -> {
-            if (intersectionFound.get()) return;
-            InterferenceItem item = (InterferenceItem) o;
-            if (item.env.intersects(e)) {
-                intersectionFound.set(true);
-            }
-        });
-        return intersectionFound.get();
+        Envelope query = toEnvelope(bounds);
+        query.expandBy(distance);
+        if (lastHit != null && lastHit.intersects(query)) return true;
+        Envelope found = index.findFirst(query);
+        if (found != null) {
+            lastHit = found;
+            return true;
+        }
+        return false;
     }
 
-    /** Adds a label into the index */
+    /** Adds a label into the index. */
     public void addLabel(LabelCacheItem item, Rectangle2D bounds) {
-        Envelope e = toEnvelope(bounds);
-        index.insert(e, new InterferenceItem(e, item));
+        index.insert(toEnvelope(bounds));
     }
 
-    /** Turns the specified Java2D rectangle into a JTS envelope */
-    private Envelope toEnvelope(Rectangle2D bounds) {
-        return new Envelope(bounds.getMinX(), bounds.getMaxX(), bounds.getMinY(), bounds.getMaxY());
-    }
-
-    /**
-     * Simple structure stored into the quadtree (keeping the item around helps in debugging)
-     *
-     * @author Andrea Aime
-     */
-    static class InterferenceItem {
-        Envelope env;
-
-        LabelCacheItem item;
-
-        public InterferenceItem(Envelope env, LabelCacheItem item) {
-            super();
-            this.env = env;
-            this.item = item;
-        }
-    }
-
-    /** Reserve the area indicated by these Geometry. */
+    /** Reserves the areas indicated by these rectangles. */
     public void reserveArea(List<Rectangle2D> reserved) {
-        for (Rectangle2D area : reserved) {
-            Envelope env = toEnvelope(area);
+        for (Rectangle2D r : reserved) index.insert(toEnvelope(r));
+    }
 
-            InterferenceItem item = new InterferenceItem(env, null);
-            index.insert(env, item);
-        }
+    private static Envelope toEnvelope(Rectangle2D r) {
+        return new Envelope(r.getMinX(), r.getMaxX(), r.getMinY(), r.getMaxY());
     }
 }

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelPainter.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelPainter.java
@@ -91,6 +91,9 @@ public class LabelPainter {
     /** The cached label bounds */
     Rectangle2D labelBounds;
 
+    /** The cached full label bounds (includes halo and shield) */
+    Rectangle2D fullLabelBounds;
+
     /** The class in charge of splitting the labels in multiple lines/scripts/fonts */
     LabelSplitter splitter = new LabelSplitter();
 
@@ -111,6 +114,7 @@ public class LabelPainter {
 
         // reset previous caches
         labelBounds = null;
+        fullLabelBounds = null;
         lines = null;
 
         // layout the label elements
@@ -213,8 +217,13 @@ public class LabelPainter {
         return lines.size();
     }
 
-    /** Get the straight label bounds, taking into account halo, shield and line wrapping */
-    public Rectangle2D getFullLabelBounds() {
+    /**
+     * Get the straight label bounds, taking into account halo, shield and line wrapping. The result is cached until the
+     * next {@link #setLabel(LabelCacheItem)} and the same instance is returned on subsequent calls: callers must treat
+     * it as read-only and must not mutate the returned rectangle.
+     */
+    Rectangle2D getFullLabelBounds() {
+        if (fullLabelBounds != null) return fullLabelBounds;
         // base bounds (clone them, we're going to alter the bounds directly)
         Rectangle2D bounds = (Rectangle2D) getLabelBounds().clone();
 
@@ -267,7 +276,7 @@ public class LabelPainter {
 
         normalizeBounds(bounds);
 
-        return bounds;
+        return fullLabelBounds = bounds;
     }
 
     Rectangle2D applyMargins(int[] margin, Rectangle2D bounds) {

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelQuadtree.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelQuadtree.java
@@ -1,0 +1,112 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2004-2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.label;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.locationtech.jts.geom.Envelope;
+
+/**
+ * Minimal quadtree for screen-space envelope collision detection with true early-exit support.
+ *
+ * <p>Unlike JTS {@code Quadtree}, {@link #anyIntersects} stops traversal immediately on the first matching item rather
+ * than visiting all intersecting branches. Items that span quadrant boundaries are stored at the node where insertion
+ * is attempted; items outside the tree bounds accumulate at the root.
+ */
+class LabelQuadtree {
+
+    private static final int SPLIT_THRESHOLD = 16;
+    private static final int MAX_DEPTH = 12;
+
+    private final double minX, minY, maxX, maxY, midX, midY;
+    private final int depth;
+    private LabelQuadtree[] children;
+    private final List<Envelope> items = new ArrayList<>();
+
+    LabelQuadtree(double minX, double minY, double maxX, double maxY) {
+        this(minX, minY, maxX, maxY, 0);
+    }
+
+    private LabelQuadtree(double minX, double minY, double maxX, double maxY, int depth) {
+        this.minX = minX;
+        this.minY = minY;
+        this.maxX = maxX;
+        this.maxY = maxY;
+        this.midX = (minX + maxX) / 2;
+        this.midY = (minY + maxY) / 2;
+        this.depth = depth;
+    }
+
+    void insert(Envelope e) {
+        if (children != null) {
+            int idx = childIndex(e);
+            if (idx >= 0) children[idx].insert(e);
+            else items.add(e);
+            return;
+        }
+        items.add(e);
+        if (items.size() > SPLIT_THRESHOLD && depth < MAX_DEPTH) split();
+    }
+
+    /** Returns the first stored envelope intersecting {@code query}, or null if none. */
+    Envelope findFirst(Envelope query) {
+        for (Envelope e : items) {
+            if (e.intersects(query)) return e;
+        }
+        if (children != null)
+            for (LabelQuadtree child : children)
+                if (child.nodeBoundsIntersect(query)) {
+                    Envelope found = child.findFirst(query);
+                    if (found != null) return found;
+                }
+        return null;
+    }
+
+    private boolean nodeBoundsIntersect(Envelope e) {
+        return e.getMinX() <= maxX && e.getMaxX() >= minX && e.getMinY() <= maxY && e.getMaxY() >= minY;
+    }
+
+    /** Returns child index [0=SW,1=SE,2=NW,3=NE] if {@code e} fits entirely in that quadrant, else -1. */
+    private int childIndex(Envelope e) {
+        // keep at this node anything not fully inside its bounds, so every item lives in a node whose
+        // envelope contains it; that is what makes findFirst's node-bounds pruning sound (mirrors the
+        // JTS Quadtree invariant, which instead grows the tree upward to contain out-of-bounds items).
+        if (e.getMinX() < minX || e.getMaxX() > maxX || e.getMinY() < minY || e.getMaxY() > maxY) return -1;
+        boolean left = e.getMaxX() <= midX, right = e.getMinX() >= midX;
+        boolean bottom = e.getMaxY() <= midY, top = e.getMinY() >= midY;
+        if (left && bottom) return 0;
+        if (right && bottom) return 1;
+        if (left && top) return 2;
+        if (right && top) return 3;
+        return -1;
+    }
+
+    private void split() {
+        children = new LabelQuadtree[4];
+        children[0] = new LabelQuadtree(minX, minY, midX, midY, depth + 1);
+        children[1] = new LabelQuadtree(midX, minY, maxX, midY, depth + 1);
+        children[2] = new LabelQuadtree(minX, midY, midX, maxY, depth + 1);
+        children[3] = new LabelQuadtree(midX, midY, maxX, maxY, depth + 1);
+        List<Envelope> old = new ArrayList<>(items);
+        items.clear();
+        for (Envelope e : old) {
+            int idx = childIndex(e);
+            if (idx >= 0) children[idx].insert(e);
+            else items.add(e);
+        }
+    }
+}

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LabelQuadtree.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LabelQuadtree.java
@@ -23,9 +23,9 @@ import org.locationtech.jts.geom.Envelope;
 /**
  * Minimal quadtree for screen-space envelope collision detection with true early-exit support.
  *
- * <p>Unlike JTS {@code Quadtree}, {@link #anyIntersects} stops traversal immediately on the first matching item rather
- * than visiting all intersecting branches. Items that span quadrant boundaries are stored at the node where insertion
- * is attempted; items outside the tree bounds accumulate at the root.
+ * <p>Unlike JTS {@code Quadtree}, {@link #findFirst(Envelope)} stops traversal immediately on the first matching item
+ * rather than visiting all intersecting branches. Items that span quadrant boundaries are stored at the node where
+ * insertion is attempted; items outside the tree bounds accumulate at the root.
  */
 class LabelQuadtree {
 

--- a/modules/library/render/src/main/java/org/geotools/renderer/label/LineInfo.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/label/LineInfo.java
@@ -97,6 +97,8 @@ class LineInfo {
     /** The components of the line */
     private List<LineComponent> components;
 
+    private double lineHeight = Double.NaN;
+
     LineInfo() {
         components = new ArrayList<>();
     }
@@ -124,7 +126,7 @@ class LineInfo {
             // the logical bounds include the spaces, we want them in the horizontal direction
             // in order to compose the element in the row, but we need the visual bounds for
             // vertical alignment
-            Rectangle2D verticalBounds = lineComponent.getGlyphVector().getVisualBounds();
+            Rectangle2D verticalBounds = lineComponent.getVisualBounds();
             Rectangle2D horizontalBounds = lineComponent.getGlyphVector().getLogicalBounds();
             // However... for empty text (used to place symbols along a line with conflict res.)
             // we have to use the logical bounds even for the vertical direction, as the visual
@@ -183,15 +185,13 @@ class LineInfo {
     }
 
     double getLineHeight() {
+        if (!Double.isNaN(lineHeight)) return lineHeight;
         double height = Float.NEGATIVE_INFINITY;
         for (LineComponent component : components) {
-            double ch = component.getGlyphVector().getVisualBounds().getHeight();
-            if (ch > height) {
-                height = ch;
-            }
+            double ch = component.getVisualBounds().getHeight();
+            if (ch > height) height = ch;
         }
-
-        return height;
+        return lineHeight = height;
     }
 
     float getAscent() {

--- a/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
+++ b/modules/library/render/src/main/java/org/geotools/renderer/lite/RendererUtilities.java
@@ -697,7 +697,7 @@ public final class RendererUtilities {
 
         Coordinate c = new Coordinate();
         Point pp = gf.createPoint(c);
-        c.y = centroid.getY();
+        c.y = centroid.getCoordinateSequence().getY(0);
         int max = -1;
         int maxIdx = -1;
         int containCounter = -1;

--- a/modules/library/render/src/test/java/org/geotools/renderer/label/LabelIndexTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/label/LabelIndexTest.java
@@ -1,0 +1,82 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.label;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+import java.util.Arrays;
+import org.junit.Test;
+
+public class LabelIndexTest {
+
+    private LabelIndex index() {
+        return new LabelIndex(new Rectangle(0, 0, 256, 256), 256);
+    }
+
+    @Test
+    public void testEmptyHasNoConflict() {
+        assertFalse(index().labelsWithinDistance(new Rectangle2D.Double(10, 10, 5, 5), 0));
+    }
+
+    @Test
+    public void testDetectsOverlap() {
+        LabelIndex index = index();
+        index.addLabel(null, new Rectangle2D.Double(10, 10, 20, 20));
+        assertTrue(index.labelsWithinDistance(new Rectangle2D.Double(15, 15, 5, 5), 0));
+    }
+
+    @Test
+    public void testNoConflictWhenDisjoint() {
+        LabelIndex index = index();
+        index.addLabel(null, new Rectangle2D.Double(10, 10, 20, 20));
+        assertFalse(index.labelsWithinDistance(new Rectangle2D.Double(100, 100, 5, 5), 0));
+    }
+
+    @Test
+    public void testDistanceExpandsTheQuery() {
+        LabelIndex index = index();
+        index.addLabel(null, new Rectangle2D.Double(10, 10, 10, 10)); // covers up to (20, 20)
+        Rectangle2D candidate = new Rectangle2D.Double(30, 30, 5, 5); // 10px gap from the stored label
+        assertFalse(index.labelsWithinDistance(candidate, 5));
+        assertTrue(index.labelsWithinDistance(candidate, 15));
+    }
+
+    @Test
+    public void testNegativeDistanceNeverConflicts() {
+        LabelIndex index = index();
+        index.addLabel(null, new Rectangle2D.Double(10, 10, 20, 20));
+        assertFalse(index.labelsWithinDistance(new Rectangle2D.Double(15, 15, 5, 5), -1));
+    }
+
+    @Test
+    public void testReservedAreaConflicts() {
+        LabelIndex index = index();
+        index.reserveArea(Arrays.asList(new Rectangle2D.Double(50, 50, 30, 30)));
+        assertTrue(index.labelsWithinDistance(new Rectangle2D.Double(60, 60, 5, 5), 0));
+    }
+
+    @Test
+    public void testLabelOutsideDisplayAreaStillDetected() {
+        // labels placed outside the display area (beyond the margin too) must still be found
+        LabelIndex index = index();
+        index.addLabel(null, new Rectangle2D.Double(-2000, -2000, 20, 20));
+        assertTrue(index.labelsWithinDistance(new Rectangle2D.Double(-1995, -1995, 5, 5), 0));
+    }
+}

--- a/modules/library/render/src/test/java/org/geotools/renderer/label/LabelQuadtreeTest.java
+++ b/modules/library/render/src/test/java/org/geotools/renderer/label/LabelQuadtreeTest.java
@@ -1,0 +1,122 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2025, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.label;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
+
+public class LabelQuadtreeTest {
+
+    private LabelQuadtree tree() {
+        return new LabelQuadtree(0, 0, 1000, 1000);
+    }
+
+    @Test
+    public void testEmptyReturnsNull() {
+        assertNull(tree().findFirst(new Envelope(10, 20, 10, 20)));
+    }
+
+    @Test
+    public void testFindsIntersectingItem() {
+        LabelQuadtree tree = tree();
+        Envelope e = new Envelope(100, 200, 100, 200);
+        tree.insert(e);
+        assertSame(e, tree.findFirst(new Envelope(150, 160, 150, 160)));
+    }
+
+    @Test
+    public void testDisjointReturnsNull() {
+        LabelQuadtree tree = tree();
+        tree.insert(new Envelope(100, 200, 100, 200));
+        assertNull(tree.findFirst(new Envelope(500, 600, 500, 600)));
+    }
+
+    @Test
+    public void testTouchingCountsAsHit() {
+        // Envelope.intersects is inclusive on the shared edge
+        LabelQuadtree tree = tree();
+        Envelope e = new Envelope(100, 200, 100, 200);
+        tree.insert(e);
+        assertSame(e, tree.findFirst(new Envelope(200, 300, 100, 200)));
+    }
+
+    @Test
+    public void testItemOutsideTreeBoundsStillFound() {
+        // items outside the tree bounds accumulate at the root and must remain queryable
+        LabelQuadtree tree = tree();
+        Envelope e = new Envelope(-500, -400, -500, -400);
+        tree.insert(e);
+        assertSame(e, tree.findFirst(new Envelope(-450, -440, -450, -440)));
+    }
+
+    @Test
+    public void testItemOutsideTreeBoundsStillFoundAfterSplit() {
+        // regression: an out-of-bounds item inserted after a split must not be pushed into a child
+        // quadrant that findFirst then prunes away. Force a split in the SW quadrant first.
+        LabelQuadtree tree = tree();
+        for (int i = 0; i < 20; i++) {
+            double x = 10 + i;
+            tree.insert(new Envelope(x, x + 0.4, 10, 10.4));
+        }
+        Envelope oob = new Envelope(-500, -400, -500, -400);
+        tree.insert(oob);
+        assertSame(oob, tree.findFirst(new Envelope(-450, -440, -450, -440)));
+    }
+
+    @Test
+    public void testItemSpanningQuadrantBoundaryFoundFromEitherSide() {
+        // straddles the root mid-lines (500,500): stays at the node, still found on both sides
+        LabelQuadtree tree = tree();
+        Envelope e = new Envelope(400, 600, 400, 600);
+        tree.insert(e);
+        assertSame(e, tree.findFirst(new Envelope(450, 460, 450, 460)));
+        assertSame(e, tree.findFirst(new Envelope(550, 560, 550, 560)));
+    }
+
+    @Test
+    public void testSplitPreservesAllItems() {
+        // exceed the split threshold inside one quadrant to force a split; every item still found
+        LabelQuadtree tree = tree();
+        Envelope[] items = new Envelope[40];
+        for (int i = 0; i < items.length; i++) {
+            double x = 10 + i; // small boxes packed in the SW quadrant
+            items[i] = new Envelope(x, x + 0.4, 10, 10.4);
+            tree.insert(items[i]);
+        }
+        for (Envelope item : items) {
+            Envelope hit = tree.findFirst(item);
+            assertNotNull(hit);
+            assertTrue(item.intersects(hit));
+        }
+    }
+
+    @Test
+    public void testFindFirstReturnsAnIntersectingItemWhenManyOverlap() {
+        LabelQuadtree tree = tree();
+        for (int i = 0; i < 30; i++) {
+            tree.insert(new Envelope(100, 300, 100, 300));
+        }
+        Envelope hit = tree.findFirst(new Envelope(150, 160, 150, 160));
+        assertNotNull(hit);
+        assertTrue(hit.intersects(new Envelope(150, 160, 150, 160)));
+    }
+}


### PR DESCRIPTION
See:
https://osgeo-org.atlassian.net/browse/GEOT-7925
https://osgeo-org.atlassian.net/browse/GEOT-7926

This is part of a 3-part series of improvements that I'm making to speed up rendering of complex vector basemaps, which overall provides a 20% speedup. I'm done with the R&D portion and now cleaning up and packaging the changes in an easier to review fashion. This PR contains the changes related to labelling.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [x] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->