### PR TITLE
Hopefully fix Windows random cql build failure

### DIFF
--- a/build/maven/jjtree-javacc/src/main/java/org/geotools/maven/JJTreeJavaCC.java
+++ b/build/maven/jjtree-javacc/src/main/java/org/geotools/maven/JJTreeJavaCC.java
@@ -38,6 +38,8 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -174,7 +176,7 @@ public class JJTreeJavaCC extends AbstractMojo {
         for (Object userNode : userNodes) {
             final File nodeFile = (File) userNode;
             try {
-                FileUtils.copyFileToDirectory(nodeFile, outputPackageDirectory);
+                copyToDirectory(nodeFile, outputPackageDirectory);
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed to copy Node.java files for JJTree.", e);
             }
@@ -194,7 +196,7 @@ public class JJTreeJavaCC extends AbstractMojo {
                 throw new MojoFailureException("JJTree failed with error code " + status + '.');
             }
             try {
-                FileUtils.copyFileToDirectory(sourceFile, new File(timestampDirectory));
+                copyToDirectory(sourceFile, new File(timestampDirectory));
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed to copy processed .jjt file.", e);
             }
@@ -223,7 +225,7 @@ public class JJTreeJavaCC extends AbstractMojo {
                 throw new MojoFailureException("JavaCC failed with error code " + status + '.');
             }
             try {
-                FileUtils.copyFileToDirectory(sourceFile, new File(timestampDirectory));
+                copyToDirectory(sourceFile, new File(timestampDirectory));
             } catch (IOException e) {
                 throw new MojoExecutionException("Failed to copy processed .jj file.", e);
             }
@@ -258,6 +260,55 @@ public class JJTreeJavaCC extends AbstractMojo {
     }
 
     /**
+     * Copies a file into a directory, overwriting any existing target. Uses {@link Files#copy} rather than plexus
+     * {@code FileUtils}, whose memory-mapped copy leaves the target locked on Windows until the mapping is
+     * garbage-collected. The copy is retried because Windows may still hold a short-lived handle on the freshly written
+     * source (antivirus/indexer scan), which surfaces as a transient "file used by another process" error.
+     */
+    private static void copyToDirectory(final File source, final File targetDirectory) throws IOException {
+        Files.createDirectories(targetDirectory.toPath());
+        final File target = new File(targetDirectory, source.getName());
+        withRetry(() -> Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING));
+    }
+
+    /** An IO operation with no result, retried by {@link #withRetry}. */
+    private interface IOAction {
+        void run() throws IOException;
+    }
+
+    /**
+     * Runs an IO action, retrying on {@link IOException} to ride out transient Windows file locks. The main offender is
+     * javacc's {@code OutputFile} constructor, which opens a reader on an already-generated shared file
+     * (JavaCharStream, TokenMgrError, ...) to checksum it and never closes it; with two grammars writing the same
+     * package, that leaked handle keeps the file locked on Windows until its {@link java.lang.ref.Cleaner} runs. Each
+     * failed attempt forces a GC to release such handles, then waits with a growing back-off and rethrows the last
+     * failure if all fail.
+     */
+    private static void withRetry(final IOAction action) throws IOException {
+        final int maxAttempts = 5;
+        for (int attempt = 1; ; attempt++) {
+            try {
+                action.run();
+                return;
+            } catch (IOException e) {
+                if (attempt == maxAttempts) {
+                    throw e;
+                }
+                // javacc leaks the reader (OutputFile ctor / checkVersion, both unfixed on master as of 7.0.13,
+                // https://github.com/javacc/javacc/blob/master/src/main/java/org/javacc/parser/OutputFile.java#L105
+                // and L173); only a GC closes it via its Cleaner. Drop this once javacc closes those readers.
+                System.gc();
+                try {
+                    Thread.sleep(50L * attempt);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw e;
+                }
+            }
+        }
+    }
+
+    /**
      * Adds @SuppressWarnings("unchecked") annotation to generated parser classes to suppress Java 17 warnings about raw
      * type usage in generated code.
      *
@@ -281,8 +332,12 @@ public class JJTreeJavaCC extends AbstractMojo {
                 writer.newLine();
             }
         }
-        sourceFile.delete();
-        fixedFile.renameTo(sourceFile);
+        replaceFile(fixedFile, sourceFile);
+    }
+
+    /** Replaces {@code target} with {@code source}, retrying to ride out transient Windows file locks. */
+    private static void replaceFile(final File source, final File target) throws IOException {
+        withRetry(() -> Files.move(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING));
     }
 
     /**
@@ -306,8 +361,7 @@ public class JJTreeJavaCC extends AbstractMojo {
                 writer.newLine();
             }
         }
-        sourceFile.delete();
-        fixedFile.renameTo(sourceFile);
+        replaceFile(fixedFile, sourceFile);
     }
 
     /**


### PR DESCRIPTION
The error that I'm trying to fix is this one:

```
Error: 1,375 [ERROR] Failed to execute goal org.geotools.maven:jjtree-javacc:35-SNAPSHOT:generate (default) on project gt-cql: Failed to copy Node.java files for JJTree. D:\a\geotools\geotools\modules\library\cql\target\generated-sources\jjtree-javacc\org\geotools\filter\text\generated\parsers\Node.java: The process cannot access the file because it is being used by another process -> [Help 1]
Error: 1,375 [ERROR] 
Error: 1,375 [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
Error: 1,375 [ERROR] Re-run Maven using the -X switch to enable full debug logging.
Error: 1,375 [ERROR] 
Error: 1,375 [ERROR] For more information about the errors and possible solutions, please read the following articles:
Error: 1,375 [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: 1,375 [ERROR] 
Error: 1,375 [ERROR] After correcting the problems, you can resume the build with the command
Error: 1,375 [ERROR]   mvn <args> -rf :gt-cql
Error: Process completed with exit code 1.
```

It's likely due to the copy function being used, internally using memory mapped buffers, which end up keeping locks until they are garbage collected (as they cannot be freed with public API).

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [ ] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->