### PR TITLE
[GEOT-7937]: DGGSFeatureCollection geometryless visitor handling

### DIFF
--- a/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/DGGSFeatureCollection.java
+++ b/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/DGGSFeatureCollection.java
@@ -84,6 +84,7 @@ public class DGGSFeatureCollection<I> implements SimpleFeatureCollection {
         // if the visitor is geometryless, we can delegate to the underlying collection
         if (isGeometryless(visitor, getSchema())) {
             delegate.accepts(visitor, progress);
+            return;
         }
 
         // special case for aggregate visitors grouping on geometry (need to map the geometry to zone ids)

--- a/modules/unsupported/dggs/dggs-core/src/test/java/org/geotools/dggs/DGGSFeatureCollectionTest.java
+++ b/modules/unsupported/dggs/dggs-core/src/test/java/org/geotools/dggs/DGGSFeatureCollectionTest.java
@@ -1,0 +1,79 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.dggs;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.Map;
+import org.geotools.api.feature.simple.SimpleFeature;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.dggs.datastore.DGGSDataStore;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.visitor.Aggregate;
+import org.geotools.feature.visitor.CountVisitor;
+import org.geotools.feature.visitor.GroupByVisitor;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DGGSFeatureCollectionTest {
+
+    private static final FilterFactory FF = CommonFactoryFinder.getFilterFactory();
+
+    private SimpleFeatureType delegateSchema;
+    private SimpleFeatureType dggsSchema;
+    private DGGSFeatureCollection<String> collection;
+
+    @Before
+    public void setup() throws Exception {
+        delegateSchema = DataUtilities.createType("delegated", "zone:String,category:String,value:Integer");
+        dggsSchema = DataUtilities.createType(
+                "dggs", "zone:String,category:String,value:Integer," + DGGSDataStore.GEOMETRY + ":Polygon");
+        SimpleFeature[] features = {
+            SimpleFeatureBuilder.build(delegateSchema, new Object[] {"A", "one", 10}, "fid.1"),
+            SimpleFeatureBuilder.build(delegateSchema, new Object[] {"B", "two", 20}, "fid.2")
+        };
+        SimpleFeatureCollection delegate = DataUtilities.collection(features);
+        collection = new DGGSFeatureCollection<>(delegate, dggsSchema, "zone", null);
+    }
+
+    @Test
+    public void testGeometrylessCountVisitorIsDelegatedOnce() throws Exception {
+        CountVisitor visitor = new CountVisitor();
+
+        collection.accepts(visitor, null);
+
+        assertEquals(2, visitor.getCount());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testGeometrylessGroupByVisitorIsDelegated() throws Exception {
+        GroupByVisitor visitor = new GroupByVisitor(
+                Aggregate.SUM, FF.property("value"), Collections.singletonList(FF.property("category")), null);
+
+        collection.accepts(visitor, null);
+
+        Map<Object, Object> result = visitor.getResult().toMap();
+        assertEquals(10, result.get(Collections.singletonList("one")));
+        assertEquals(20, result.get(Collections.singletonList("two")));
+    }
+}


### PR DESCRIPTION
[![GEOT-7937](https://badgen.net/badge/JIRA/GEOT-7937/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7937) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Downstream integration builds: if this change needs matching PRs in GeoWebCache,
GeoServer or mapfish-print-v2 to compile or pass tests, add one line per companion so
the integration workflow checks out that PR instead of the default branch:
Downstream GeoWebCache PR: 1234
Downstream GeoServer PR: 5678
Downstream mapfish-print-v2 PR: 9012
Otherwise the workflow uses a companion branch with the same name as this PR's branch,
or the default branch. -->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 