### PR TITLE
[34.x backport] [GEOT-7932] Allow caching small images used by ImageMosaic in memory

### DIFF
--- a/docs/user/library/coverage/mosaic.rst
+++ b/docs/user/library/coverage/mosaic.rst
@@ -111,6 +111,31 @@ An example data set looks something like::
     
   * ``NumFiles``: should be the same as the number of features in your shapefile
 
+Granule image cache
+^^^^^^^^^^^^^^^^^^^
+
+Mosaics made of many small granules (small tiles, or zoomed-out views that compose thousands of tiny
+overviews when no pyramid was built) re-read and re-decode the same granules from disk on every
+request. An optional cache can keep the decoded granule images in memory and serve later reads of the
+same granule from there, skipping the disk I/O and decode. All later processing (band select, rescale,
+affine, ROI) still runs after the cache, so the output is identical to an uncached read.
+
+The cache is a shared pool that is created and owned outside the reader and injected through the
+``Hints.GRANULE_IMAGE_CACHE`` hint (an ``org.geotools.gce.imagemosaic.GranuleImageCache`` instance),
+much like the multithreaded-read ``ExecutorService`` is injected through ``Hints.EXECUTOR_SERVICE``.
+The pool is bounded by total decoded bytes and evicts least-recently-used entries; a single pool can be
+shared by many readers. Entries are keyed by owning mosaic plus granule URL, image index and bands, so
+disposing a reader drops all of that mosaic's entries at once (via ``invalidateMosaic``).
+A single stale granule (an in-place overwrite, a re-harvest, a delete) is dropped with
+``GranuleImageCache.invalidateGranule``, while ``invalidateAll`` clears the whole pool.
+
+Caching is off unless enabled per read, through two read parameters:
+
+* ``CacheGranules`` (Boolean, default ``false``): enables reuse and population of the injected cache.
+* ``CacheGranulesThresholdKB`` (Integer, default ``-1``): overrides the pool's default per-granule
+  eligibility threshold for this read; a granule whose full decoded raster is larger than the threshold
+  is read normally and not cached. ``-1`` keeps the pool default.
+
 **Reference**
 
 * `ImageMosaicFormat <https://docs.geotools.org/latest/javadocs/org/geotools/gce/imagemosaic/ImageMosaicFormat.html>`_ (javadoc)

--- a/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
+++ b/modules/library/metadata/src/main/java/org/geotools/util/factory/Hints.java
@@ -679,6 +679,13 @@ public class Hints extends RenderingHints {
      */
     public static final ClassKey EXECUTOR_SERVICE = new ClassKey("java.util.concurrent.ExecutorService");
 
+    /**
+     * The shared image-mosaic granule image cache to use, an {@code org.geotools.gce.imagemosaic.GranuleImageCache}.
+     *
+     * @since 36.0
+     */
+    public static final ClassKey GRANULE_IMAGE_CACHE = new ClassKey("org.geotools.gce.imagemosaic.GranuleImageCache");
+
     /** Default resample tolerance value, if not specified via the {@link #RESAMPLE_TOLERANCE} hint */
     public static double DEFAULT_RESAMPLE_TOLERANCE = 0.333;
 

--- a/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
+++ b/modules/plugin/coverage-multidim/netcdf/src/test/java/org/geotools/coverage/io/netcdf/NetCDFMosaicReaderTest.java
@@ -98,6 +98,8 @@ import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.NameImpl;
+import org.geotools.gce.imagemosaic.GranuleImageCache;
+import org.geotools.gce.imagemosaic.GuavaGranuleImageCache;
 import org.geotools.gce.imagemosaic.ImageMosaicFormat;
 import org.geotools.gce.imagemosaic.ImageMosaicReader;
 import org.geotools.gce.imagemosaic.Utils;
@@ -310,6 +312,47 @@ public class NetCDFMosaicReaderTest {
             float[] v1 = (float[]) coverage1.evaluate(center);
             float[] v2 = (float[]) coverage2.evaluate(center);
             assertNotEquals(v1[0], v2[0], 0f);
+        } finally {
+            reader.dispose();
+        }
+    }
+
+    @Test
+    public void testCachedTimeSlicesDoNotCollide() throws Exception {
+        // polyphemus holds two time slices in a single file: same location, imageindex 0 and 1. With the granule
+        // image cache enabled, reading one slice must not serve its pixels for the other, i.e. the two slices must
+        // produce distinct cache keys even though they share a URL.
+        File nc1 = TestData.file(this, "polyphemus_20130301_test.nc");
+        File mosaic = tempFolder.newFolder("nc_cache_slices");
+        FileUtils.copyFileToDirectory(nc1, mosaic);
+
+        String indexer = "TimeAttribute=time\n"
+                + "Schema=the_geom:Polygon,location:String,imageindex:Integer,time:java.util.Date\n";
+        FileUtils.writeStringToFile(new File(mosaic, "indexer.properties"), indexer, StandardCharsets.UTF_8);
+        File dsp = TestData.file(this, "datastore.properties");
+        FileUtils.copyFileToDirectory(dsp, mosaic);
+
+        // cache injected as a shared pool and turned on via the read parameter
+        GranuleImageCache cache = new GuavaGranuleImageCache(64L * 1024 * 1024, 10L * 1024 * 1024);
+        ImageMosaicFormat format = new ImageMosaicFormat();
+        ImageMosaicReader reader = format.getReader(mosaic, new Hints(Hints.GRANULE_IMAGE_CACHE, cache));
+        assertNotNull(reader);
+        try {
+            ParameterValue<Boolean> cacheGranules = ImageMosaicFormat.CACHE_GRANULES.createValue();
+            cacheGranules.setValue(true);
+            ParameterValue<List> time = ImageMosaicFormat.TIME.createValue();
+            time.setValue(Arrays.asList(parseTimeStamp("2013-03-01T00:00:00.000Z")));
+            GeneralParameterValue[] params = {NO_DEFERRED_LOADING_PARAM, cacheGranules, time};
+            GridCoverage2D coverage1 = reader.read(params); // populates the cache for slice 0
+            time.setValue(Arrays.asList(parseTimeStamp("2013-03-01T01:00:00.000Z")));
+            GridCoverage2D coverage2 = reader.read(params);
+
+            Position center = reader.getOriginalEnvelope().getMedian();
+            float[] v1 = (float[]) coverage1.evaluate(center);
+            float[] v2 = (float[]) coverage2.evaluate(center);
+            // a cache-key collision would make the second read return the first slice's cached pixels
+            assertNotEquals("Time slices must not share a cache entry", v1[0], v2[0], 0f);
+            assertTrue("both slices should be cached", cache.size() >= 2);
         } finally {
             reader.dispose();
         }

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleDescriptor.java
@@ -30,6 +30,7 @@ import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
 import java.awt.image.IndexColorModel;
 import java.awt.image.RenderedImage;
@@ -42,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.imageio.ImageIO;
@@ -1049,87 +1051,43 @@ public class GranuleDescriptor {
                 imageIndex = index;
                 readParameters = imageReadParameters;
             }
-            // Defining an Overview Index value
-            int ovrIndex = imageIndex;
+            // Overview index and (for external overviews) URL, resolved from metadata so a cache hit needs no open
             boolean isExternal = ovrProvider.isExternalOverview(imageIndex);
-            // Define a new URL to use (it may change if using external overviews)
-            URL granuleURLUpdated = granuleUrl;
-            // If the file is external we must update the Granule elements
-            if (isExternal) {
-                granuleURLUpdated = ovrProvider.getOvrURL();
-                assert ovrProvider.getExternalOverviewInputStreamSpi() != null
-                        : "no cachedStreamSPI available for external overview!";
-                SourceSPIProvider sourceSpiProvider =
-                        ovrProvider.getSourceSpiProvider().getCompatibleSourceProvider(granuleURLUpdated);
-                inStream = sourceSpiProvider.getStream();
-                // get a reader and try to cache the relevant SPI
-                reader = sourceSpiProvider.getReader();
-                if (reader == null) {
-                    if (LOGGER.isLoggable(java.util.logging.Level.WARNING)) {
-                        LOGGER.warning(new StringBuilder("Unable to get s reader for granuleDescriptor ")
-                                .append(this.toString())
-                                .append(" with request ")
-                                .append(request.toString())
-                                .append(" Resulting in no granule loaded: Empty result")
-                                .toString());
-                    }
-                    return null;
-                }
-                // set input
-                boolean ignoreMetadata = false;
-                if (reader instanceof InitializingReader initializingReader) {
-                    ignoreMetadata = initializingReader.init(hints);
-                }
-                reader.setInput(inStream, false, ignoreMetadata);
-                // External Overview index
-                ovrIndex = ovrProvider.getOverviewIndex(imageIndex);
+            URL granuleURLUpdated = isExternal ? ovrProvider.getOvrURL() : granuleUrl;
+            int ovrIndex = ovrProvider.getOverviewIndex(imageIndex);
 
+            // Try to serve the whole granule straight from the shared cache, without opening the file. The key needs
+            // only metadata; a hit also carries the level dimensions, enough to rebuild the geometry (this descriptor
+            // is alive) and clip to the requested window. The base level must be present to rebuild; if not (unusual),
+            // fall back to a normal open.
+            ImageMosaicReader parentReader = request.getRasterManager().parentReader;
+            GranuleImageCache imageCache = Optional.ofNullable(parentReader.getGranuleImageCache())
+                    .filter(c -> c.isEnabled() && request.isCacheGranules())
+                    .orElse(null);
+            ImageCacheKey cacheKey = imageCache == null
+                    ? null
+                    : new ImageCacheKey(parentReader.getMosaicId(), granuleURLUpdated, ovrIndex, request.getBands());
+            BufferedImage cached = null;
+            if (imageCache != null) {
+                // a hit rebuilds the level geometry from this descriptor's base level; without it, fall back to an open
+                cached = granuleLevels.get(0) == null ? null : imageCache.get(cacheKey);
+                boolean isHit = cached != null;
+                LOGGER.fine(() -> (isHit ? "Granule cache hit for " : "Granule cache miss for ") + cacheKey);
+            }
+
+            final GranuleOverviewLevelDescriptor selectedlevel;
+            if (cached != null) {
+                cleanupInFinally = true; // nothing was opened, the finally has nothing to close
+                selectedlevel = buildLevel(isExternal ? imageIndex : ovrIndex, cached);
             } else {
-                ovrIndex = ovrProvider.getOverviewIndex(imageIndex);
-
-                // get a stream from the granuleAccessProvider
-                assert cachedStreamSPI != null : "no cachedStreamSPI available!";
-                inStream = granuleAccessProvider.getImageInputStream();
-
-                if (inStream == null) return null;
-
-                // get a reader and try to cache the relevant SPI
-                if (cachedReaderSPI == null) {
-                    reader = ImageIOExt.getImageioReader(inStream);
-                    if (reader != null) cachedReaderSPI = reader.getOriginatingProvider();
-                } else {
-                    reader = granuleAccessProvider.getImageReader();
+                Opened opened = openAndGetLevel(isExternal, granuleURLUpdated, imageIndex, ovrIndex, hints, request);
+                reader = opened.reader();
+                inStream = opened.inStream();
+                if (opened.selectedlevel() == null) {
+                    return null; // could not open or get a reader, already logged; the finally closes the stream
                 }
-                if (reader == null) {
-                    if (LOGGER.isLoggable(java.util.logging.Level.WARNING)) {
-                        LOGGER.warning(new StringBuilder("Unable to get a reader for granuleDescriptor ")
-                                .append(this.toString())
-                                .append(" with request ")
-                                .append(request.toString())
-                                .append(" Resulting in no granule loaded: Empty result")
-                                .toString());
-                    }
-                    return null;
-                }
+                selectedlevel = opened.selectedlevel();
             }
-            // set input
-            if (reader instanceof InitializingReader initializingReader) {
-                initializingReader.init(hints);
-            }
-            reader.setInput(inStream);
-
-            // check if the reader wants to be aware of the current request
-            if (MethodUtils.getAccessibleMethod(reader.getClass(), "setRasterLayerRequest", RasterLayerRequest.class)
-                    != null) {
-                try {
-                    MethodUtils.invokeMethod(reader, "setRasterLayerRequest", request);
-                } catch (Exception exception) {
-                    throw new RuntimeException("Error setting raster layer request on reader.", exception);
-                }
-            }
-
-            // get selected level and base level dimensions
-            final GranuleOverviewLevelDescriptor selectedlevel = getLevel(ovrIndex, reader, imageIndex, isExternal);
 
             // now create the crop grid to world which can be used to decide
             // which source area we need to crop in the selected level taking
@@ -1178,69 +1136,47 @@ public class GranuleDescriptor {
                         + granuleUrl);
             }
 
-            // Setting subsampling
-            int newSubSamplingFactor = 0;
-            final String pluginName = cachedReaderSPI.getPluginClassName();
-            if (pluginName != null && pluginName.equals(ImageUtilities.DIRECT_KAKADU_PLUGIN)) {
-                final int ssx = readParameters.getSourceXSubsampling();
-                final int ssy = readParameters.getSourceYSubsampling();
-                newSubSamplingFactor = ImageIOUtilities.getSubSamplingFactor2(ssx, ssy);
-                if (newSubSamplingFactor != 0) {
-                    if (newSubSamplingFactor > maxDecimationFactor && maxDecimationFactor != -1) {
-                        newSubSamplingFactor = maxDecimationFactor;
-                    }
-                    readParameters.setSourceSubsampling(newSubSamplingFactor, newSubSamplingFactor, 0, 0);
-                }
-            }
-
-            // set the source region
+            // request source region, needed by the read and by the ROI / raster-to-model tail
             readParameters.setSourceRegion(sourceArea);
-
-            // don't pass down the band selection if the original color model is indexed and
-            // color expansion is enabled
             final boolean expandToRGB = request.getRasterManager().isExpandMe();
-            if (expandToRGB
-                    && getRawColorModel(reader, ovrIndex) instanceof IndexColorModel
-                    && readParameters instanceof EnhancedImageReadParam erp) {
-                erp.setBands(null);
-            }
-
-            // deferred loading needs a target image type to work, otherwise it's going
-            // to use the native image number of bands
-            if (nativeBandSelection
-                    && readParameters instanceof EnhancedImageReadParam param
-                    && param.getBands() != null
-                    && request.getReadType() == ReadType.JAI_IMAGEREAD) {
-                int[] bands = param.getBands();
-                ImageTypeSpecifier selected = ImageIOUtilities.getBandSelectedType(bands.length, sampleModel);
-                readParameters.setDestinationType(selected);
-            }
 
             RenderedImage raster;
-            try {
-                // read
-                raster = request.getReadType()
-                        .read(
-                                readParameters,
-                                ovrIndex,
-                                granuleURLUpdated,
+            if (cached != null) {
+                // served from cache: clip the whole-granule image to the requested window, no read
+                raster = ImageCacheClipper.clip(
+                        cached,
+                        sourceArea,
+                        readParameters.getSourceXSubsampling(),
+                        readParameters.getSourceYSubsampling());
+            } else {
+                boolean willCache = cacheKey != null
+                        && ImageCacheKey.isCacheable(
+                                imageCache,
+                                request.getGranuleCacheThresholdKB(),
                                 selectedlevel.rasterDimensions,
-                                reader,
-                                hints,
-                                false);
-
-            } catch (Throwable e) {
-                if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
-                    LOGGER.log(
-                            java.util.logging.Level.FINE,
-                            "Unable to load raster for granuleDescriptor "
-                                    + this.toString()
-                                    + " with request "
-                                    + request.toString()
-                                    + " Resulting in no granule loaded: Empty result",
-                            e);
+                                request.getBands(),
+                                sampleModel);
+                if (willCache) {
+                    // a cached read is always realized, so the reader and stream can be closed in the finally
+                    cleanupInFinally = true;
+                    LOGGER.fine(() -> "Caching granule read for " + cacheKey);
                 }
-                return null;
+                raster = readGranuleImage(
+                        request,
+                        readParameters,
+                        reader,
+                        hints,
+                        ovrIndex,
+                        granuleURLUpdated,
+                        selectedlevel,
+                        imageCache,
+                        cacheKey,
+                        sourceArea,
+                        expandToRGB,
+                        willCache);
+                if (raster == null) {
+                    return null;
+                }
             }
 
             // perform band selection if necessary, so far netcdf is the only low level reader that
@@ -1399,6 +1335,266 @@ public class GranuleDescriptor {
                     reader.dispose();
                 }
             }
+        }
+    }
+
+    /**
+     * The open reader and stream plus the resolved level; {@code selectedlevel} is {@code null} when the open failed.
+     */
+    private record Opened(
+            ImageReader reader, ImageInputStream inStream, GranuleOverviewLevelDescriptor selectedlevel) {}
+
+    /**
+     * Opens the granule (or its external overview) and reads the level geometry from it. On failure the returned
+     * {@link Opened#selectedlevel()} is {@code null}, while {@code reader}/{@code inStream} still carry whatever was
+     * opened so the caller's finally can close them.
+     */
+    private Opened openAndGetLevel(
+            boolean isExternal,
+            URL granuleURLUpdated,
+            int imageIndex,
+            int ovrIndex,
+            Hints hints,
+            RasterLayerRequest request)
+            throws IOException {
+        ImageInputStream inStream;
+        ImageReader reader;
+        if (isExternal) {
+            assert ovrProvider.getExternalOverviewInputStreamSpi() != null
+                    : "no cachedStreamSPI available for external overview!";
+            SourceSPIProvider sourceSpiProvider =
+                    ovrProvider.getSourceSpiProvider().getCompatibleSourceProvider(granuleURLUpdated);
+            inStream = sourceSpiProvider.getStream();
+            reader = sourceSpiProvider.getReader();
+            if (reader == null) {
+                if (LOGGER.isLoggable(java.util.logging.Level.WARNING)) {
+                    LOGGER.warning(new StringBuilder("Unable to get s reader for granuleDescriptor ")
+                            .append(this.toString())
+                            .append(" with request ")
+                            .append(request.toString())
+                            .append(" Resulting in no granule loaded: Empty result")
+                            .toString());
+                }
+                return new Opened(reader, inStream, null);
+            }
+            boolean ignoreMetadata = false;
+            if (reader instanceof InitializingReader initializingReader) {
+                ignoreMetadata = initializingReader.init(hints);
+            }
+            reader.setInput(inStream, false, ignoreMetadata);
+        } else {
+            // get a stream from the granuleAccessProvider
+            assert cachedStreamSPI != null : "no cachedStreamSPI available!";
+            inStream = granuleAccessProvider.getImageInputStream();
+
+            if (inStream == null) return new Opened(null, null, null);
+
+            // get a reader and try to cache the relevant SPI
+            if (cachedReaderSPI == null) {
+                reader = ImageIOExt.getImageioReader(inStream);
+                if (reader != null) cachedReaderSPI = reader.getOriginatingProvider();
+            } else {
+                reader = granuleAccessProvider.getImageReader();
+            }
+            if (reader == null) {
+                if (LOGGER.isLoggable(java.util.logging.Level.WARNING)) {
+                    LOGGER.warning(new StringBuilder("Unable to get a reader for granuleDescriptor ")
+                            .append(this.toString())
+                            .append(" with request ")
+                            .append(request.toString())
+                            .append(" Resulting in no granule loaded: Empty result")
+                            .toString());
+                }
+                return new Opened(reader, inStream, null);
+            }
+        }
+        // set input
+        if (reader instanceof InitializingReader initializingReader) {
+            initializingReader.init(hints);
+        }
+        reader.setInput(inStream);
+
+        // check if the reader wants to be aware of the current request
+        if (MethodUtils.getAccessibleMethod(reader.getClass(), "setRasterLayerRequest", RasterLayerRequest.class)
+                != null) {
+            try {
+                MethodUtils.invokeMethod(reader, "setRasterLayerRequest", request);
+            } catch (Exception exception) {
+                throw new RuntimeException("Error setting raster layer request on reader.", exception);
+            }
+        }
+
+        // get selected level and base level dimensions
+        GranuleOverviewLevelDescriptor selectedlevel = getLevel(ovrIndex, reader, imageIndex, isExternal);
+        return new Opened(reader, inStream, selectedlevel);
+    }
+
+    /**
+     * Reads the granule from the open reader, either populating and clipping through the cache (when {@code willCache})
+     * or with a plain read; returns {@code null} if nothing could be read (logged at FINE).
+     */
+    private RenderedImage readGranuleImage(
+            RasterLayerRequest request,
+            ImageReadParam readParameters,
+            ImageReader reader,
+            Hints hints,
+            int ovrIndex,
+            URL granuleURLUpdated,
+            GranuleOverviewLevelDescriptor selectedlevel,
+            GranuleImageCache imageCache,
+            ImageCacheKey cacheKey,
+            Rectangle sourceArea,
+            boolean expandToRGB,
+            boolean willCache) {
+        // Kakadu decode-subsampling only helps a direct decode; a cached read pulls the whole granule at full
+        // resolution and subsamples in the clip, so skip it when caching
+        if (!willCache) {
+            final String pluginName = cachedReaderSPI.getPluginClassName();
+            if (pluginName != null && pluginName.equals(ImageUtilities.DIRECT_KAKADU_PLUGIN)) {
+                final int ssx = readParameters.getSourceXSubsampling();
+                final int ssy = readParameters.getSourceYSubsampling();
+                int newSubSamplingFactor = ImageIOUtilities.getSubSamplingFactor2(ssx, ssy);
+                if (newSubSamplingFactor != 0) {
+                    if (newSubSamplingFactor > maxDecimationFactor && maxDecimationFactor != -1) {
+                        newSubSamplingFactor = maxDecimationFactor;
+                    }
+                    readParameters.setSourceSubsampling(newSubSamplingFactor, newSubSamplingFactor, 0, 0);
+                }
+            }
+        }
+
+        // don't pass down the band selection if the original color model is indexed and color expansion is on
+        if (expandToRGB
+                && getRawColorModel(reader, ovrIndex) instanceof IndexColorModel
+                && readParameters instanceof EnhancedImageReadParam erp) {
+            erp.setBands(null);
+        }
+        // deferred loading needs a target image type, otherwise it uses the native band count
+        if (nativeBandSelection
+                && readParameters instanceof EnhancedImageReadParam param
+                && param.getBands() != null
+                && request.getReadType() == ReadType.JAI_IMAGEREAD) {
+            int[] selBands = param.getBands();
+            ImageTypeSpecifier selected = ImageIOUtilities.getBandSelectedType(selBands.length, sampleModel);
+            readParameters.setDestinationType(selected);
+        }
+
+        try {
+            if (willCache) {
+                return readCached(
+                        imageCache,
+                        cacheKey,
+                        request.getReadType(),
+                        readParameters,
+                        ovrIndex,
+                        granuleURLUpdated,
+                        selectedlevel.rasterDimensions,
+                        reader,
+                        hints,
+                        sourceArea,
+                        readParameters.getSourceXSubsampling(),
+                        readParameters.getSourceYSubsampling());
+            }
+            return request.getReadType()
+                    .read(
+                            readParameters,
+                            ovrIndex,
+                            granuleURLUpdated,
+                            selectedlevel.rasterDimensions,
+                            reader,
+                            hints,
+                            false);
+        } catch (Throwable e) {
+            if (LOGGER.isLoggable(java.util.logging.Level.FINE)) {
+                LOGGER.log(
+                        java.util.logging.Level.FINE,
+                        "Unable to load raster for granuleDescriptor "
+                                + this.toString()
+                                + " with request "
+                                + request.toString()
+                                + " Resulting in no granule loaded: Empty result",
+                        e);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Serves a whole-granule read through the image cache, clipped to the requested view, or {@code null} if nothing
+     * was read.
+     */
+    private static RenderedImage readCached(
+            GranuleImageCache imageCache,
+            ImageCacheKey cacheKey,
+            ReadType readType,
+            ImageReadParam readParameters,
+            int imageIndex,
+            URL granuleUrl,
+            Rectangle rasterDimensions,
+            ImageReader reader,
+            Hints hints,
+            Rectangle sourceArea,
+            int subsamplingX,
+            int subsamplingY)
+            throws Exception {
+        // getOrLoad reads the whole granule once per key, atomically: concurrent requests share one read, and a
+        // MissingRasterException from the loader comes back as a null granule. Read via the configured readType so
+        // cached pixels match the uncached output (read types decode some sources differently, e.g. LZW TIFFs with a
+        // horizontal predictor). Mutating readParameters is safe: GranuleLoader gives each load its own clone; restored
+        // in the finally for the rest of loadRaster.
+        BufferedImage granule = imageCache.getOrLoad(cacheKey, () -> {
+            readParameters.setSourceRegion(rasterDimensions);
+            readParameters.setSourceSubsampling(1, 1, 0, 0);
+            try {
+                RenderedImage read =
+                        readType.read(readParameters, imageIndex, granuleUrl, rasterDimensions, reader, hints, false);
+                if (read == null) {
+                    throw new GranuleImageCache.MissingRasterException();
+                }
+                // the whole level is read at full resolution, so the cached image size is the level dimension and a
+                // later hit can rebuild the geometry and clip without reopening the granule
+                if (read instanceof BufferedImage bufferedImage) {
+                    return bufferedImage;
+                }
+                // deferred read (JAI_IMAGEREAD): copy into a detached image while the stream is open, then
+                // dispose the operation so its rendering and cached tiles are not leaked; the reader and stream
+                // are left to loadRaster's finally (cleanupInFinally is set), so they are not touched here
+                PlanarImage deferred = PlanarImage.wrapRenderedImage(read);
+                try {
+                    return deferred.getAsBufferedImage();
+                } finally {
+                    ImageUtilities.disposeSinglePlanarImage(deferred);
+                }
+            } finally {
+                readParameters.setSourceRegion(sourceArea);
+                readParameters.setSourceSubsampling(subsamplingX, subsamplingY, 0, 0);
+            }
+        });
+        if (granule == null) {
+            return null;
+        }
+        return ImageCacheClipper.clip(granule, sourceArea, subsamplingX, subsamplingY);
+    }
+
+    /**
+     * Rebuilds the overview level for a cache hit from the cached image size, reusing the base level and this
+     * descriptor's base grid-to-world, so no granule open is needed. Mirrors the construction in {@link #getLevel}.
+     */
+    private GranuleOverviewLevelDescriptor buildLevel(int indexValue, RenderedImage image) {
+        synchronized (granuleLevels) {
+            GranuleOverviewLevelDescriptor existing = granuleLevels.get(indexValue);
+            if (existing != null) {
+                return existing;
+            }
+            // the cached image was read over the whole level at full resolution, so its size is the level dimension
+            int width = image.getWidth();
+            int height = image.getHeight();
+            GranuleOverviewLevelDescriptor baseLevel = granuleLevels.get(0);
+            double scaleX = baseLevel.width / (1.0 * width);
+            double scaleY = baseLevel.height / (1.0 * height);
+            GranuleOverviewLevelDescriptor newLevel = new GranuleOverviewLevelDescriptor(scaleX, scaleY, width, height);
+            granuleLevels.put(indexValue, newLevel);
+            return newLevel;
         }
     }
 

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleImageCache.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GranuleImageCache.java
@@ -1,0 +1,84 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import java.awt.image.BufferedImage;
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+/**
+ * A bounded, shared pool of decoded whole-granule images that {@link ImageMosaicReader}s can reuse across requests,
+ * sized by total decoded bytes with LRU eviction. Built and owned by the caller, injected into readers at construction
+ * time through {@link org.geotools.util.factory.Hints#GRANULE_IMAGE_CACHE} and enabled via the
+ * {@link ImageMosaicFormat#CACHE_GRANULES} read parameter. Implementations must be thread-safe.
+ *
+ * <p>Entries are keyed by owning mosaic plus granule URL, image index and band selection, so the pool can shed a
+ * mosaic's whole footprint at once through {@link #invalidateMosaic(String)} when its reader is disposed (store reload,
+ * remove or reset): heap then tracks the mosaic's lifecycle instead of lingering until the LRU bound reclaims it. A
+ * stale single granule (an in-place overwrite, a re-harvest, a delete) is dropped with {@link #invalidateGranule(URL)},
+ * and {@link #invalidateAll()} clears the pool. The band selection is part of the key because it's typically associated
+ * with multispectral/hyperspectral images where there are too many bands to cache the whole set.
+ *
+ * <p>A cached BufferedImage is shared, as-is, by every request that hits it, so the read path must treat it strictly
+ * read-only: no consumer may write into its raster in place, or it would corrupt other requests' and other mosaics'
+ * reads.
+ */
+public interface GranuleImageCache {
+
+    /**
+     * Applies new sizing while keeping this instance's identity, so readers holding it through
+     * {@link org.geotools.util.factory.Hints#GRANULE_IMAGE_CACHE} see the change with no rebuild on their side. A
+     * change in total size may drop the current entries and free their heap at once; the threshold is applied in place.
+     */
+    void reconfigure(long maximumSizeBytes, long defaultThresholdBytes);
+
+    /** Whether caching is on: a non-positive max size means the pool is present but denies caching. */
+    boolean isEnabled();
+
+    /** Number of granule images currently held. */
+    long size();
+
+    /** Drops all cached granule images. */
+    void invalidateAll();
+
+    /** Drops every cached read of the given granule, whatever the mosaic, image index or band selection. */
+    void invalidateGranule(URL granuleUrl);
+
+    /** Drops every entry owned by the given mosaic, called when its reader is disposed to free heap at once. */
+    void invalidateMosaic(String mosaicId);
+
+    /** Maximum size of the pool, in bytes. */
+    long getMaximumSizeBytes();
+
+    /** Largest decoded granule eligible for caching, in bytes (a read parameter can override it). */
+    long getDefaultThresholdBytes();
+
+    /** Returns the cached image for the key, or {@code null} on a miss; never loads. */
+    BufferedImage get(ImageCacheKey key);
+
+    /**
+     * Returns the cached image for the key, loading it once atomically if absent. Returns {@code null} if the loader
+     * signals nothing was read by throwing {@link MissingRasterException}; any other loader failure propagates.
+     */
+    BufferedImage getOrLoad(ImageCacheKey key, Callable<BufferedImage> loader) throws Exception;
+
+    /**
+     * Thrown by a {@link #getOrLoad} loader to signal the read produced nothing; {@link #getOrLoad} maps it to a
+     * {@code null} result instead of caching.
+     */
+    class MissingRasterException extends RuntimeException {}
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GuavaGranuleImageCache.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/GuavaGranuleImageCache.java
@@ -1,0 +1,112 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.Weigher;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.awt.image.BufferedImage;
+import java.net.URL;
+import java.util.concurrent.Callable;
+
+/** Default {@link GranuleImageCache}: a single-JVM, heap-backed pool over a Guava {@link Cache}. Thread-safe. */
+public final class GuavaGranuleImageCache implements GranuleImageCache {
+
+    private volatile Cache<ImageCacheKey, BufferedImage> cache;
+    private volatile long maximumSizeBytes;
+    private volatile long defaultThresholdBytes;
+
+    public GuavaGranuleImageCache(long maximumSizeBytes, long defaultThresholdBytes) {
+        reconfigure(maximumSizeBytes, defaultThresholdBytes);
+    }
+
+    @Override
+    public synchronized void reconfigure(long maximumSizeBytes, long defaultThresholdBytes) {
+        this.defaultThresholdBytes = defaultThresholdBytes;
+        // Guava fixes the maximum weight at build time, so a size change rebuilds the cache, dropping the current
+        // entries and freeing their heap at once; the threshold is a plain field, applied in place.
+        if (cache == null || this.maximumSizeBytes != maximumSizeBytes) {
+            this.maximumSizeBytes = maximumSizeBytes;
+            Weigher<ImageCacheKey, BufferedImage> weigher = (key, image) -> imageBytes(image);
+            this.cache = CacheBuilder.newBuilder()
+                    .maximumWeight(maximumSizeBytes)
+                    .weigher(weigher)
+                    .build();
+        }
+    }
+
+    private static int imageBytes(BufferedImage image) {
+        // getPixelSize is total bits across all bands, so it already accounts for the band count
+        int bytesPerPixel = (image.getColorModel().getPixelSize() + 7) / 8;
+        long bytes = (long) image.getWidth() * image.getHeight() * bytesPerPixel;
+        return (int) Math.min(bytes, Integer.MAX_VALUE);
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return maximumSizeBytes > 0;
+    }
+
+    @Override
+    public long size() {
+        cache.cleanUp();
+        return cache.size();
+    }
+
+    @Override
+    public void invalidateAll() {
+        cache.invalidateAll();
+    }
+
+    @Override
+    public void invalidateGranule(URL granuleUrl) {
+        cache.asMap().keySet().removeIf(key -> key.sameGranule(granuleUrl));
+    }
+
+    @Override
+    public void invalidateMosaic(String mosaicId) {
+        cache.asMap().keySet().removeIf(key -> key.sameMosaic(mosaicId));
+    }
+
+    @Override
+    public long getMaximumSizeBytes() {
+        return maximumSizeBytes;
+    }
+
+    @Override
+    public long getDefaultThresholdBytes() {
+        return defaultThresholdBytes;
+    }
+
+    @Override
+    public BufferedImage get(ImageCacheKey key) {
+        return cache.getIfPresent(key);
+    }
+
+    @Override
+    public BufferedImage getOrLoad(ImageCacheKey key, Callable<BufferedImage> loader) throws Exception {
+        try {
+            return cache.get(key, loader);
+        } catch (UncheckedExecutionException e) {
+            if (e.getCause() instanceof MissingRasterException) {
+                return null;
+            }
+            throw e;
+        }
+    }
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageCacheClipper.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageCacheClipper.java
@@ -1,0 +1,85 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.SampleModel;
+import java.awt.image.WritableRaster;
+
+/**
+ * Extracts, from an already decoded image, the exact pixel window an {@link javax.imageio.ImageReader} would have
+ * produced for a given source region and subsampling.
+ */
+final class ImageCacheClipper {
+
+    private ImageCacheClipper() {}
+
+    /**
+     * Returns the pixels an ImageIO read with the given {@code sourceRegion} and subsampling would have decoded, per
+     * {@link javax.imageio.ImageReadParam#setSourceSubsampling}: output pixel (i, j) is source pixel
+     * {@code (sourceRegion.x + i * subsamplingX, sourceRegion.y + j * subsamplingY)}, no interpolation.
+     *
+     * <p>The result may be a new image (in case of subsampling > 1), a subimage of the original image, or the original
+     * image itself.
+     */
+    static RenderedImage clip(BufferedImage image, Rectangle sourceRegion, int subsamplingX, int subsamplingY) {
+        if (subsamplingX == 1
+                && subsamplingY == 1
+                && sourceRegion.x == 0
+                && sourceRegion.y == 0
+                && sourceRegion.width == image.getWidth()
+                && sourceRegion.height == image.getHeight()) {
+            return image;
+        }
+        // zero-copy view over the source raster, already translated so the crop's own origin is (0, 0)
+        BufferedImage cropped =
+                image.getSubimage(sourceRegion.x, sourceRegion.y, sourceRegion.width, sourceRegion.height);
+        if (subsamplingX == 1 && subsamplingY == 1) {
+            return cropped;
+        }
+        return subsample(cropped, subsamplingX, subsamplingY);
+    }
+
+    /** Picks every {@code subsamplingX}-th/{@code subsamplingY}-th pixel of the already-cropped {@code image}. */
+    private static RenderedImage subsample(BufferedImage image, int subsamplingX, int subsamplingY) {
+        int outWidth = (image.getWidth() + subsamplingX - 1) / subsamplingX;
+        int outHeight = (image.getHeight() + subsamplingY - 1) / subsamplingY;
+
+        Raster source = image.getRaster();
+        SampleModel targetSampleModel = source.getSampleModel().createCompatibleSampleModel(outWidth, outHeight);
+        WritableRaster target = Raster.createWritableRaster(targetSampleModel, new Point(0, 0));
+        // getDataElements moves native-typed samples with no double conversion (measured 3 times faster than
+        // getPixel(double[]) on average; an ImageN affine/NN op was also tried and found to be slower)
+        Object element = null;
+        for (int y = 0; y < outHeight; y++) {
+            int sy = y * subsamplingY;
+            for (int x = 0; x < outWidth; x++) {
+                int sx = x * subsamplingX;
+                element = source.getDataElements(sx, sy, element);
+                target.setDataElements(x, y, element);
+            }
+        }
+
+        ColorModel colorModel = image.getColorModel();
+        return new BufferedImage(colorModel, target, colorModel.isAlphaPremultiplied(), null);
+    }
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageCacheKey.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageCacheKey.java
@@ -1,0 +1,106 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import java.awt.Rectangle;
+import java.awt.image.DataBuffer;
+import java.awt.image.SampleModel;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.logging.Logger;
+import org.geotools.util.logging.Logging;
+
+/**
+ * Identifies a whole-granule read of a single source image index in the shared {@link GranuleImageCache}. Carries the
+ * owning mosaic id so the pool can drop all of a mosaic's entries at once when its reader is disposed (store
+ * reload/remove/reset), keeping heap in step with the mosaic's lifecycle.
+ */
+class ImageCacheKey {
+
+    private static final Logger LOGGER = Logging.getLogger(ImageCacheKey.class);
+
+    private final String mosaicId;
+
+    // external string form, not a URL: URL#hashCode/#equals can do a blocking DNS lookup, and this key is hashed
+    // and compared on every cache access, including for remote (COG) granules
+    private final String granuleUrlSpec;
+
+    private final int imageIndex;
+    private final int[] bands;
+
+    ImageCacheKey(String mosaicId, URL granuleUrl, int imageIndex, int[] bands) {
+        this.mosaicId = mosaicId;
+        this.granuleUrlSpec = granuleUrl.toExternalForm();
+        this.imageIndex = imageIndex;
+        this.bands = bands;
+    }
+
+    /**
+     * Whether a whole-granule read of this size is small enough to cache: its estimated decoded bytes must not exceed
+     * the threshold (the per-request {@code thresholdOverrideKB} when positive, otherwise the pool default).
+     */
+    static boolean isCacheable(
+            GranuleImageCache cache,
+            int thresholdOverrideKB,
+            Rectangle rasterDimensions,
+            int[] bands,
+            SampleModel sampleModel) {
+        int numBands = bands != null ? bands.length : sampleModel.getNumBands();
+        int bytesPerSample = DataBuffer.getDataTypeSize(sampleModel.getDataType()) / 8;
+        long estimatedBytes = (long) rasterDimensions.width * rasterDimensions.height * numBands * bytesPerSample;
+        long thresholdBytes = thresholdOverrideKB > 0 ? thresholdOverrideKB * 1024L : cache.getDefaultThresholdBytes();
+        boolean cacheable = estimatedBytes <= thresholdBytes;
+        if (!cacheable) {
+            LOGGER.fine(() -> "Granule not cached, estimated " + estimatedBytes + " bytes exceeds cache threshold of "
+                    + thresholdBytes + " bytes");
+        }
+        return cacheable;
+    }
+
+    /** Returns whether this key refers to the given granule, without the DNS cost of {@link URL#equals(Object)}. */
+    boolean sameGranule(URL granuleUrl) {
+        return granuleUrl != null && granuleUrlSpec.equals(granuleUrl.toExternalForm());
+    }
+
+    /** Returns whether this key belongs to the given mosaic. */
+    boolean sameMosaic(String mosaicId) {
+        return Objects.equals(this.mosaicId, mosaicId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ImageCacheKey other)) return false;
+        return imageIndex == other.imageIndex
+                && Objects.equals(mosaicId, other.mosaicId)
+                && Objects.equals(granuleUrlSpec, other.granuleUrlSpec)
+                && Arrays.equals(bands, other.bands);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(mosaicId, granuleUrlSpec, imageIndex);
+        return 31 * result + Arrays.hashCode(bands);
+    }
+
+    @Override
+    public String toString() {
+        return "ImageCacheKey{mosaicId=" + mosaicId + ", granuleUrl=" + granuleUrlSpec + ", imageIndex=" + imageIndex
+                + ", bands=" + Arrays.toString(bands) + '}';
+    }
+}

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicConfigHandler.java
@@ -632,6 +632,28 @@ public class ImageMosaicConfigHandler {
 
         // Add the granules collection to the store
         store.addGranules(collection);
+
+        // a (re)harvest of this location means the file may have changed: drop any stale cached image for it
+        invalidateCachedGranule(mosaicReader, mosaicConfiguration, fileLocation);
+    }
+
+    /**
+     * Drops the shared-cache entry for a granule location, resolving its URL the same way the read path does (the
+     * mosaic parent directory as the RELATIVE base). No-op when no cache is injected, or when the granule file no
+     * longer exists (URL resolution checks readability), so call this before deleting the file.
+     */
+    static void invalidateCachedGranule(
+            ImageMosaicReader mosaicReader, MosaicConfigurationBean mosaicConfiguration, String fileLocation) {
+        GranuleImageCache imageCache = mosaicReader.getGranuleImageCache();
+        File parentDirectory = mosaicReader.parentDirectory;
+        if (imageCache == null || mosaicConfiguration == null || parentDirectory == null || fileLocation == null) {
+            return;
+        }
+        PathType pathType = mosaicConfiguration.getCatalogConfigurationBean().getPathType();
+        URL granuleUrl = pathType.resolvePath(URLs.fileToUrl(parentDirectory).toString(), fileLocation);
+        if (granuleUrl != null) {
+            imageCache.invalidateGranule(granuleUrl);
+        }
     }
 
     private void handleStructuredGridCoverage(

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicFormat.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicFormat.java
@@ -147,6 +147,14 @@ public final class ImageMosaicFormat extends AbstractGridFormat implements Forma
     public static final ParameterDescriptor<Boolean> ALLOW_MULTITHREADING = new DefaultParameterDescriptor<>(
             "AllowMultithreading", Boolean.class, new Boolean[] {Boolean.TRUE, Boolean.FALSE}, Boolean.FALSE);
 
+    /** Enables reuse of decoded granules through the shared cache injected via {@link Hints#GRANULE_IMAGE_CACHE}. */
+    public static final ParameterDescriptor<Boolean> CACHE_GRANULES = new DefaultParameterDescriptor<>(
+            "CacheGranules", Boolean.class, new Boolean[] {Boolean.TRUE, Boolean.FALSE}, Boolean.FALSE);
+
+    /** Overrides the cache pool's default per-granule eligibility threshold, in KB; -1 keeps the pool default. */
+    public static final ParameterDescriptor<Integer> GRANULE_CACHE_THRESHOLD_KB =
+            new DefaultParameterDescriptor<>("CacheGranulesThresholdKB", Integer.class, null, Integer.valueOf(-1));
+
     /** Control the background values for the output coverage */
     public static final ParameterDescriptor<double[]> BACKGROUND_VALUES =
             new DefaultParameterDescriptor<>("BackgroundValues", double[].class, null, null);
@@ -260,6 +268,8 @@ public final class ImageMosaicFormat extends AbstractGridFormat implements Forma
                     BACKGROUND_VALUES,
                     SUGGESTED_TILE_SIZE,
                     ALLOW_MULTITHREADING,
+                    CACHE_GRANULES,
+                    GRANULE_CACHE_THRESHOLD_KB,
                     MAX_ALLOWED_TILES,
                     TIME,
                     ELEVATION,

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicReader.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/ImageMosaicReader.java
@@ -141,6 +141,8 @@ public class ImageMosaicReader extends AbstractGridCoverage2DReader implements S
 
     ExecutorService multiThreadedLoader;
 
+    GranuleImageCache granuleImageCache;
+
     String locationAttributeName = Utils.DEFAULT_LOCATION_ATTRIBUTE;
 
     int maxAllowedTiles = ImageMosaicFormat.MAX_ALLOWED_TILES.getDefaultValue();
@@ -187,6 +189,11 @@ public class ImageMosaicReader extends AbstractGridCoverage2DReader implements S
                     }
                 }
             }
+        }
+
+        // shared granule image cache, injected by the caller; absent hint = no caching
+        if (this.hints.get(Hints.GRANULE_IMAGE_CACHE) instanceof GranuleImageCache cache) {
+            this.granuleImageCache = cache;
         }
 
         // max allowed tiles for a single request
@@ -683,12 +690,20 @@ public class ImageMosaicReader extends AbstractGridCoverage2DReader implements S
         super.dispose();
         synchronized (this) {
             try {
+                // free this mosaic's cached granule images when the reader goes (store reload/remove/reset), so heap
+                // tracks the mosaic lifecycle rather than waiting for the shared pool's size bound to reclaim it
+                if (granuleImageCache != null) granuleImageCache.invalidateMosaic(getMosaicId());
                 if (granuleCatalog != null) this.granuleCatalog.dispose();
                 disposeManagers();
             } catch (Exception e) {
                 if (LOGGER.isLoggable(Level.FINE)) LOGGER.log(Level.FINE, e.getLocalizedMessage(), e);
             }
         }
+    }
+
+    /** Stable identifier of this mosaic, shared by all its coverages, used to scope granule cache eviction. */
+    public String getMosaicId() {
+        return sourceURL != null ? sourceURL.toExternalForm() : null;
     }
 
     /** Dispose raster managers */
@@ -1389,6 +1404,11 @@ public class ImageMosaicReader extends AbstractGridCoverage2DReader implements S
 
     public ExecutorService getMultiThreadedLoader() {
         return multiThreadedLoader;
+    }
+
+    /** Returns the shared granule image cache injected via {@link Hints#GRANULE_IMAGE_CACHE}, or {@code null}. */
+    public GranuleImageCache getGranuleImageCache() {
+        return granuleImageCache;
     }
 
     @Override

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/PurgingGranuleStore.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/PurgingGranuleStore.java
@@ -97,6 +97,14 @@ class PurgingGranuleStore extends GranuleStoreDecorator {
                 Set<String> removedLocations = getRemovedLocations(countsByFilter, countsByLocation);
                 boolean deleteData = policy == GranuleRemovalPolicy.ALL;
 
+                // drop stale cached images before the files go: URL resolution needs the file to still exist
+                if (deleteData) {
+                    for (String location : removedLocations) {
+                        ImageMosaicConfigHandler.invalidateCachedGranule(
+                                manager.parentReader, manager.configuration, location);
+                    }
+                }
+
                 // for single files, we can be efficient and do a single pass, for files
                 // providing multiple granules, not, as the descriptor is going to be created
                 // during the visit, whether we use it or not, and that may cause the involved

--- a/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerRequest.java
+++ b/modules/plugin/imagemosaic/src/main/java/org/geotools/gce/imagemosaic/RasterLayerRequest.java
@@ -120,6 +120,11 @@ public class RasterLayerRequest {
 
     private boolean multithreadingAllowed;
 
+    private boolean cacheGranules;
+
+    private int granuleCacheThresholdKB =
+            ImageMosaicFormat.GRANULE_CACHE_THRESHOLD_KB.getDefaultValue().intValue();
+
     private boolean skipDuplicates;
 
     private List<?> requestedTimes;
@@ -193,6 +198,16 @@ public class RasterLayerRequest {
 
     public boolean isMultithreadingAllowed() {
         return multithreadingAllowed;
+    }
+
+    /** Whether this read should reuse and populate the shared granule image cache. */
+    public boolean isCacheGranules() {
+        return cacheGranules;
+    }
+
+    /** Per-request override of the pool's per-granule caching threshold, in KB; -1 to keep the pool default. */
+    public int getGranuleCacheThresholdKB() {
+        return granuleCacheThresholdKB;
     }
 
     public DecimationPolicy getDecimationPolicy() {
@@ -514,6 +529,18 @@ public class RasterLayerRequest {
                 continue;
             }
 
+            if (name.equals(ImageMosaicFormat.CACHE_GRANULES.getName())) {
+                if (value == null) continue;
+                cacheGranules = ((Boolean) value).booleanValue();
+                continue;
+            }
+
+            if (name.equals(ImageMosaicFormat.GRANULE_CACHE_THRESHOLD_KB.getName())) {
+                if (value == null) continue;
+                granuleCacheThresholdKB = (Integer) value;
+                continue;
+            }
+
             if (name.equals(AbstractGridFormat.FOOTPRINT_BEHAVIOR.getName())) {
                 if (value == null) continue;
                 footprintBehavior = FootprintBehavior.valueOf((String) value);
@@ -768,6 +795,20 @@ public class RasterLayerRequest {
             final Object value = param.getValue();
             if (value == null) return;
             multithreadingAllowed = ((Boolean) value).booleanValue();
+            return;
+        }
+
+        if (name.equals(ImageMosaicFormat.CACHE_GRANULES.getName())) {
+            final Object value = param.getValue();
+            if (value == null) return;
+            cacheGranules = ((Boolean) value).booleanValue();
+            return;
+        }
+
+        if (name.equals(ImageMosaicFormat.GRANULE_CACHE_THRESHOLD_KB.getName())) {
+            final Object value = param.getValue();
+            if (value == null) return;
+            granuleCacheThresholdKB = (Integer) value;
             return;
         }
 

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/GranuleImageCacheTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/GranuleImageCacheTest.java
@@ -1,0 +1,359 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import java.net.URL;
+import org.apache.commons.io.FileUtils;
+import org.geotools.api.parameter.GeneralParameterValue;
+import org.geotools.api.parameter.ParameterValue;
+import org.geotools.coverage.grid.GridCoverage2D;
+import org.geotools.coverage.grid.io.AbstractGridFormat;
+import org.geotools.coverage.grid.io.GranuleRemovalPolicy;
+import org.geotools.coverage.grid.io.GranuleStore;
+import org.geotools.filter.text.ecql.ECQL;
+import org.geotools.image.test.ImageAssert;
+import org.geotools.test.TestData;
+import org.geotools.util.factory.Hints;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * End-to-end coverage of the injected {@link GranuleImageCache} enabled through
+ * {@link ImageMosaicFormat#CACHE_GRANULES}.
+ */
+public class GranuleImageCacheTest {
+
+    private static final long KB = 1024;
+    private static final long MB = 1024 * 1024;
+
+    @Test
+    public void testCachePopulatedWhenEnabled() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        withReader(reader(cache), r -> {
+            read(r, true, -1).dispose(true);
+            assertTrue("cache should hold at least one granule", cache.size() > 0);
+        });
+    }
+
+    @Test
+    public void testCacheUntouchedWhenParamOff() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        withReader(reader(cache), r -> {
+            read(r, false, -1).dispose(true);
+            assertEquals(0, cache.size());
+        });
+    }
+
+    @Test
+    public void testDisabledPoolDeniesCaching() throws Exception {
+        // pool present but with a 0 budget: caching must be off even with the param on
+        GranuleImageCache cache = new GuavaGranuleImageCache(0, 0);
+        assertFalse(cache.isEnabled());
+        withReader(reader(cache), r -> {
+            read(r, true, -1).dispose(true);
+            assertEquals(0, cache.size());
+        });
+    }
+
+    @Test
+    public void testNoHintReadsWithoutCaching() throws Exception {
+        withReader(reader(null), r -> {
+            // param on, but no pool injected: must still read fine
+            read(r, true, -1).dispose(true);
+        });
+    }
+
+    @Test
+    public void testThresholdOverrideExcludesGranules() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        withReader(reader(cache), r -> {
+            // 1 KB per-granule ceiling is smaller than any decoded tile -> nothing cached
+            read(r, true, 1).dispose(true);
+            assertEquals(0, cache.size());
+        });
+    }
+
+    @Test
+    public void testGranuleTooLargeForPoolDefaultNotCached() throws Exception {
+        // pool default of 1 KB is smaller than any decoded tile, and the read keeps the default (-1) -> nothing cached
+        GranuleImageCache cache = new GuavaGranuleImageCache(64 * MB, KB);
+        withReader(reader(cache), r -> {
+            read(r, true, -1).dispose(true);
+            assertEquals(0, cache.size());
+        });
+    }
+
+    @Test
+    public void testDirectReadPopulatesCacheAndMatches() throws Exception {
+        // ReadType.DIRECT_READ yields a BufferedImage straight away: readCached must cache it without materializing,
+        // and still match an uncached direct read
+        GridCoverage2D uncached = withReader(reader(null), r -> {
+            return readDirect(r, false);
+        });
+
+        GranuleImageCache cache = defaultCache();
+        ImageMosaicReader reader = reader(cache);
+        try {
+            GridCoverage2D cached = readDirect(reader, true);
+            assertTrue("direct-read granules should populate the cache", cache.size() > 0);
+            ImageAssert.assertEquals(uncached.getRenderedImage(), cached.getRenderedImage(), 0);
+            cached.dispose(true);
+        } finally {
+            reader.dispose();
+            uncached.dispose(true);
+        }
+    }
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testCacheHitSkipsFileOpen() throws Exception {
+        File dir = tempFolder.newFolder("rgb_openskip");
+        FileUtils.copyDirectory(TestData.file(this, "rgb"), dir);
+
+        GranuleImageCache cache = defaultCache();
+        withReader(new ImageMosaicFormat().getReader(dir, new Hints(Hints.GRANULE_IMAGE_CACHE, cache)), r -> {
+            GridCoverage2D warm = read(r, true, -1);
+            assertTrue(cache.size() > 0);
+
+            // delete every granule file: a read that still opened files would now drop those granules and change
+            // the output, so an identical result proves the second read was served entirely from the cache
+            File[] granules = dir.listFiles((d, n) -> n.endsWith(".png"));
+            assertTrue(granules != null && granules.length > 0);
+            for (File f : granules) {
+                assertTrue("could not delete " + f, f.delete());
+            }
+
+            GridCoverage2D served = read(r, true, -1);
+            ImageAssert.assertEquals(warm.getRenderedImage(), served.getRenderedImage(), 0);
+            warm.dispose(true);
+            served.dispose(true);
+        });
+    }
+
+    @Test
+    public void testReharvestInvalidatesGranule() throws Exception {
+        File dir = tempFolder.newFolder("rgb_reharvest");
+        FileUtils.copyDirectory(TestData.file(this, "rgb"), dir);
+
+        GranuleImageCache cache = defaultCache();
+        withReader(new ImageMosaicFormat().getReader(dir, new Hints(Hints.GRANULE_IMAGE_CACHE, cache)), r -> {
+            read(r, true, -1).dispose(true);
+            long populated = cache.size();
+            assertTrue("expected several granules cached", populated > 1);
+
+            // re-harvesting a granule signals its file may have changed: its cached image must be dropped
+            r.harvest(null, new File(dir, "global_mosaic_0.png"), null);
+            assertEquals(populated - 1, cache.size());
+        });
+    }
+
+    @Test
+    public void testDeleteGranuleInvalidatesCache() throws Exception {
+        File dir = tempFolder.newFolder("rgb_delete");
+        FileUtils.copyDirectory(TestData.file(this, "rgb"), dir);
+
+        GranuleImageCache cache = defaultCache();
+        withReader(new ImageMosaicFormat().getReader(dir, new Hints(Hints.GRANULE_IMAGE_CACHE, cache)), r -> {
+            read(r, true, -1).dispose(true);
+            long populated = cache.size();
+            assertTrue(populated > 1);
+
+            // removal with GranuleRemovalPolicy.ALL deletes the file, so its cached image must be dropped too
+            GranuleStore store = (GranuleStore) r.getGranules(r.getGridCoverageNames()[0], false);
+            Hints purge = new Hints(Hints.GRANULE_REMOVAL_POLICY, GranuleRemovalPolicy.ALL);
+            store.removeGranules(ECQL.toFilter("location = 'global_mosaic_0.png'"), purge);
+            assertEquals(populated - 1, cache.size());
+        });
+    }
+
+    @Test
+    public void testInvalidateAllClearsCache() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        withReader(reader(cache), r -> {
+            read(r, true, -1).dispose(true);
+            assertTrue(cache.size() > 0);
+            cache.invalidateAll();
+            assertEquals(0, cache.size());
+        });
+    }
+
+    @Test
+    public void testInvalidateGranuleDropsOnlyThatGranule() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        URL granuleA = new URL("file:/mosaic/a.tif");
+        URL granuleB = new URL("file:/mosaic/b.tif");
+        BufferedImage dummy = new BufferedImage(1, 1, BufferedImage.TYPE_3BYTE_BGR);
+        cache.getOrLoad(new ImageCacheKey("m", granuleA, 0, null), () -> dummy);
+        cache.getOrLoad(new ImageCacheKey("m", granuleA, 1, null), () -> dummy);
+        cache.getOrLoad(new ImageCacheKey("m", granuleB, 0, null), () -> dummy);
+        assertEquals(3, cache.size());
+
+        cache.invalidateGranule(granuleA);
+        assertEquals("only granule A's entries should be dropped", 1, cache.size());
+
+        cache.invalidateGranule(new URL("file:/mosaic/unknown.tif"));
+        assertEquals("an unrelated URL must not drop any entry", 1, cache.size());
+
+        assertTrue(cache.size() > 0);
+    }
+
+    @Test
+    public void testReconfigureThresholdKeepsEntries() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        cache.getOrLoad(
+                new ImageCacheKey("m", new URL("file:/g.tif"), 0, null),
+                () -> new BufferedImage(1, 1, BufferedImage.TYPE_3BYTE_BGR));
+        assertEquals(1, cache.size());
+
+        // threshold-only change: same budget, entries survive
+        cache.reconfigure(64 * MB, 5 * MB);
+        assertEquals(1, cache.size());
+        assertEquals(5 * MB, cache.getDefaultThresholdBytes());
+    }
+
+    @Test
+    public void testReconfigureResizeDropsEntries() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        cache.getOrLoad(
+                new ImageCacheKey("m", new URL("file:/g.tif"), 0, null),
+                () -> new BufferedImage(1, 1, BufferedImage.TYPE_3BYTE_BGR));
+        assertEquals(1, cache.size());
+
+        // size change rebuilds the backing cache, dropping current entries and freeing their heap
+        cache.reconfigure(32 * MB, 10 * MB);
+        assertEquals(0, cache.size());
+        assertEquals(32 * MB, cache.getMaximumSizeBytes());
+    }
+
+    @Test
+    public void testInvalidateMosaicDropsOnlyThatMosaic() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        URL granule = new URL("file:/data/g.tif");
+        BufferedImage dummy = new BufferedImage(1, 1, BufferedImage.TYPE_3BYTE_BGR);
+        cache.getOrLoad(new ImageCacheKey("mosaicA", granule, 0, null), () -> dummy);
+        cache.getOrLoad(new ImageCacheKey("mosaicA", granule, 1, null), () -> dummy);
+        cache.getOrLoad(new ImageCacheKey("mosaicB", granule, 0, null), () -> dummy);
+        assertEquals(3, cache.size());
+
+        cache.invalidateMosaic("mosaicA");
+        assertEquals("only mosaicA's entries should be dropped", 1, cache.size());
+    }
+
+    @Test
+    public void testReaderDisposeDropsItsCache() throws Exception {
+        GranuleImageCache cache = defaultCache();
+        ImageMosaicReader reader = reader(cache);
+        read(reader, true, -1).dispose(true);
+        assertTrue(cache.size() > 0);
+
+        // disposing the reader (e.g. on a store reload, remove or reset) must free its cached granules
+        reader.dispose();
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    public void testCachedReadMatchesUncached() throws Exception {
+        GridCoverage2D uncached = withReader(reader(null), r -> {
+            return read(r, false, -1);
+        });
+
+        GranuleImageCache cache = defaultCache();
+        ImageMosaicReader reader = reader(cache);
+        try {
+            RenderedImage expected = uncached.getRenderedImage();
+            // first read populates the cache, second is served from it: both must match the uncached output
+            GridCoverage2D miss = read(reader, true, -1);
+            ImageAssert.assertEquals(expected, miss.getRenderedImage(), 0);
+            GridCoverage2D hit = read(reader, true, -1);
+            ImageAssert.assertEquals(expected, hit.getRenderedImage(), 0);
+            assertTrue(cache.size() > 0);
+            miss.dispose(true);
+            hit.dispose(true);
+        } finally {
+            reader.dispose();
+            uncached.dispose(true);
+        }
+    }
+
+    /** A 64 MB pool with a 10 MB per-granule default, big enough that the test granules are always cached. */
+    private static GranuleImageCache defaultCache() {
+        return new GuavaGranuleImageCache(64 * MB, 10 * MB);
+    }
+
+    @FunctionalInterface
+    private interface ReaderTask {
+        void accept(ImageMosaicReader reader) throws Exception;
+    }
+
+    /** Runs the task against the reader and disposes the reader afterwards, even on failure. */
+    private static void withReader(ImageMosaicReader reader, ReaderTask task) throws Exception {
+        try {
+            task.accept(reader);
+        } finally {
+            reader.dispose();
+        }
+    }
+
+    @FunctionalInterface
+    private interface ReaderFunction<R> {
+        R apply(ImageMosaicReader reader) throws Exception;
+    }
+
+    /**
+     * Returns the task result, disposing the reader afterwards even on failure; the result must not hold the reader.
+     */
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // actually used by PMD cannot see it
+    private static <R> R withReader(ImageMosaicReader reader, ReaderFunction<R> task) throws Exception {
+        try {
+            return task.apply(reader);
+        } finally {
+            reader.dispose();
+        }
+    }
+
+    private ImageMosaicReader reader(GranuleImageCache cache) throws Exception {
+        URL rgb = TestData.url(this, "rgb");
+        Hints hints = cache == null ? null : new Hints(Hints.GRANULE_IMAGE_CACHE, cache);
+        return new ImageMosaicFormat().getReader(rgb, hints);
+    }
+
+    private GridCoverage2D read(ImageMosaicReader reader, boolean cacheGranules, int thresholdKB) throws Exception {
+        ParameterValue<Boolean> cache = ImageMosaicFormat.CACHE_GRANULES.createValue();
+        cache.setValue(cacheGranules);
+        ParameterValue<Integer> threshold = ImageMosaicFormat.GRANULE_CACHE_THRESHOLD_KB.createValue();
+        threshold.setValue(thresholdKB);
+        return reader.read(new GeneralParameterValue[] {cache, threshold});
+    }
+
+    private GridCoverage2D readDirect(ImageMosaicReader reader, boolean cacheGranules) throws Exception {
+        ParameterValue<Boolean> cache = ImageMosaicFormat.CACHE_GRANULES.createValue();
+        cache.setValue(cacheGranules);
+        ParameterValue<Boolean> useImageN = AbstractGridFormat.USE_IMAGEN_IMAGEREAD.createValue();
+        useImageN.setValue(false); // ReadType.DIRECT_READ
+        return reader.read(new GeneralParameterValue[] {cache, useImageN});
+    }
+}

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageCacheClipperTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageCacheClipperTest.java
@@ -1,0 +1,98 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+import java.io.File;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
+import javax.imageio.stream.ImageInputStream;
+import org.geotools.image.test.ImageAssert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Confirms {@link ImageCacheClipper} reproduces exactly what a real {@link ImageReader} would decode. */
+public class ImageCacheClipperTest {
+
+    private static final int WIDTH = 64;
+    private static final int HEIGHT = 48;
+
+    private static File file;
+    private static BufferedImage full;
+
+    @BeforeClass
+    public static void writeSourceImage() throws Exception {
+        BufferedImage image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_3BYTE_BGR);
+        for (int y = 0; y < HEIGHT; y++) {
+            for (int x = 0; x < WIDTH; x++) {
+                image.setRGB(x, y, ((x * 3) & 0xFF) << 16 | ((y * 5) & 0xFF) << 8 | ((x + y) & 0xFF));
+            }
+        }
+        file = File.createTempFile("clipper", ".png");
+        file.deleteOnExit();
+        ImageIO.write(image, "png", file);
+        full = ImageIO.read(file);
+    }
+
+    @Test
+    public void testFullRegionReturnsSameImage() {
+        assertEquals(full, ImageCacheClipper.clip(full, new Rectangle(0, 0, WIDTH, HEIGHT), 1, 1));
+    }
+
+    @Test
+    public void testCropOnly() throws Exception {
+        assertMatchesReader(new Rectangle(10, 8, 20, 16), 1, 1);
+    }
+
+    @Test
+    public void testSubsamplingOnly() throws Exception {
+        assertMatchesReader(new Rectangle(0, 0, WIDTH, HEIGHT), 3, 2);
+    }
+
+    @Test
+    public void testCropAndSubsampling() throws Exception {
+        assertMatchesReader(new Rectangle(7, 5, 40, 30), 4, 3);
+    }
+
+    private void assertMatchesReader(Rectangle region, int ssx, int ssy) throws Exception {
+        RenderedImage expected = readWithReader(region, ssx, ssy);
+        RenderedImage actual = ImageCacheClipper.clip(full, region, ssx, ssy);
+        assertEquals(expected.getWidth(), actual.getWidth());
+        assertEquals(expected.getHeight(), actual.getHeight());
+        ImageAssert.assertEquals(expected, actual, 0);
+    }
+
+    private RenderedImage readWithReader(Rectangle region, int ssx, int ssy) throws Exception {
+        try (ImageInputStream iis = ImageIO.createImageInputStream(file)) {
+            ImageReader reader = ImageIO.getImageReaders(iis).next();
+            reader.setInput(iis);
+            ImageReadParam param = reader.getDefaultReadParam();
+            param.setSourceRegion(region);
+            param.setSourceSubsampling(ssx, ssy, 0, 0);
+            try {
+                return reader.read(0, param);
+            } finally {
+                reader.dispose();
+            }
+        }
+    }
+}

--- a/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageCacheKeyTest.java
+++ b/modules/plugin/imagemosaic/src/test/java/org/geotools/gce/imagemosaic/ImageCacheKeyTest.java
@@ -1,0 +1,114 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.gce.imagemosaic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.Test;
+
+public class ImageCacheKeyTest {
+
+    private static final String MOSAIC_A = "file:/mosaic/a";
+    private static final String MOSAIC_B = "file:/mosaic/b";
+    private static final URL URL_A = url("file:/data/a.tif");
+    private static final URL URL_B = url("file:/data/b.tif");
+
+    @Test
+    public void testEqualKeys() {
+        ImageCacheKey k1 = new ImageCacheKey(MOSAIC_A, URL_A, 0, new int[] {0, 1, 2});
+        ImageCacheKey k2 = new ImageCacheKey(MOSAIC_A, URL_A, 0, new int[] {0, 1, 2});
+        assertEquals(k1, k2);
+        assertEquals(k1.hashCode(), k2.hashCode());
+    }
+
+    @Test
+    public void testDifferentMosaicId() {
+        assertNotEquals(new ImageCacheKey(MOSAIC_A, URL_A, 0, null), new ImageCacheKey(MOSAIC_B, URL_A, 0, null));
+    }
+
+    @Test
+    public void testDifferentUrl() {
+        assertNotEquals(new ImageCacheKey(MOSAIC_A, URL_A, 0, null), new ImageCacheKey(MOSAIC_A, URL_B, 0, null));
+    }
+
+    @Test
+    public void testDifferentImageIndex() {
+        assertNotEquals(new ImageCacheKey(MOSAIC_A, URL_A, 0, null), new ImageCacheKey(MOSAIC_A, URL_A, 1, null));
+    }
+
+    @Test
+    public void testDifferentBands() {
+        assertNotEquals(
+                new ImageCacheKey(MOSAIC_A, URL_A, 0, new int[] {0}),
+                new ImageCacheKey(MOSAIC_A, URL_A, 0, new int[] {1}));
+    }
+
+    @Test
+    public void testSameGranule() {
+        ImageCacheKey key = new ImageCacheKey(MOSAIC_A, URL_A, 0, null);
+        assertTrue(key.sameGranule(URL_A));
+        assertFalse(key.sameGranule(URL_B));
+        assertFalse(key.sameGranule(null));
+    }
+
+    @Test
+    public void testSameMosaic() {
+        ImageCacheKey key = new ImageCacheKey(MOSAIC_A, URL_A, 0, null);
+        assertTrue(key.sameMosaic(MOSAIC_A));
+        assertFalse(key.sameMosaic(MOSAIC_B));
+    }
+
+    @Test
+    public void testEligibleWithinThreshold() {
+        // 10x10 RGB = 300 bytes, pool default 1 KB -> eligible
+        GranuleImageCache cache = new GuavaGranuleImageCache(1024 * 1024, 1024);
+        BufferedImage sm = new BufferedImage(10, 10, BufferedImage.TYPE_3BYTE_BGR);
+        assertTrue(ImageCacheKey.isCacheable(
+                cache, -1, new Rectangle(0, 0, 10, 10), new int[] {0, 1, 2}, sm.getSampleModel()));
+    }
+
+    @Test
+    public void testTooLargeForPoolDefault() {
+        // 100x100 RGB = 30000 bytes > 1 KB default -> not eligible
+        GranuleImageCache cache = new GuavaGranuleImageCache(1024 * 1024, 1024);
+        BufferedImage sm = new BufferedImage(100, 100, BufferedImage.TYPE_3BYTE_BGR);
+        assertFalse(ImageCacheKey.isCacheable(cache, -1, new Rectangle(0, 0, 100, 100), null, sm.getSampleModel()));
+    }
+
+    @Test
+    public void testThresholdOverrideWidensEligibility() {
+        GranuleImageCache cache = new GuavaGranuleImageCache(1024 * 1024, 1024);
+        BufferedImage sm = new BufferedImage(100, 100, BufferedImage.TYPE_3BYTE_BGR);
+        // 30000 bytes fits a 64 KB override
+        assertTrue(ImageCacheKey.isCacheable(cache, 64, new Rectangle(0, 0, 100, 100), null, sm.getSampleModel()));
+    }
+
+    private static URL url(String spec) {
+        try {
+            return new URL(spec);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}


### PR DESCRIPTION
[![GEOT-7932](https://badgen.net/badge/JIRA/GEOT-7932/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7932) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

34.x backport of #5758 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 