### PR TITLE
[CI] Handle errors when checking out integration build PR in workflow

### DIFF
--- a/.github/workflows/integration-qa.yml
+++ b/.github/workflows/integration-qa.yml
@@ -61,7 +61,7 @@ jobs:
             pr_num=$(printf '%s' "$PR_BODY" | grep -oiP "downstream\s+${label}\s+PR:\s*#?\K[0-9]+" | head -1 || true)
             if [ -n "$pr_num" ]; then
               echo "Explicit downstream PR for ${label}: #${pr_num}"
-              gh pr checkout "$pr_num"
+              gh pr checkout "$pr_num" || true
               return
             fi
             if git ls-remote --heads origin "refs/heads/$BRANCH_NAME" | grep -q .; then


### PR DESCRIPTION
Add error handling to PR checkout command.

Because the PR body has an instructional  comment that triggers this script, a GeoTools PR will fail unless you are "lucky" that it happens to exist.

see eg. https://github.com/geotools/geotools/actions/runs/29824458995/job/88652900437?pr=5773

<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Downstream integration builds: if this change needs matching PRs in GeoWebCache,
GeoServer or mapfish-print-v2 to compile or pass tests, add one line per companion so
the integration workflow checks out that PR instead of the default branch:
Downstream GeoWebCache PR: 1234
Downstream GeoServer PR: 5678
Downstream mapfish-print-v2 PR: 9012
Otherwise the workflow uses a companion branch with the same name as this PR's branch,
or the default branch. -->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->