### PR TITLE
[GEOT-7940]:bbox and property selection not working together

### DIFF
--- a/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/datastore/DGGSFeatureSourceImpl.java
+++ b/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/datastore/DGGSFeatureSourceImpl.java
@@ -42,6 +42,7 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.crs.ForceCoordinateSystemFeatureResults;
 import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.data.store.ReTypingFeatureCollection;
 import org.geotools.data.store.ReprojectingFeatureCollection;
 import org.geotools.dggs.DGGSFeatureCollection;
 import org.geotools.dggs.DGGSInstance;
@@ -209,16 +210,26 @@ public class DGGSFeatureSourceImpl<I> implements DGGSFeatureSource<I> {
     public SimpleFeatureCollection getFeatures(Query query) throws IOException {
         DGGSQuerySplitter.PrePost split = splitter.split(query);
 
-        SimpleFeatureCollection result = delegate.getFeatures(split.pre);
         String[] propertyNames = query.getPropertyNames();
-        // need to wrap only if the geometry property is requested
-        if (propertyNames == null
-                || Arrays.stream(propertyNames).anyMatch(n -> GEOMETRY.equals(n) || DEFAULT_GEOMETRY.equals(n))) {
-            SimpleFeatureType outputSchema = getSchema();
-            if (propertyNames != null) {
-                outputSchema = SimpleFeatureTypeBuilder.retype(getSchema(), propertyNames);
+        // geometry is virtual: compute it whenever explicitly requested, or whenever a
+        // post-filter (e.g. bbox) needs to evaluate it, even if the caller's property
+        // selection did not ask for geometry in the output
+        boolean geometryRequested = propertyNames == null
+                || Arrays.stream(propertyNames).anyMatch(n -> GEOMETRY.equals(n) || DEFAULT_GEOMETRY.equals(n));
+        boolean needsGeometry = geometryRequested || split.post != Filter.INCLUDE;
+        if (needsGeometry && propertyNames != null) {
+            String zoneIdAttribute = dataStore.getZoneIdAttribute();
+            String[] delegateProperties = split.pre.getPropertyNames();
+            if (delegateProperties != null && Arrays.stream(delegateProperties).noneMatch(zoneIdAttribute::equals)) {
+                String[] expandedProperties = Arrays.copyOf(delegateProperties, delegateProperties.length + 1);
+                expandedProperties[delegateProperties.length] = zoneIdAttribute;
+                split.pre.setPropertyNames(expandedProperties);
             }
-            result = new DGGSFeatureCollection<>(result, outputSchema, dataStore.getZoneIdAttribute(), getDGGS());
+        }
+
+        SimpleFeatureCollection result = delegate.getFeatures(split.pre);
+        if (needsGeometry) {
+            result = new DGGSFeatureCollection<>(result, getSchema(), dataStore.getZoneIdAttribute(), getDGGS());
         }
         if (split.post != Filter.INCLUDE) {
             result = new FilteringSimpleFeatureCollection(result, split.post);
@@ -228,6 +239,12 @@ public class DGGSFeatureSourceImpl<I> implements DGGSFeatureSource<I> {
         } else if (delegate.getDataStore() instanceof Wrapper w && w.isWrapperFor(JDBCDataStore.class)) {
             JDBCDataStore jdbcDataStore = w.unwrap(JDBCDataStore.class);
             result = new AggregatorCollection(result, jdbcDataStore, new Query(split.pre), getSchema());
+        }
+        // drop back down to what the caller actually asked for (e.g. geometry pulled in
+        // above only to satisfy the post-filter, but not part of the requested properties)
+        if (propertyNames != null && (needsGeometry && !geometryRequested)) {
+            SimpleFeatureType outputSchema = SimpleFeatureTypeBuilder.retype(getSchema(), propertyNames);
+            result = new ReTypingFeatureCollection(result, outputSchema);
         }
         result = reprojectFeatureCollection(result, query);
         return result;

--- a/modules/unsupported/dggs/dggs-h3/src/test/java/org/geotools/dggs/h3/H3DGGSDelegateDatastoreTest.java
+++ b/modules/unsupported/dggs/dggs-h3/src/test/java/org/geotools/dggs/h3/H3DGGSDelegateDatastoreTest.java
@@ -27,13 +27,16 @@ import java.util.HashMap;
 import java.util.Map;
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.Query;
+import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
+import org.geotools.data.DataUtilities;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.dggs.datastore.DGGSDataStore;
 import org.geotools.dggs.datastore.DGGSStoreFactory;
 import org.geotools.dggs.gstore.DGGSFeatureSource;
 import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,6 +89,52 @@ public class H3DGGSDelegateDatastoreTest extends H3DGGSInstanceTest {
             SimpleFeatureCollection above20 = source.getFeatures(landcoverQuery);
             assertEquals(25, above20.size());
 
+        } finally {
+            if (datastore != null) {
+                datastore.dispose();
+            }
+        }
+    }
+
+    @Test
+    public void testDelegateDatastoreBBoxWithPropertySelection() throws IOException, URISyntaxException {
+        DGGSStoreFactory factory = new DGGSStoreFactory();
+        URL resource = getClass().getResource("/org/geotools/dggs/h3/localsample.parquet");
+        File file = new File(resource.toURI());
+        String dataUri = file.toURI().toASCIIString();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(DGGSStoreFactory.ZONE_ID_COLUMN_NAME.key, "h3indexstr");
+        params.put(DGGSStoreFactory.RESOLUTION.key, "10");
+        params.put(DGGSStoreFactory.DGGS_FACTORY_ID.key, "H3");
+        params.put(DGGSStoreFactory.DELEGATE_PREFIX + "dbtype", "geoparquet");
+        params.put(DGGSStoreFactory.DELEGATE_PREFIX + "uri", dataUri);
+        DGGSDataStore<?> datastore = null;
+        try {
+            datastore = (DGGSDataStore<?>) factory.createDataStore(params);
+            String typeName = datastore.getTypeNames()[0];
+            DGGSFeatureSource<?> source = datastore.getFeatureSource(typeName);
+
+            SimpleFeatureCollection all = source.getFeatures();
+            int expectedCount = all.size();
+            ReferencedEnvelope bounds = DataUtilities.bounds(all);
+            Filter bboxFilter = FF.bbox(FF.property(""), bounds);
+
+            // bbox alone (full property set, geometry included): must match every feature
+            Query bboxOnly = new Query(typeName, bboxFilter);
+            assertEquals(expectedCount, source.getFeatures(bboxOnly).size());
+
+            // bbox + property selection that excludes geometry: must still match every
+            // feature, geometry is only needed internally to evaluate the bbox post-filter
+            Query bboxWithProperties = new Query(typeName, bboxFilter);
+            bboxWithProperties.setPropertyNames("landcover");
+            SimpleFeatureCollection restricted = source.getFeatures(bboxWithProperties);
+            assertEquals(expectedCount, restricted.size());
+
+            // and the output schema must honor the requested property selection
+            SimpleFeatureType resultSchema = restricted.getSchema();
+            assertEquals(1, resultSchema.getAttributeCount());
+            assertEquals("landcover", resultSchema.getDescriptor(0).getLocalName());
         } finally {
             if (datastore != null) {
                 datastore.dispose();


### PR DESCRIPTION
[![GEOT-7940](https://badgen.net/badge/JIRA/GEOT-7940/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7940) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Downstream integration builds: if this change needs matching PRs in GeoWebCache,
GeoServer or mapfish-print-v2 to compile or pass tests, add one line per companion so
the integration workflow checks out that PR instead of the default branch:
Downstream GeoWebCache PR: <number>
Downstream GeoServer PR: <number>
Downstream mapfish-print-v2 PR: <number>
Otherwise the workflow uses a companion branch with the same name as this PR's branch,
or the default branch. -->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 