### PR TITLE
Fix random test failure due to bad execution timing

### DIFF
--- a/modules/library/main/src/test/java/org/geotools/filter/function/ParseTimeFunctionTest.java
+++ b/modules/library/main/src/test/java/org/geotools/filter/function/ParseTimeFunctionTest.java
@@ -73,17 +73,16 @@ public class ParseTimeFunctionTest {
     private static void assertionForParsedInstance(String expression, TemporalAmount timeInThePast) {
         Function parseTime = FF.function("parseTime", FF.literal(expression));
 
-        Instant generatedDate = Instant.now().minus(timeInThePast);
+        Instant generatedDate = Instant.now().minus(timeInThePast).truncatedTo(ChronoUnit.SECONDS);
         Date date = (Date) parseTime.evaluate(null);
         Instant evaluatedTime = date.toInstant().truncatedTo(ChronoUnit.SECONDS);
 
-        // round to nearest second (add 0.5 second and truncate)
-        Instant generatedDateRounded =
-                generatedDate.plus(500, ChronoUnit.MICROS).truncatedTo(ChronoUnit.SECONDS);
-        Instant evaluatedTimeRounded =
-                evaluatedTime.plus(500, ChronoUnit.MICROS).truncatedTo(ChronoUnit.SECONDS);
-
-        assertEquals(timeInThePast.toString(), generatedDateRounded, evaluatedTimeRounded);
+        // two separate clock reads (here and inside the function) can land on either side
+        // of a second boundary, so allow up to 1 second of drift instead of requiring exact equality
+        long diffSeconds =
+                Math.abs(Duration.between(generatedDate, evaluatedTime).getSeconds());
+        assertTrue(
+                timeInThePast + " expected close to " + generatedDate + " but was " + evaluatedTime, diffSeconds <= 1);
     }
 
     private static void assertionForParseLocalDateTIme(


### PR DESCRIPTION
The test randomly fails when it's so "lucky" as to land the two Instant calculations across the boundaries of a second. I did not open a Jira as this change does not affect users: it's not release notes worthy.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->