### PR TITLE
[GEOT-7930] PMTiles reads a zoom level too deep compared to on screen display

### DIFF
--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStoreFactory.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStoreFactory.java
@@ -46,6 +46,7 @@ import org.geotools.tileverse.rangereader.ParamBuilder;
 import org.geotools.tileverse.rangereader.RangeReaderParams;
 import org.geotools.util.Converters;
 import org.geotools.util.logging.Logging;
+import org.geotools.vectortiles.store.VectorTilesDataStore;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 
@@ -72,6 +73,8 @@ import org.jspecify.annotations.NullMarked;
  * <ul>
  *   <li>{@linkplain #URIP pmtiles} - PMTiles archive URI (required)
  *   <li>{@linkplain #NAMESPACEP namespace} - Feature type namespace (optional)
+ *   <li>{@linkplain #DISPLAY_TILE_SIZE displayTileSize} - Display tile size in pixels rendering clients use, defaults
+ *       to {@value VectorTilesDataStore#DEFAULT_DISPLAY_TILE_SIZE}
  *   <li>{@linkplain #RANGEREADER_PROVIDER_ID io.tileverse.rangereader.provider} - Optionally force a specific
  *       {@code RangeReaderProvider} by its {@link RangeReaderProvider#getId() id}, defaults to automatic detection by
  *       {@link RangeReaderFactory#findBestProvider(io.tileverse.rangereader.spi.RangeReaderConfig)}
@@ -156,6 +159,22 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
             .title("Namespace prefix")
             .type(String.class)
             .optional()
+            .advancedLevel()
+            .build();
+
+    /**
+     * Display tile size (in pixels) the archive's rendering clients are assumed to use, overriding
+     * {@link VectorTilesDataStore#DEFAULT_DISPLAY_TILE_SIZE}.
+     */
+    public static final Param DISPLAY_TILE_SIZE = ParamBuilder.builder()
+            .key("displayTileSize")
+            .title("Display tile size")
+            .description("Tile size in pixels rendering clients of this archive are assumed to use when picking a "
+                    + "zoom level. Protomaps and the MapLibre/Mapbox GL family target 512px; override only if the "
+                    + "archive's clients use a different convention.")
+            .type(Integer.class)
+            .optional()
+            .defaultValue(VectorTilesDataStore.DEFAULT_DISPLAY_TILE_SIZE)
             .advancedLevel()
             .build();
 
@@ -309,7 +328,7 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
                 .toList();
 
         Predicate<Param> filter = p -> !ignore.contains(p.key);
-        return RangeReaderParams.appendAfter(filter, NAMESPACEP, URIP);
+        return RangeReaderParams.appendAfter(filter, NAMESPACEP, URIP, DISPLAY_TILE_SIZE);
     }
 
     @Override
@@ -347,6 +366,9 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
 
         String namespaceURI = lookup(NAMESPACEP, params, String.class);
         store.setNamespaceURI(namespaceURI);
+
+        Integer displayTileSize = lookup(DISPLAY_TILE_SIZE, params, Integer.class);
+        store.setDisplayTileSize(displayTileSize);
 
         return store;
     }

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesDataStore.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesDataStore.java
@@ -75,7 +75,12 @@ public abstract class VectorTilesDataStore extends ContentDataStore {
     public static final GeometryFactory DEFAULT_GEOMETRY_FACTORY =
             new GeometryFactory(new PackedCoordinateSequenceFactory());
 
+    /** Default value for {@link #setDisplayTileSize(int)}, matching the Protomaps/MapLibre/Mapbox GL convention. */
+    public static final int DEFAULT_DISPLAY_TILE_SIZE = 512;
+
     private VectorTileStore tileStore;
+
+    private int displayTileSize = DEFAULT_DISPLAY_TILE_SIZE;
 
     /**
      * Creates a new vector tiles datastore.
@@ -102,6 +107,28 @@ public abstract class VectorTilesDataStore extends ContentDataStore {
      */
     public VectorTileStore getTileStore() {
         return this.tileStore;
+    }
+
+    /**
+     * Returns the tile size (in pixels) that a rendering client is assumed to display each tile at when picking a zoom
+     * level for a given screen resolution.
+     *
+     * @see #setDisplayTileSize(int)
+     */
+    public int getDisplayTileSize() {
+        return displayTileSize;
+    }
+
+    /**
+     * Sets the tile size (in pixels) rendering clients of this dataset are assumed to display each tile at.
+     *
+     * <p>Protomaps and the MapLibre/Mapbox GL family target 512px, regardless of the tile matrix's own pixel width
+     * (typically 256). This can't be derived from the tile data, so it must be configured per dataset.
+     *
+     * @param displayTileSize the display tile size in pixels, defaults to {@value #DEFAULT_DISPLAY_TILE_SIZE}
+     */
+    public void setDisplayTileSize(int displayTileSize) {
+        this.displayTileSize = displayTileSize;
     }
 
     /**

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
@@ -125,6 +125,14 @@ public class VectorTilesFeatureSource extends ContentFeatureSource {
 
     private static final Logger LOGGER = Logging.getLogger(VectorTilesFeatureSource.class);
 
+    /**
+     * Display tile size vector tiles are authored against (Mapbox/MapLibre/protomaps use 512px, which is universal for
+     * vector tiles); overridable via the {@code org.geotools.vectortiles.displayTileSize} system property for the rare
+     * data authored for a different target.
+     */
+    private static final int VECTOR_TILE_DISPLAY_SIZE =
+            Integer.getInteger("org.geotools.vectortiles.displayTileSize", 512);
+
     /** TileJSON layer metadata */
     protected final VectorLayer layerMetadata;
 
@@ -617,8 +625,13 @@ public class VectorTilesFeatureSource extends ContentFeatureSource {
         final int matrixsetMinZoom = matrixSet.minZoomLevel();
         final int matrixsetMaxZoom = matrixSet.maxZoomLevel();
 
+        // Vector tiles are authored for 512px display (Mapbox/MapLibre/protomaps convention), but the pyramid
+        // resolutions are for 256px tiles; scale by 512/tileWidth so the picked zoom matches the resolution the
+        // tiles were authored for, instead of one level too deep (finer detail than the screen resolution warrants).
+        final double displayResolution = simplificationDistance * VECTOR_TILE_DISPLAY_SIZE / matrixSet.tileWidth();
+
         final int bestZoom =
-                tileStore.findBestZoomLevel(simplificationDistance, strategy, matrixsetMinZoom, matrixsetMaxZoom);
+                tileStore.findBestZoomLevel(displayResolution, strategy, matrixsetMinZoom, matrixsetMaxZoom);
 
         final boolean layerIsVisible = layerIsVisibleAtZoomLevel(bestZoom);
 

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
@@ -125,14 +125,6 @@ public class VectorTilesFeatureSource extends ContentFeatureSource {
 
     private static final Logger LOGGER = Logging.getLogger(VectorTilesFeatureSource.class);
 
-    /**
-     * Display tile size vector tiles are authored against (Mapbox/MapLibre/protomaps use 512px, which is universal for
-     * vector tiles); overridable via the {@code org.geotools.vectortiles.displayTileSize} system property for the rare
-     * data authored for a different target.
-     */
-    private static final int VECTOR_TILE_DISPLAY_SIZE =
-            Integer.getInteger("org.geotools.vectortiles.displayTileSize", 512);
-
     /** TileJSON layer metadata */
     protected final VectorLayer layerMetadata;
 
@@ -625,10 +617,12 @@ public class VectorTilesFeatureSource extends ContentFeatureSource {
         final int matrixsetMinZoom = matrixSet.minZoomLevel();
         final int matrixsetMaxZoom = matrixSet.maxZoomLevel();
 
-        // Vector tiles are authored for 512px display (Mapbox/MapLibre/protomaps convention), but the pyramid
-        // resolutions are for 256px tiles; scale by 512/tileWidth so the picked zoom matches the resolution the
-        // tiles were authored for, instead of one level too deep (finer detail than the screen resolution warrants).
-        final double displayResolution = simplificationDistance * VECTOR_TILE_DISPLAY_SIZE / matrixSet.tileWidth();
+        // Protomaps and the MapLibre/Mapbox GL family target a 512px display size, regardless of the matrix's own
+        // pixel width (256, per the WebMercatorQuad definition), so for a given screen resolution they request one
+        // zoom level shallower than a 256px-based reader would. Scale by displayTileSize/tileWidth to match that
+        // convention, instead of reading one level too deep.
+        final int displayTileSize = getDataStore().getDisplayTileSize();
+        final double displayResolution = simplificationDistance * displayTileSize / matrixSet.tileWidth();
 
         final int bestZoom =
                 tileStore.findBestZoomLevel(displayResolution, strategy, matrixsetMinZoom, matrixsetMaxZoom);

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/vectortiles/store/VectorTilesFeatureSourceTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/vectortiles/store/VectorTilesFeatureSourceTest.java
@@ -36,7 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-public class VectorTilesZoomSelectionTest {
+public class VectorTilesFeatureSourceTest {
 
     @Rule
     public TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -60,8 +60,9 @@ public class VectorTilesZoomSelectionTest {
     }
 
     /**
-     * The 256px WebMercatorQuad pyramid must be read as 512px display tiles (Mapbox/MapLibre/protomaps convention), so
-     * a screen resolution that matches matrix level z resolves to z-1, not z.
+     * The 256px WebMercatorQuad pyramid must be read as {@link VectorTilesDataStore#DEFAULT_DISPLAY_TILE_SIZE 512px}
+     * display tiles, matching the MapLibre/Mapbox GL vector source convention, so a screen resolution that matches
+     * matrix level z resolves to z-1, not z.
      */
     @Test
     public void testDisplaySizeShiftsZoomOneLevelShallower() throws IOException {
@@ -78,9 +79,25 @@ public class VectorTilesZoomSelectionTest {
         assertEquals(rawZoom, rawMatch);
 
         // reading tiles as 512px display shifts the pick one level shallower; the generalization-distance path
-        // takes the screen resolution directly, so the test pins only the 512/tileWidth shift under test
+        // takes the screen resolution directly, so the test pins only the displayTileSize/tileWidth shift under test
         Query query = new Query("boundaries");
         query.setHints(new Hints(Hints.GEOMETRY_GENERALIZATION, resolution));
         assertEquals(OptionalInt.of(rawZoom - 1), fs.determineZoomLevel(query));
+    }
+
+    @Test
+    public void testDisplayTileSizeIsConfigurablePerStore() throws IOException {
+        store.setDisplayTileSize(256);
+
+        VectorTilesFeatureSource fs = (VectorTilesFeatureSource) store.getFeatureSource("boundaries");
+        TileMatrixSet ms = fs.getMatrixSet();
+
+        int rawZoom = 13;
+        double resolution = ms.resolution(rawZoom);
+
+        // displayTileSize == tileWidth (256 == 256), no shift
+        Query query = new Query("boundaries");
+        query.setHints(new Hints(Hints.GEOMETRY_GENERALIZATION, resolution));
+        assertEquals(OptionalInt.of(rawZoom), fs.determineZoomLevel(query));
     }
 }

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/vectortiles/store/VectorTilesZoomSelectionTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/vectortiles/store/VectorTilesZoomSelectionTest.java
@@ -1,0 +1,86 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.vectortiles.store;
+
+import static io.tileverse.tiling.store.TileStore.Strategy.SPEED;
+import static org.junit.Assert.assertEquals;
+
+import io.tileverse.pmtiles.PMTilesReader;
+import io.tileverse.pmtiles.PMTilesTestData;
+import io.tileverse.tiling.matrix.TileMatrixSet;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.OptionalInt;
+import org.geotools.api.data.Query;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.pmtiles.store.PMTilesDataStore;
+import org.geotools.pmtiles.store.PMTilesDataStoreFactory;
+import org.geotools.util.factory.Hints;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class VectorTilesZoomSelectionTest {
+
+    @Rule
+    public TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private PMTilesReader reader;
+    private PMTilesDataStore store;
+
+    @Before
+    public void setUp() throws IOException {
+        Path andorra = PMTilesTestData.andorra(tmpFolder.getRoot().toPath());
+        reader = new PMTilesReader(andorra);
+        store = new PMTilesDataStore(new PMTilesDataStoreFactory(), reader);
+        store.setNamespaceURI("http://test");
+        store.setFeatureTypeFactory(CommonFactoryFinder.getFeatureTypeFactory(null));
+        store.setFeatureFactory(CommonFactoryFinder.getFeatureFactory(null));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (reader != null) reader.close();
+    }
+
+    /**
+     * The 256px WebMercatorQuad pyramid must be read as 512px display tiles (Mapbox/MapLibre/protomaps convention), so
+     * a screen resolution that matches matrix level z resolves to z-1, not z.
+     */
+    @Test
+    public void testDisplaySizeShiftsZoomOneLevelShallower() throws IOException {
+        // boundaries spans the whole pyramid, so it is visible at the shifted zoom (deterministic assertion)
+        VectorTilesFeatureSource fs = (VectorTilesFeatureSource) store.getFeatureSource("boundaries");
+        TileMatrixSet ms = fs.getMatrixSet();
+        assertEquals("andorra pyramid is 256px", 256, ms.tileWidth());
+
+        int rawZoom = 13;
+        double resolution = ms.resolution(rawZoom);
+
+        // the raw resolution matches rawZoom exactly against the 256px matrix
+        int rawMatch = fs.getTileStore().findBestZoomLevel(resolution, SPEED, ms.minZoomLevel(), ms.maxZoomLevel());
+        assertEquals(rawZoom, rawMatch);
+
+        // reading tiles as 512px display shifts the pick one level shallower; the generalization-distance path
+        // takes the screen resolution directly, so the test pins only the 512/tileWidth shift under test
+        Query query = new Query("boundaries");
+        query.setHints(new Hints(Hints.GEOMETRY_GENERALIZATION, resolution));
+        assertEquals(OptionalInt.of(rawZoom - 1), fs.determineZoomLevel(query));
+    }
+}


### PR DESCRIPTION
[![GEOT-7930](https://badgen.net/badge/JIRA/GEOT-7930/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7930) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

@groldan another one to get protomaps to render so that it matches the in-browser version (that, and some 20-ish other fixes in mbstyles, for now I'm collecting the issues, the actual fixes will follow).

Btw, this one will definitely conflict with https://github.com/geotools/geotools/pull/5741, once either is merged I'll amend the other to match.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 