### PR TITLE
[GEOT-7928] PMTiles datastore breaks with filters/functions that need Feature/SimpleFeature implementations

### DIFF
--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
@@ -54,6 +54,7 @@ import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.FeatureTypeFactory;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Function;
 import org.geotools.api.filter.sort.SortBy;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -64,6 +65,7 @@ import org.geotools.data.store.ContentFeatureSource;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.filter.spatial.DefaultCRSFilterVisitor;
 import org.geotools.filter.spatial.ReprojectingFilterVisitor;
+import org.geotools.filter.visitor.DefaultFilterVisitor;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.filter.visitor.SpatialFilterVisitor;
 import org.geotools.geometry.jts.GeometryCoordinateSequenceTransformer;
@@ -124,6 +126,22 @@ import org.locationtech.jts.geom.util.AffineTransformation;
 public class VectorTilesFeatureSource extends ContentFeatureSource {
 
     private static final Logger LOGGER = Logging.getLogger(VectorTilesFeatureSource.class);
+
+    /** Detects presence of a function call in a filter */
+    private static class FunctionDetector extends DefaultFilterVisitor {
+
+        boolean foundFunction = false;
+
+        @Override
+        public Object visit(Function expression, Object data) {
+            foundFunction = true;
+            return data;
+        }
+
+        public boolean foundFunction() {
+            return foundFunction;
+        }
+    }
 
     /** TileJSON layer metadata */
     protected final VectorLayer layerMetadata;
@@ -480,7 +498,23 @@ public class VectorTilesFeatureSource extends ContentFeatureSource {
      */
     private Predicate<Feature> preFilter(Query query) {
         Filter filter = query.getFilter();
+        if (Filter.INCLUDE.equals(filter)) {
+            return f -> true;
+        }
+        // Functions like geometry() instanceof/cast to Feature/SimpleFeature and return null against a plain
+        // MvtFeature, silently dropping every feature. When the filter uses a function, evaluate it against a
+        // temporary SimpleFeature view; otherwise the property accessor handles PropertyName access directly.
+        if (containsFunction(filter)) {
+            SimpleFeatureType schema = getSchema();
+            return mvtFeature -> filter.evaluate(new VectorTilesSimpleFeature(schema, mvtFeature));
+        }
         return filter::evaluate;
+    }
+
+    private static boolean containsFunction(Filter filter) {
+        FunctionDetector detector = new FunctionDetector();
+        filter.accept(detector, null);
+        return detector.foundFunction();
     }
 
     private Filter postFilter(Query query) {

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreTest.java
@@ -46,6 +46,8 @@ import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.feature.type.GeometryDescriptor;
 import org.geotools.api.feature.type.Name;
 import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.expression.Function;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -204,5 +206,26 @@ public class PMTilesDataStoreTest {
                 assertThat(defaultGeometry, instanceOf(Geometry.class));
             }
         }
+    }
+
+    /**
+     * A filter using a function that casts to Feature (here dimension(geometry())) must be evaluated against a
+     * SimpleFeature view of each vector tile feature, not the raw MvtFeature, which would return null and drop
+     * everything. The buildings layer is all polygons, so the polygon predicate keeps them all and the line predicate
+     * keeps none.
+     */
+    @Test
+    public void getFeaturesWithGeometryFunctionFilter() throws IOException {
+        FilterFactory ff = store.getFilterFactory();
+        SimpleFeatureSource buildings = store.getFeatureSource("buildings");
+        int total = buildings.getFeatures().size();
+        assertThat(total, greaterThan(0));
+
+        Function dimension = ff.function("dimension", ff.function("geometry"));
+        assertEquals(
+                total,
+                buildings.getFeatures(ff.equals(dimension, ff.literal(2))).size());
+        assertEquals(
+                0, buildings.getFeatures(ff.equals(dimension, ff.literal(1))).size());
     }
 }


### PR DESCRIPTION
[![GEOT-7928](https://badgen.net/badge/JIRA/GEOT-7928/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7928) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

See ticket for a detailed description. @groldan can you have a look?

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 