### PR TITLE
PMTiles: upgrade to Tileverse 2.0.2

### DIFF
--- a/docs/user/unsupported/pmtiles.rst
+++ b/docs/user/unsupported/pmtiles.rst
@@ -28,8 +28,7 @@ Features
 - **Attribute Filters**: Filter data based on attribute values
 - **Vector Tiles**: Accesses Mapbox Vector Tile (MVT) data stored in PMTiles format
 - **Efficient Random Access**: Leverages PMTiles' optimized structure for fast tile retrieval
-- **Memory Caching**: Configurable in-memory caching with block alignment for performance optimization
-- **Block-Aligned Reads**: Optimizes cloud storage access with configurable block alignment
+- **Memory Caching**: Configurable in-memory caching of byte ranges for performance optimization
 
 How It Works
 ------------
@@ -46,7 +45,7 @@ The Range Reader library provides a unified interface for reading byte ranges fr
 
 - **Decorators**: Composable caching and optimization layers
 - **Authentication**: Flexible credential management for cloud storage and HTTP
-- **Performance**: Block-aligned reads and in-memory caching
+- **Performance**: In-memory caching of byte ranges
 
 Usage
 -----
@@ -91,8 +90,8 @@ Remote PMTiles with HTTP Basic Authentication
 
    Map<String, Object> params = new HashMap<>();
    params.put("pmtiles", "https://example.com/secure/data.pmtiles");
-   params.put("io.tileverse.rangereader.http.username", "myuser");
-   params.put("io.tileverse.rangereader.http.password", "mypassword");
+   params.put("storage.http.username", "myuser");
+   params.put("storage.http.password", "mypassword");
 
    DataStore store = DataStoreFinder.getDataStore(params);
 
@@ -103,7 +102,7 @@ Remote PMTiles with Bearer Token
 
    Map<String, Object> params = new HashMap<>();
    params.put("pmtiles", "https://example.com/secure/data.pmtiles");
-   params.put("io.tileverse.rangereader.http.bearer-token", "your-bearer-token");
+   params.put("storage.http.bearer-token", "your-bearer-token");
 
    DataStore store = DataStoreFinder.getDataStore(params);
 
@@ -114,9 +113,9 @@ AWS S3
 
    Map<String, Object> params = new HashMap<>();
    params.put("pmtiles", "s3://my-bucket/tiles/data.pmtiles");
-   params.put("io.tileverse.rangereader.s3.region", "us-west-2");
-   params.put("io.tileverse.rangereader.s3.aws-access-key-id", "AKIAIOSFODNN7EXAMPLE");
-   params.put("io.tileverse.rangereader.s3.aws-secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+   params.put("storage.s3.region", "us-west-2");
+   params.put("storage.s3.aws-access-key-id", "AKIAIOSFODNN7EXAMPLE");
+   params.put("storage.s3.aws-secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 
    DataStore store = DataStoreFinder.getDataStore(params);
 
@@ -127,7 +126,7 @@ Azure Blob Storage
 
    Map<String, Object> params = new HashMap<>();
    params.put("pmtiles", "https://myaccount.blob.core.windows.net/container/tiles/data.pmtiles");
-   params.put("io.tileverse.rangereader.azure.account-key", "BASE64_ENCODED_KEY");
+   params.put("storage.azure.account-key", "BASE64_ENCODED_KEY");
 
    DataStore store = DataStoreFinder.getDataStore(params);
 
@@ -138,9 +137,9 @@ Google Cloud Storage
 
    Map<String, Object> params = new HashMap<>();
    params.put("pmtiles", "https://storage.googleapis.com/my-bucket/tiles/data.pmtiles");
-   params.put("io.tileverse.rangereader.gcs.project-id", "my-project");
+   params.put("storage.gcs.project-id", "my-project");
    // Enable default credentials chain (looks for application default credentials)
-   params.put("io.tileverse.rangereader.gcs.default-credentials-chain", true);
+   params.put("storage.gcs.default-credentials-chain", true);
 
    DataStore store = DataStoreFinder.getDataStore(params);
 
@@ -151,12 +150,10 @@ With Caching and Optimization
 
    Map<String, Object> params = new HashMap<>();
    params.put("pmtiles", "s3://my-bucket/tiles/data.pmtiles");
-   params.put("io.tileverse.rangereader.s3.region", "us-west-2");
+   params.put("storage.s3.region", "us-west-2");
 
-   // Enable in-memory caching with block alignment
-   params.put("io.tileverse.rangereader.caching.enabled", true);
-   params.put("io.tileverse.rangereader.caching.blockaligned", true);
-   params.put("io.tileverse.rangereader.caching.blocksize", 65536); // 64 KB blocks
+   // Enable in-memory caching
+   params.put("storage.caching.enabled", true);
 
    DataStore store = DataStoreFinder.getDataStore(params);
 
@@ -166,76 +163,86 @@ Parameters
 Core Parameters
 ^^^^^^^^^^^^^^^
 
-====================================== ======== ========= =================================================================================================================================
-Parameter                              Type     Required  Description
-====================================== ======== ========= =================================================================================================================================
-**pmtiles**                            String   Yes       URI to a PMTiles file. Supports local files (file://), HTTP/HTTPS, AWS S3 (s3://), Azure Blob Storage, and Google Cloud Storage URLs
-**namespace**                          String   No        Namespace URI to use for features
-**io.tileverse.rangereader.provider**  String   No        Force a specific RangeReader provider (file, http, s3, azure, gcs)
-====================================== ======== ========= =================================================================================================================================
+==================== ====== ======== ====================================================================================================================================
+Parameter            Type   Required Description
+==================== ====== ======== ====================================================================================================================================
+**pmtiles**          String Yes      URI to a PMTiles file. Supports local files (file://), HTTP/HTTPS, AWS S3 (s3://), Azure Blob Storage, and Google Cloud Storage URLs
+**namespace**        String No       Namespace URI to use for features
+**storage.provider** String No       Force a specific storage provider (file, http, s3, azure, gcs)
+==================== ====== ======== ====================================================================================================================================
 
 HTTP/HTTPS Parameters
 ^^^^^^^^^^^^^^^^^^^^^
 
-======================================================== ======== ==================================================================================
-Parameter                                                Type     Description
-======================================================== ======== ==================================================================================
-**io.tileverse.rangereader.http.timeout-millis**         Integer  HTTP connection timeout in milliseconds
-**io.tileverse.rangereader.http.trust-all-certificates** Boolean  Trust all SSL/TLS certificates (use with caution, for development only)
-**io.tileverse.rangereader.http.username**               String   HTTP Basic Authentication username
-**io.tileverse.rangereader.http.password**               String   HTTP Basic Authentication password
-**io.tileverse.rangereader.http.bearer-token**           String   Bearer token for token-based authentication
-**io.tileverse.rangereader.http.api-key-headername**     String   Custom header name for API key authentication
-**io.tileverse.rangereader.http.api-key**                String   API key value
-**io.tileverse.rangereader.http.api-key-value-prefix**   String   Optional prefix for API key value (e.g., "Bearer " or "ApiKey ")
-======================================================== ======== ==================================================================================
+======================================= ======= =======================================================================
+Parameter                               Type    Description
+======================================= ======= =======================================================================
+**storage.http.timeout-millis**         Integer HTTP connection timeout in milliseconds
+**storage.http.trust-all-certificates** Boolean Trust all SSL/TLS certificates (use with caution, for development only)
+**storage.http.username**               String  HTTP Basic Authentication username
+**storage.http.password**               String  HTTP Basic Authentication password
+**storage.http.bearer-token**           String  Bearer token for token-based authentication
+**storage.http.api-key-headername**     String  Custom header name for API key authentication
+**storage.http.api-key**                String  API key value
+**storage.http.api-key-value-prefix**   String  Optional prefix for API key value (e.g., "Bearer " or "ApiKey ")
+======================================= ======= =======================================================================
 
 Memory Caching Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-================================================= ======== ===================================================================================
-Parameter                                         Type     Description
-================================================= ======== ===================================================================================
-**io.tileverse.rangereader.caching.enabled**      Boolean  Enable in-memory caching (default: false)
-**io.tileverse.rangereader.caching.blockaligned** Boolean  Apply block alignment for cached byte ranges (default: false)
-**io.tileverse.rangereader.caching.blocksize**    Integer  Cache block size in bytes, must be power of 2 (default: 65536 = 64 KB)
-================================================= ======== ===================================================================================
+=========================== ======= ========================================================
+Parameter                   Type    Description
+=========================== ======= ========================================================
+**storage.caching.enabled** Boolean Enable in-memory caching of byte ranges (default: false)
+=========================== ======= ========================================================
 
 AWS S3 Parameters
 ^^^^^^^^^^^^^^^^^
 
-================================================================== ======== =============================================================================================
-Parameter                                                          Type     Description
-================================================================== ======== =============================================================================================
-**io.tileverse.rangereader.s3.region**                             String   AWS region (e.g., us-west-2)
-**io.tileverse.rangereader.s3.aws-access-key-id**                  String   AWS access key ID
-**io.tileverse.rangereader.s3.aws-secret-access-key**              String   AWS secret access key
-**io.tileverse.rangereader.s3.use-default-credentials-provider**   Boolean  Use AWS default credentials provider chain (default: false)
-**io.tileverse.rangereader.s3.default-credentials-profile**        String   AWS credentials profile name to use
-**io.tileverse.rangereader.s3.force-path-style**                   Boolean  Enable S3 path style access for S3-compatible services like MinIO (default: false)
-================================================================== ======== =============================================================================================
+=============================================== ======= ===============================================================================================================================================
+Parameter                                       Type    Description
+=============================================== ======= ===============================================================================================================================================
+**storage.s3.region**                           String  AWS region (e.g., us-west-2)
+**storage.s3.endpoint**                         String  Custom S3 endpoint URL for S3-compatible services (e.g., http://localhost:9000 for MinIO); lets an s3://bucket/key URI target a non-AWS service
+**storage.s3.aws-access-key-id**                String  AWS access key ID
+**storage.s3.aws-secret-access-key**            String  AWS secret access key
+**storage.s3.anonymous**                        Boolean Anonymous (unsigned) access for public buckets (default: false)
+**storage.s3.requester-pays**                   Boolean Add the requester-pays header to bill the requester rather than the bucket owner (default: false)
+**storage.s3.use-default-credentials-provider** Boolean Use AWS default credentials provider chain (default: false)
+**storage.s3.default-credentials-profile**      String  AWS credentials profile name to use
+**storage.s3.force-path-style**                 Boolean Enable S3 path style access for S3-compatible services like MinIO; defaults to true when an endpoint override is in effect
+=============================================== ======= ===============================================================================================================================================
 
 Azure Blob Storage Parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-============================================== ======== ================================================================
-Parameter                                      Type     Description
-============================================== ======== ================================================================
-**io.tileverse.rangereader.azure.blob-name**   String   Set the blob name if the endpoint points to the account URL
-**io.tileverse.rangereader.azure.account-key** String   Azure storage account key
-**io.tileverse.rangereader.azure.sas-token**   String   Shared Access Signature (SAS) token
-============================================== ======== ================================================================
+=================================== ======= ====================================================================================================================================
+Parameter                           Type    Description
+=================================== ======= ====================================================================================================================================
+**storage.azure.blob-name**         String  Set the blob name if the endpoint points to the account URL
+**storage.azure.account-key**       String  Azure storage account key
+**storage.azure.sas-token**         String  Shared Access Signature (SAS) token
+**storage.azure.connection-string** String  Full Azure Storage connection string (common for Azurite / local development)
+**storage.azure.endpoint**          String  Custom Blob service endpoint URL; lets a short-form az://account/container URI target an emulator, sovereign cloud, or custom domain
+**storage.azure.anonymous**         Boolean Anonymous access for public containers (default: false)
+**storage.azure.max-retries**       Integer Maximum number of retry attempts for failed requests (default: 3)
+**storage.azure.retry-delay**       String  Initial retry backoff delay, ISO-8601 duration (default: PT4S)
+**storage.azure.max-retry-delay**   String  Maximum retry backoff delay, ISO-8601 duration (default: PT2M)
+**storage.azure.try-timeout**       String  Per-attempt request timeout, ISO-8601 duration (default: PT60S)
+=================================== ======= ====================================================================================================================================
 
 Google Cloud Storage Parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-========================================================== ======== ==============================================================
-Parameter                                                  Type     Description
-========================================================== ======== ==============================================================
-**io.tileverse.rangereader.gcs.project-id**                String   Google Cloud project ID
-**io.tileverse.rangereader.gcs.quota-project-id**          String   Quota project ID for billing purposes
-**io.tileverse.rangereader.gcs.default-credentials-chain** Boolean  Use default application credentials chain (default: false)
-========================================================== ======== ==============================================================
+========================================= ======= ======================================================================================================================
+Parameter                                 Type    Description
+========================================= ======= ======================================================================================================================
+**storage.gcs.project-id**                String  Google Cloud project ID
+**storage.gcs.quota-project-id**          String  Quota project ID for billing purposes
+**storage.gcs.user-project**              String  Billing project for Requester Pays buckets
+**storage.gcs.default-credentials-chain** Boolean Use default application credentials chain (default: false)
+**storage.gcs.endpoint**                  String  Custom GCS endpoint URL for emulators (e.g., http://localhost:4443 for fake-gcs-server); full URL, not a bare hostname
+========================================= ======= ======================================================================================================================
 
 Performance Optimization
 ------------------------
@@ -243,31 +250,20 @@ Performance Optimization
 Memory Caching Architecture
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For optimal performance with cloud storage, enable in-memory caching with block alignment::
+For optimal performance with cloud storage, enable in-memory caching::
 
    Client Request → Memory Cache (fast, configurable size)
-                 → Block Alignment (optimize read sizes)
                  → RangeReader (S3/Azure/HTTP/File)
+
+PMTiles is optimized for byte-range requests natively; enabling the memory cache is sufficient.
 
 Recommended Settings for Cloud Storage
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: java
 
-   // Enable memory cache with block alignment for optimal cloud storage performance
-   params.put("io.tileverse.rangereader.caching.enabled", true);
-   params.put("io.tileverse.rangereader.caching.blockaligned", true);
-   params.put("io.tileverse.rangereader.caching.blocksize", 65536); // 64 KB for cloud storage
-
-Block Alignment Strategy
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Block-aligned reads are particularly beneficial for cloud storage:
-
-- Reduces the number of HTTP requests
-- Aligns reads with cloud storage block boundaries
-- Trades slightly higher bandwidth for lower latency
-- Recommended block size: 64 KB for cloud, 4 KB for local files
+   // Enable memory cache for optimal cloud storage performance
+   params.put("storage.caching.enabled", true);
 
 PMTiles Format
 --------------

--- a/modules/unsupported/pmtiles/README.md
+++ b/modules/unsupported/pmtiles/README.md
@@ -18,24 +18,23 @@ The PMTiles DataStore provides read and query access to Protomaps PMTiles format
 - **Attribute Filters**: Filter data based on attribute values
 - **Vector Tiles**: Accesses Mapbox Vector Tile (MVT) data stored in PMTiles format
 - **Efficient Random Access**: Leverages PMTiles' optimized structure for fast tile retrieval
-- **Memory Caching**: Configurable in-memory caching with block alignment for performance optimization
-- **Block-Aligned Reads**: Optimizes cloud storage access with configurable block alignment
+- **Memory Caching**: Configurable in-memory caching for performance optimization
 
 ## How It Works
 
-Under the hood, this DataStore uses the [Tileverse PMTiles](https://github.com/tileverse/tileverse) library and the [Tileverse Range Reader](https://github.com/tileverse/tileverse) library to provide flexible, high-performance access to PMTiles files. The implementation:
+Under the hood, this DataStore uses the [Tileverse PMTiles](https://github.com/tileverse/tileverse) library and the [Tileverse Storage](https://github.com/tileverse/tileverse) library to provide flexible, high-performance access to PMTiles files. The implementation:
 
-1. Uses the Range Reader library to access PMTiles files from various sources (local, HTTP, S3, Azure, GCS)
+1. Uses the Storage library to access PMTiles files from various sources (local, HTTP, S3, Azure, GCS)
 2. Reads the PMTiles header and directory structure for efficient tile lookups
 3. Decodes Mapbox Vector Tiles (MVT) from the PMTiles archive
 4. Translates GeoTools queries to tile requests based on spatial bounds and zoom levels
 5. Provides a standard GeoTools DataStore interface for vector tile data
 
-The Range Reader library provides a unified interface for reading byte ranges from different storage backends, with support for:
+The Storage library provides a unified interface for reading byte ranges from different storage backends, with support for:
 
 - **Decorators**: Composable caching and optimization layers
 - **Authentication**: Flexible credential management for cloud storage and HTTP
-- **Performance**: Block-aligned reads and in-memory caching
+- **Performance**: In-memory caching of byte ranges
 
 ## Usage
 
@@ -75,8 +74,8 @@ DataStore store = DataStoreFinder.getDataStore(params);
 ```java
 Map<String, Object> params = new HashMap<>();
 params.put("pmtiles", "https://example.com/secure/data.pmtiles");
-params.put("io.tileverse.rangereader.http.username", "myuser");
-params.put("io.tileverse.rangereader.http.password", "mypassword");
+params.put("storage.http.username", "myuser");
+params.put("storage.http.password", "mypassword");
 
 DataStore store = DataStoreFinder.getDataStore(params);
 ```
@@ -86,7 +85,7 @@ DataStore store = DataStoreFinder.getDataStore(params);
 ```java
 Map<String, Object> params = new HashMap<>();
 params.put("pmtiles", "https://example.com/secure/data.pmtiles");
-params.put("io.tileverse.rangereader.http.bearer-token", "your-bearer-token");
+params.put("storage.http.bearer-token", "your-bearer-token");
 
 DataStore store = DataStoreFinder.getDataStore(params);
 ```
@@ -96,9 +95,9 @@ DataStore store = DataStoreFinder.getDataStore(params);
 ```java
 Map<String, Object> params = new HashMap<>();
 params.put("pmtiles", "s3://my-bucket/tiles/data.pmtiles");
-params.put("io.tileverse.rangereader.s3.region", "us-west-2");
-params.put("io.tileverse.rangereader.s3.aws-access-key-id", "AKIAIOSFODNN7EXAMPLE");
-params.put("io.tileverse.rangereader.s3.aws-secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+params.put("storage.s3.region", "us-west-2");
+params.put("storage.s3.aws-access-key-id", "AKIAIOSFODNN7EXAMPLE");
+params.put("storage.s3.aws-secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
 
 DataStore store = DataStoreFinder.getDataStore(params);
 ```
@@ -108,7 +107,7 @@ DataStore store = DataStoreFinder.getDataStore(params);
 ```java
 Map<String, Object> params = new HashMap<>();
 params.put("pmtiles", "https://myaccount.blob.core.windows.net/container/tiles/data.pmtiles");
-params.put("io.tileverse.rangereader.azure.account-key", "BASE64_ENCODED_KEY");
+params.put("storage.azure.account-key", "BASE64_ENCODED_KEY");
 
 DataStore store = DataStoreFinder.getDataStore(params);
 ```
@@ -118,9 +117,9 @@ DataStore store = DataStoreFinder.getDataStore(params);
 ```java
 Map<String, Object> params = new HashMap<>();
 params.put("pmtiles", "https://storage.googleapis.com/my-bucket/tiles/data.pmtiles");
-params.put("io.tileverse.rangereader.gcs.project-id", "my-project");
+params.put("storage.gcs.project-id", "my-project");
 // Enable default credentials chain (looks for application default credentials)
-params.put("io.tileverse.rangereader.gcs.default-credentials-chain", true);
+params.put("storage.gcs.default-credentials-chain", true);
 
 DataStore store = DataStoreFinder.getDataStore(params);
 ```
@@ -130,12 +129,10 @@ DataStore store = DataStoreFinder.getDataStore(params);
 ```java
 Map<String, Object> params = new HashMap<>();
 params.put("pmtiles", "s3://my-bucket/tiles/data.pmtiles");
-params.put("io.tileverse.rangereader.s3.region", "us-west-2");
+params.put("storage.s3.region", "us-west-2");
 
-// Enable in-memory caching with block alignment
-params.put("io.tileverse.rangereader.caching.enabled", true);
-params.put("io.tileverse.rangereader.caching.blockaligned", true);
-params.put("io.tileverse.rangereader.caching.blocksize", 65536); // 64 KB blocks
+// Enable in-memory caching
+params.put("storage.caching.enabled", true);
 
 DataStore store = DataStoreFinder.getDataStore(params);
 ```
@@ -148,84 +145,73 @@ DataStore store = DataStoreFinder.getDataStore(params);
 |-----------|------|----------|-------------|
 | **pmtiles** | String | Yes | URI to a PMTiles file. Supports local files (file://), HTTP/HTTPS, AWS S3 (s3://), Azure Blob Storage, and Google Cloud Storage URLs |
 | **namespace** | String | No | Namespace URI to use for features |
-| **io.tileverse.rangereader.provider** | String | No | Force a specific RangeReader provider (file, http, s3, azure, gcs) |
+| **storage.provider** | String | No | Force a specific storage provider (file, http, s3, azure, gcs) |
 
 ### HTTP/HTTPS Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **io.tileverse.rangereader.http.timeout-millis** | Integer | HTTP connection timeout in milliseconds |
-| **io.tileverse.rangereader.http.trust-all-certificates** | Boolean | Trust all SSL/TLS certificates (use with caution, for development only) |
-| **io.tileverse.rangereader.http.username** | String | HTTP Basic Authentication username |
-| **io.tileverse.rangereader.http.password** | String | HTTP Basic Authentication password |
-| **io.tileverse.rangereader.http.bearer-token** | String | Bearer token for token-based authentication |
-| **io.tileverse.rangereader.http.api-key-headername** | String | Custom header name for API key authentication |
-| **io.tileverse.rangereader.http.api-key** | String | API key value |
-| **io.tileverse.rangereader.http.api-key-value-prefix** | String | Optional prefix for API key value (e.g., "Bearer " or "ApiKey ") |
+| **storage.http.timeout-millis** | Integer | HTTP connection timeout in milliseconds |
+| **storage.http.trust-all-certificates** | Boolean | Trust all SSL/TLS certificates (use with caution, for development only) |
+| **storage.http.username** | String | HTTP Basic Authentication username |
+| **storage.http.password** | String | HTTP Basic Authentication password |
+| **storage.http.bearer-token** | String | Bearer token for token-based authentication |
+| **storage.http.api-key-headername** | String | Custom header name for API key authentication |
+| **storage.http.api-key** | String | API key value |
+| **storage.http.api-key-value-prefix** | String | Optional prefix for API key value (e.g., "Bearer " or "ApiKey ") |
 
 ### Memory Caching Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **io.tileverse.rangereader.caching.enabled** | Boolean | Enable in-memory caching (default: false) |
-| **io.tileverse.rangereader.caching.blockaligned** | Boolean | Apply block alignment for cached byte ranges (default: false) |
-| **io.tileverse.rangereader.caching.blocksize** | Integer | Cache block size in bytes, must be power of 2 (default: 65536 = 64 KB) |
+| **storage.caching.enabled** | Boolean | Enable in-memory caching (default: false) |
 
 ### AWS S3 Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **io.tileverse.rangereader.s3.region** | String | AWS region (e.g., us-west-2) |
-| **io.tileverse.rangereader.s3.aws-access-key-id** | String | AWS access key ID |
-| **io.tileverse.rangereader.s3.aws-secret-access-key** | String | AWS secret access key |
-| **io.tileverse.rangereader.s3.use-default-credentials-provider** | Boolean | Use AWS default credentials provider chain (default: false) |
-| **io.tileverse.rangereader.s3.default-credentials-profile** | String | AWS credentials profile name to use |
-| **io.tileverse.rangereader.s3.force-path-style** | Boolean | Enable S3 path style access for S3-compatible services like MinIO (default: false) |
+| **storage.s3.region** | String | AWS region (e.g., us-west-2) |
+| **storage.s3.aws-access-key-id** | String | AWS access key ID |
+| **storage.s3.aws-secret-access-key** | String | AWS secret access key |
+| **storage.s3.use-default-credentials-provider** | Boolean | Use AWS default credentials provider chain (default: false) |
+| **storage.s3.default-credentials-profile** | String | AWS credentials profile name to use |
+| **storage.s3.force-path-style** | Boolean | Enable S3 path style access for S3-compatible services like MinIO (default: false) |
 
 ### Azure Blob Storage Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **io.tileverse.rangereader.azure.blob-name** | String | Set the blob name if the endpoint points to the account URL |
-| **io.tileverse.rangereader.azure.account-key** | String | Azure storage account key |
-| **io.tileverse.rangereader.azure.sas-token** | String | Shared Access Signature (SAS) token |
+| **storage.azure.blob-name** | String | Set the blob name if the endpoint points to the account URL |
+| **storage.azure.account-key** | String | Azure storage account key |
+| **storage.azure.sas-token** | String | Shared Access Signature (SAS) token |
 
 ### Google Cloud Storage Parameters
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| **io.tileverse.rangereader.gcs.project-id** | String | Google Cloud project ID |
-| **io.tileverse.rangereader.gcs.quota-project-id** | String | Quota project ID for billing purposes |
-| **io.tileverse.rangereader.gcs.default-credentials-chain** | Boolean | Use default application credentials chain (default: false) |
+| **storage.gcs.project-id** | String | Google Cloud project ID |
+| **storage.gcs.quota-project-id** | String | Quota project ID for billing purposes |
+| **storage.gcs.default-credentials-chain** | Boolean | Use default application credentials chain (default: false) |
 
 ## Performance Optimization
 
 ### Memory Caching Architecture
 
-For optimal performance with cloud storage, enable in-memory caching with block alignment:
+For optimal performance with cloud storage, enable in-memory caching:
 
 ```
 Client Request → Memory Cache (fast, configurable size)
-              → Block Alignment (optimize read sizes)
-              → RangeReader (S3/Azure/HTTP/File)
+              → Storage Range Reader (S3/Azure/HTTP/File)
 ```
+
+PMTiles is optimized for byte-range requests natively; enabling the memory cache is sufficient.
 
 ### Recommended Settings for Cloud Storage
 
 ```java
-// Enable memory cache with block alignment for optimal cloud storage performance
-params.put("io.tileverse.rangereader.caching.enabled", true);
-params.put("io.tileverse.rangereader.caching.blockaligned", true);
-params.put("io.tileverse.rangereader.caching.blocksize", 65536); // 64 KB for cloud storage
+// Enable memory cache for optimal cloud storage performance
+params.put("storage.caching.enabled", true);
 ```
-
-### Block Alignment Strategy
-
-Block-aligned reads are particularly beneficial for cloud storage:
-- Reduces the number of HTTP requests
-- Aligns reads with cloud storage block boundaries
-- Trades slightly higher bandwidth for lower latency
-- Recommended block size: 64 KB for cloud, 4 KB for local files
 
 ## PMTiles Format
 
@@ -240,7 +226,7 @@ PMTiles is designed for efficient cloud-native tile serving:
 ## Implementation Notes
 
 - The DataStore is read-only (no writing capabilities)
-- All RangeReader implementations are thread-safe for concurrent server use
+- All storage range reader implementations are thread-safe for concurrent server use
 - Proper resource management: Use try-with-resources or call dispose() on the DataStore
 - The PMTiles directory is cached in memory for fast tile lookups
 - Tile data is decoded on-demand as features are requested
@@ -251,7 +237,6 @@ PMTiles is designed for efficient cloud-native tile serving:
 - Support for major cloud storage providers (S3, Azure, GCS)
 - Flexible HTTP authentication mechanisms
 - Multi-level caching for performance
-- Block-aligned reads for cloud optimization
 - Integration with GeoTools DataStore API
 - Spatial and attribute query support
 
@@ -270,11 +255,11 @@ PMTiles is designed for efficient cloud-native tile serving:
 
 - GeoTools Core modules
 - Tileverse PMTiles library (io.tileverse.pmtiles:tileverse-pmtiles)
-- Tileverse Range Reader library (io.tileverse.rangereader:tileverse-rangereader-all)
+- Tileverse Storage library (io.tileverse.storage:tileverse-storage-all)
 
 ## Resources
 
 - [PMTiles Specification](https://github.com/protomaps/PMTiles/blob/main/spec/v3/spec.md)
 - [Protomaps.com](https://protomaps.com/) - PMTiles hosting and tools
 - [Mapbox Vector Tiles Specification](https://github.com/mapbox/vector-tile-spec)
-- [Tileverse Range Reader](https://github.com/tileverse/tileverse-io)
+- [Tileverse Storage](https://github.com/tileverse/tileverse-io)

--- a/modules/unsupported/pmtiles/pom.xml
+++ b/modules/unsupported/pmtiles/pom.xml
@@ -49,7 +49,7 @@
   </developers>
 
   <properties>
-    <tileverse.version>1.4.0</tileverse.version>
+    <tileverse.version>2.0.2</tileverse.version>
   </properties>
   <!-- =========================================================== -->
   <!--     Dependency Mangement                                    -->
@@ -84,8 +84,8 @@
       <artifactId>tileverse-pmtiles</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.tileverse.rangereader</groupId>
-      <artifactId>tileverse-rangereader-all</artifactId>
+      <groupId>io.tileverse.storage</groupId>
+      <artifactId>tileverse-storage-all</artifactId>
     </dependency>
 
     <!-- test depedencies -->

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStore.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStore.java
@@ -18,7 +18,7 @@ package org.geotools.pmtiles.store;
 
 import io.tileverse.pmtiles.PMTilesReader;
 import io.tileverse.pmtiles.store.PMTilesVectorTileStore;
-import io.tileverse.rangereader.RangeReader;
+import io.tileverse.storage.RangeReader;
 import java.io.IOException;
 import java.util.logging.Level;
 import org.geotools.vectortiles.store.VectorTilesDataStore;

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStoreFactory.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/PMTilesDataStoreFactory.java
@@ -22,23 +22,18 @@ import io.tileverse.cache.CacheStats;
 import io.tileverse.io.ByteBufferPool;
 import io.tileverse.io.ByteBufferPool.PoolStatistics;
 import io.tileverse.pmtiles.PMTilesReader;
-import io.tileverse.rangereader.RangeReader;
-import io.tileverse.rangereader.RangeReaderFactory;
-import io.tileverse.rangereader.azure.AzureBlobRangeReaderProvider;
-import io.tileverse.rangereader.gcs.GoogleCloudStorageRangeReaderProvider;
-import io.tileverse.rangereader.http.HttpRangeReaderProvider;
-import io.tileverse.rangereader.s3.S3RangeReaderProvider;
-import io.tileverse.rangereader.spi.RangeReaderConfig;
-import io.tileverse.rangereader.spi.RangeReaderProvider;
+import io.tileverse.storage.StorageConfig;
+import io.tileverse.storage.StorageFactory;
+import io.tileverse.storage.azure.AzureBlobStorageProvider;
+import io.tileverse.storage.gcs.GoogleCloudStorageProvider;
+import io.tileverse.storage.http.HttpStorageProvider;
+import io.tileverse.storage.s3.S3StorageProvider;
+import io.tileverse.storage.spi.StorageProvider;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 import org.geotools.api.data.DataStore;
 import org.geotools.api.data.DataStoreFactorySpi;
 import org.geotools.api.data.Parameter;
@@ -54,8 +49,8 @@ import org.jspecify.annotations.NullMarked;
  * Factory for creating {@link PMTilesDataStore} instances.
  *
  * <p>This factory supports creating PMTiles datastores from various sources including local files, HTTP/HTTPS servers,
- * and cloud storage providers (AWS S3, Azure Blob Storage, Google Cloud Storage). It uses the Tileverse Range Reader
- * library's SPI mechanism to automatically select the appropriate {@link RangeReaderProvider} based on the URI scheme.
+ * and cloud storage providers (AWS S3, Azure Blob Storage, Google Cloud Storage). It uses the Tileverse Storage
+ * library's SPI mechanism to automatically select the appropriate {@link StorageProvider} based on the URI scheme.
  *
  * <p><b>Supported URI Schemes:</b>
  *
@@ -75,71 +70,66 @@ import org.jspecify.annotations.NullMarked;
  *   <li>{@linkplain #NAMESPACEP namespace} - Feature type namespace (optional)
  *   <li>{@linkplain #DISPLAY_TILE_SIZE displayTileSize} - Display tile size in pixels rendering clients use, defaults
  *       to {@value VectorTilesDataStore#DEFAULT_DISPLAY_TILE_SIZE}
- *   <li>{@linkplain #RANGEREADER_PROVIDER_ID io.tileverse.rangereader.provider} - Optionally force a specific
- *       {@code RangeReaderProvider} by its {@link RangeReaderProvider#getId() id}, defaults to automatic detection by
- *       {@link RangeReaderFactory#findBestProvider(io.tileverse.rangereader.spi.RangeReaderConfig)}
+ *   <li>{@linkplain #RANGEREADER_PROVIDER_ID storage.provider} - Optionally force a specific {@code StorageProvider} by
+ *       its {@link StorageProvider#getId() id}, defaults to automatic detection by
+ *       {@link StorageFactory#findProvider(StorageConfig)}
  *       <ul>
- *         <li>{@code http} for {@link HttpRangeReaderProvider}
- *         <li>{@code azure} for {@link AzureBlobRangeReaderProvider}
- *         <li>{@code s3} for {@link S3RangeReaderProvider}
- *         <li>{@code gcs} for {@link GoogleCloudStorageRangeReaderProvider}
+ *         <li>{@code http} for {@link HttpStorageProvider}
+ *         <li>{@code azure} for {@link AzureBlobStorageProvider}
+ *         <li>{@code s3} for {@link S3StorageProvider}
+ *         <li>{@code gcs} for {@link GoogleCloudStorageProvider}
  *       </ul>
  *   <li><strong>Caching parameters</strong>:
  *       <ul>
- *         <li>{@linkplain #MEMORY_CACHE_ENABLED io.tileverse.rangereader.caching.enabled} - Enable in-memory caching
+ *         <li>{@linkplain #MEMORY_CACHE_ENABLED storage.caching.enabled} - Enable in-memory caching
  *       </ul>
  *   <li><strong>HTTP(S) parameters</strong>:
  *       <ul>
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_CONNECTION_TIMEOUT_MILLIS
- *             io.tileverse.rangereader.http.timeout-millis} - HTTP connection timeout in milliseconds
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_TRUST_ALL_SSL_CERTIFICATES
- *             io.tileverse.rangereader.http.trust-all-certificates} - Trust all SSL/TLS certificates
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_AUTH_USERNAME io.tileverse.rangereader.http.username} - HTTP
- *             Basic Auth username
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_AUTH_PASSWORD io.tileverse.rangereader.http.password} - HTTP
- *             Basic Auth password
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_AUTH_BEARER_TOKEN io.tileverse.rangereader.http.bearer-token} -
- *             HTTP Bearer Token
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_AUTH_API_KEY_HEADERNAME
- *             io.tileverse.rangereader.http.api-key-headername} - API-Key header name
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_AUTH_API_KEY io.tileverse.rangereader.http.api-key} - API key
- *             value
- *         <li>{@linkplain HttpRangeReaderProvider#HTTP_AUTH_API_KEY_VALUE_PREFIX
- *             io.tileverse.rangereader.http.api-key-value-prefix} - API key value prefix
+ *         <li>{@linkplain HttpStorageProvider#HTTP_CONNECTION_TIMEOUT_MILLIS storage.http.timeout-millis} - HTTP
+ *             connection timeout in milliseconds
+ *         <li>{@linkplain HttpStorageProvider#HTTP_TRUST_ALL_SSL_CERTIFICATES storage.http.trust-all-certificates} -
+ *             Trust all SSL/TLS certificates
+ *         <li>{@linkplain HttpStorageProvider#HTTP_AUTH_USERNAME storage.http.username} - HTTP Basic Auth username
+ *         <li>{@linkplain HttpStorageProvider#HTTP_AUTH_PASSWORD storage.http.password} - HTTP Basic Auth password
+ *         <li>{@linkplain HttpStorageProvider#HTTP_AUTH_BEARER_TOKEN storage.http.bearer-token} - HTTP Bearer Token
+ *         <li>{@linkplain HttpStorageProvider#HTTP_AUTH_API_KEY_HEADERNAME storage.http.api-key-headername} - API-Key
+ *             header name
+ *         <li>{@linkplain HttpStorageProvider#HTTP_AUTH_API_KEY storage.http.api-key} - API key value
+ *         <li>{@linkplain HttpStorageProvider#HTTP_AUTH_API_KEY_VALUE_PREFIX storage.http.api-key-value-prefix} - API
+ *             key value prefix
  *       </ul>
  *   <li><strong>Azure Blob parameters</strong>:
  *       <ul>
- *         <li>{@linkplain AzureBlobRangeReaderProvider#AZURE_BLOB_NAME io.tileverse.rangereader.azure.blob-name} - Set
- *             the Azure blob name if the endpoint points to the account url
- *         <li>{@linkplain AzureBlobRangeReaderProvider#AZURE_ACCOUNT_KEY io.tileverse.rangereader.azure.account-key} -
- *             Azure Account access key
- *         <li>{@linkplain AzureBlobRangeReaderProvider#AZURE_SAS_TOKEN io.tileverse.rangereader.azure.sas-token} -
- *             Azure SAS token to use for authenticating requests
+ *         <li>{@linkplain AzureBlobStorageProvider#AZURE_BLOB_NAME storage.azure.blob-name} - Set the Azure blob name
+ *             if the endpoint points to the account url
+ *         <li>{@linkplain AzureBlobStorageProvider#AZURE_ACCOUNT_KEY storage.azure.account-key} - Azure Account access
+ *             key
+ *         <li>{@linkplain AzureBlobStorageProvider#AZURE_SAS_TOKEN storage.azure.sas-token} - Azure SAS token to use
+ *             for authenticating requests
  *       </ul>
  *   <li><strong>AWS S3 parameters</strong>:
  *       <ul>
- *         <li>{@linkplain S3RangeReaderProvider#S3_FORCE_PATH_STYLE io.tileverse.rangereader.s3.force-path-style} -
- *             Enable S3 path style access
- *         <li>{@linkplain S3RangeReaderProvider#S3_AWS_REGION io.tileverse.rangereader.s3.region} - Configure the
- *             region with which the AWS S3 SDK should communicate
- *         <li>{@linkplain S3RangeReaderProvider#S3_AWS_ACCESS_KEY_ID io.tileverse.rangereader.s3.aws-access-key-id} -
- *             AWS Access Key ID
- *         <li>{@linkplain S3RangeReaderProvider#S3_AWS_SECRET_ACCESS_KEY
- *             io.tileverse.rangereader.s3.aws-secret-access-key} - AWS Secret Access Key
- *         <li>{@linkplain S3RangeReaderProvider#S3_USE_DEFAULT_CREDENTIALS_PROVIDER
- *             io.tileverse.rangereader.s3.use-default-credentials-provider} - Use Default Credentials Provider
- *         <li>{@linkplain S3RangeReaderProvider#S3_DEFAULT_CREDENTIALS_PROFILE
- *             io.tileverse.rangereader.s3.default-credentials-profile} - Default Credentials Profile
+ *         <li>{@linkplain S3StorageProvider#S3_FORCE_PATH_STYLE storage.s3.force-path-style} - Enable S3 path style
+ *             access
+ *         <li>{@linkplain S3StorageProvider#S3_REGION storage.s3.region} - Configure the region with which the AWS S3
+ *             SDK should communicate
+ *         <li>{@linkplain S3StorageProvider#S3_ANONYMOUS storage.s3.anonymous} - Anonymous public access (skips
+ *             credential resolution; use for buckets like Overture Maps that allow unsigned reads)
+ *         <li>{@linkplain S3StorageProvider#S3_AWS_ACCESS_KEY_ID storage.s3.aws-access-key-id} - AWS Access Key ID
+ *         <li>{@linkplain S3StorageProvider#S3_AWS_SECRET_ACCESS_KEY storage.s3.aws-secret-access-key} - AWS Secret
+ *             Access Key
+ *         <li>{@linkplain S3StorageProvider#S3_USE_DEFAULT_CREDENTIALS_PROVIDER
+ *             storage.s3.use-default-credentials-provider} - Use Default Credentials Provider
+ *         <li>{@linkplain S3StorageProvider#S3_DEFAULT_CREDENTIALS_PROFILE storage.s3.default-credentials-profile} -
+ *             Default Credentials Profile
  *       </ul>
  *   <li><strong>Google Cloud Storage parameters</strong>:
  *       <ul>
- *         <li>{@linkplain GoogleCloudStorageRangeReaderProvider#GCS_PROJECT_ID io.tileverse.rangereader.gcs.project-id}
- *             - Google Cloud project ID
- *         <li>{@linkplain GoogleCloudStorageRangeReaderProvider#GCS_QUOTA_PROJECT_ID
- *             io.tileverse.rangereader.gcs.quota-project-id} - Quota ProjectId that specifies the project used for
- *             quota and billing purposes
- *         <li>{@linkplain GoogleCloudStorageRangeReaderProvider#GCS_USE_DEFAULT_APPLICTION_CREDENTIALS} - Whether to
- *             use the default application credentials chain
+ *         <li>{@linkplain GoogleCloudStorageProvider#GCS_PROJECT_ID storage.gcs.project-id} - Google Cloud project ID
+ *         <li>{@linkplain GoogleCloudStorageProvider#GCS_QUOTA_PROJECT_ID storage.gcs.quota-project-id} - Quota
+ *             ProjectId that specifies the project used for quota and billing purposes
+ *         <li>{@linkplain GoogleCloudStorageProvider#GCS_USE_DEFAULT_APPLICTION_CREDENTIALS} - Whether to use the
+ *             default application credentials chain
  *       </ul>
  * </ul>
  *
@@ -198,17 +188,12 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
             .build();
 
     /**
-     * Optional parameter to force selecting a specific {@link RangeReaderProvider} by its
-     * {@link RangeReaderProvider#getId() id}
+     * Optional parameter to force selecting a specific {@link StorageProvider} by its {@link StorageProvider#getId()
+     * id}
      */
     public static final Param RANGEREADER_PROVIDER_ID = RangeReaderParams.RANGEREADER_PROVIDER_ID;
 
-    /**
-     * Enable memory cache for raw byte data.
-     *
-     * <p>{@link RangeReaderParams#MEMORY_CACHE_BLOCK_ALIGNED} and {@link RangeReaderParams#MEMORY_CACHE_BLOCK_SIZE} are
-     * not included because they don't make sense for PMTiles, which is optimized for byte-range requests natively
-     */
+    /** Enable memory cache for raw byte data. */
     public static final Param MEMORY_CACHE_ENABLED = RangeReaderParams.MEMORY_CACHE_ENABLED;
 
     public static final Param HTTP_CONNECTION_TIMEOUT_MILLIS = RangeReaderParams.HTTP_CONNECTION_TIMEOUT_MILLIS;
@@ -222,6 +207,8 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
 
     /** Set the blob name if the endpoint points to the account url */
     public static final Param AZURE_BLOB_NAME = RangeReaderParams.AZURE_BLOB_NAME;
+    /** Anonymous public access (Container- or Blob-level) - skips Azure credential resolution entirely */
+    public static final Param AZURE_ANONYMOUS = RangeReaderParams.AZURE_ANONYMOUS;
     /** Account access key */
     public static final Param AZURE_ACCOUNT_KEY = RangeReaderParams.AZURE_ACCOUNT_KEY;
     /** SAS token to use for authenticating requests */
@@ -231,6 +218,8 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
     public static final Param S3_FORCE_PATH_STYLE = RangeReaderParams.S3_FORCE_PATH_STYLE;
     /** Force an AWS region */
     public static final Param S3_AWS_REGION = RangeReaderParams.S3_AWS_REGION;
+    /** Anonymous public access - skips S3 credential resolution entirely */
+    public static final Param S3_ANONYMOUS = RangeReaderParams.S3_ANONYMOUS;
     /** AWS Access Key */
     public static final Param S3_AWS_ACCESS_KEY_ID = RangeReaderParams.S3_AWS_ACCESS_KEY_ID;
     /** AWS Secret Access Key */
@@ -315,20 +304,13 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
     }
 
     /**
-     * Dynamically builds the list of configuration parameters based on which {@link RangeReaderProvider}s are
-     * available.
+     * Dynamically builds the list of configuration parameters based on which {@link StorageProvider}s are available.
      *
      * @see RangeReaderParams#appendAfter(org.geotools.api.data.DataAccessFactory.Param...)
      */
     @Override
     public Param[] getParametersInfo() {
-        List<String> ignore = Stream.of(
-                        RangeReaderParams.MEMORY_CACHE_BLOCK_ALIGNED, RangeReaderParams.MEMORY_CACHE_BLOCK_SIZE)
-                .map(p -> p.key)
-                .toList();
-
-        Predicate<Param> filter = p -> !ignore.contains(p.key);
-        return RangeReaderParams.appendAfter(filter, NAMESPACEP, URIP, DISPLAY_TILE_SIZE);
+        return RangeReaderParams.appendAfter(NAMESPACEP, URIP, DISPLAY_TILE_SIZE);
     }
 
     @Override
@@ -338,7 +320,7 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
 
     @Override
     public boolean canProcess(java.util.Map<String, ?> params) {
-        params = RangeReaderConfig.normalizeKeys(params);
+        params = StorageConfig.normalizeKeys(params);
         boolean canProcess = DataStoreFactorySpi.super.canProcess(params);
         URI toURI;
         try {
@@ -373,19 +355,11 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
         return store;
     }
 
-    @SuppressWarnings("PMD.CloseResource")
     private PMTilesReader createPMTilesReader(Map<String, ?> params) throws IOException {
-        RangeReader reader = createRangeReader(params);
-        PMTilesReader pmTilesReader = new PMTilesReader(reader);
+        URI uri = lookup(URIP, params, URI.class);
+        PMTilesReader pmTilesReader = PMTilesReader.open(RangeReaderParams.toStorageConfig(uri, params));
         pmTilesReader.cacheManager(cacheManager);
         return pmTilesReader;
-    }
-
-    static RangeReader createRangeReader(Map<String, ?> params) throws IOException {
-        URI uri = lookup(URIP, params, URI.class);
-
-        Properties rangeReaderConfig = RangeReaderParams.toProperties(params);
-        return RangeReaderFactory.create(uri, rangeReaderConfig);
     }
 
     /**
@@ -401,7 +375,7 @@ public class PMTilesDataStoreFactory implements DataStoreFactorySpi {
             if (rawValue == null) {
                 lookUp = null;
             } else {
-                lookUp = RangeReaderConfig.convertToURI(rawValue);
+                lookUp = StorageConfig.convertToURI(rawValue);
             }
         } else {
             lookUp = param.lookUp(params);

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/package-info.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/pmtiles/store/package-info.java
@@ -60,8 +60,7 @@
  * // Create datastore from S3
  * Map<String, Object> params = new HashMap<>();
  * params.put("pmtiles", "s3://my-bucket/tiles.pmtiles");
- * params.put("io.tileverse.rangereader.caching.enabled", true);
- * params.put("io.tileverse.rangereader.caching.blockaligned", true);
+ * params.put("storage.caching.enabled", true);
  *
  * PMTilesDataStore datastore = PMTilesDataStoreFactory.INSTANCE.createDataStore(params);
  *
@@ -87,9 +86,7 @@
  *
  * <ul>
  *   <li><b>namespace</b>: Feature type namespace URI
- *   <li><b>io.tileverse.rangereader.caching.enabled</b>: Enable memory caching (default: false)
- *   <li><b>io.tileverse.rangereader.caching.blockaligned</b>: Use block-aligned caching (default: false)
- *   <li><b>io.tileverse.rangereader.caching.blocksize</b>: Cache block size in bytes
+ *   <li><b>storage.caching.enabled</b>: Enable memory caching (default: false)
  * </ul>
  *
  * <h3>Cloud Provider Authentication</h3>
@@ -110,7 +107,6 @@
  *
  * <ul>
  *   <li>Enable memory caching for frequently accessed data
- *   <li>Use block-aligned caching to align reads with tile boundaries
  *   <li>Provide resolution hints ({@link org.geotools.util.factory.Hints#GEOMETRY_DISTANCE}) for automatic zoom level
  *       selection
  *   <li>Use spatial filters (BBOX) to minimize tile reads

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/tileverse/rangereader/RangeReaderParams.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/tileverse/rangereader/RangeReaderParams.java
@@ -18,17 +18,18 @@
 package org.geotools.tileverse.rangereader;
 
 import com.google.api.client.util.store.DataStoreFactory;
-import io.tileverse.rangereader.RangeReaderFactory;
-import io.tileverse.rangereader.azure.AzureBlobRangeReaderProvider;
-import io.tileverse.rangereader.gcs.GoogleCloudStorageRangeReaderProvider;
-import io.tileverse.rangereader.http.HttpRangeReaderProvider;
-import io.tileverse.rangereader.s3.S3RangeReaderProvider;
-import io.tileverse.rangereader.spi.AbstractRangeReaderProvider;
-import io.tileverse.rangereader.spi.RangeReaderConfig;
-import io.tileverse.rangereader.spi.RangeReaderParameter;
-import io.tileverse.rangereader.spi.RangeReaderProvider;
+import io.tileverse.storage.StorageConfig;
+import io.tileverse.storage.StorageFactory;
+import io.tileverse.storage.StorageParameter;
+import io.tileverse.storage.azure.AzureBlobStorageProvider;
+import io.tileverse.storage.gcs.GoogleCloudStorageProvider;
+import io.tileverse.storage.http.HttpStorageProvider;
+import io.tileverse.storage.s3.S3StorageProvider;
+import io.tileverse.storage.spi.AbstractStorageProvider;
+import io.tileverse.storage.spi.StorageProvider;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -44,13 +45,13 @@ import org.geotools.util.Converters;
  * <p>This class converts between:
  *
  * <ul>
- *   <li>{@link RangeReaderParameter} - Tileverse Range Reader SPI configuration parameters
+ *   <li>{@link StorageParameter} - Tileverse Storage SPI configuration parameters
  *   <li>{@link Param} - GeoTools DataStore factory parameters
- *   <li>{@link Properties} - Configuration properties for {@link RangeReaderFactory}
+ *   <li>{@link Properties} - Configuration properties for {@link StorageFactory}
  * </ul>
  *
- * <p><b>Purpose:</b> The Tileverse Range Reader library uses an SPI mechanism with {@link RangeReaderProvider}s that
- * declare their configuration parameters. This class dynamically discovers all available providers and converts their
+ * <p><b>Purpose:</b> The Tileverse Storage library uses an SPI mechanism with {@link StorageProvider}s that declare
+ * their configuration parameters. This class dynamically discovers all available providers and converts their
  * parameters to GeoTools DataStore parameters, enabling seamless configuration through GeoServer or other GeoTools
  * applications.
  *
@@ -68,70 +69,77 @@ import org.geotools.util.Converters;
  * <pre>{@code
  * // In PMTilesDataStoreFactory
  * Map<String, Object> connectionParams = ...;
- * Properties rangeReaderConfig = RangeReaderParams.toProperties(connectionParams);
- * RangeReader reader = RangeReaderFactory.create(uri, rangeReaderConfig);
+ * Properties storageConfig = RangeReaderParams.toProperties(connectionParams);
+ * try (Storage storage = StorageFactory.open(parent, storageConfig);
+ *         RangeReader reader = storage.openRangeReader(key)) { ... }
  * }</pre>
  *
- * @see RangeReaderFactory
- * @see RangeReaderProvider
+ * @see StorageFactory
+ * @see StorageProvider
  * @see PMTilesDataStoreFactory
  */
 public class RangeReaderParams {
 
     /**
-     * Param {@link DataStoreFactory} can use to force selecting a specific {@link RangeReaderProvider} with
-     * {@link RangeReaderParams#toProperties(Map) toProperties(connectionParameters)} and used to obtain the range reder
-     * through {@link RangeReaderFactory#create(Properties)} or {@link RangeReaderConfig#fromProperties(Properties)}
+     * Param {@link DataStoreFactory} can use to force selecting a specific {@link StorageProvider} with
+     * {@link RangeReaderParams#toProperties(Map) toProperties(connectionParameters)} and used to obtain the storage
+     * through {@link StorageFactory#open(Properties)} or {@link StorageConfig#fromProperties(Properties)}
      */
-    public static final Param RANGEREADER_PROVIDER_ID = dataStoreParam(RangeReaderConfig.FORCE_PROVIDER_ID);
+    public static final Param RANGEREADER_PROVIDER_ID = dataStoreParam(StorageConfig.FORCE_PROVIDER_ID);
 
-    public static final Param MEMORY_CACHE_ENABLED = dataStoreParam(AbstractRangeReaderProvider.MEMORY_CACHE_ENABLED);
-    public static final Param MEMORY_CACHE_BLOCK_ALIGNED =
-            dataStoreParam(AbstractRangeReaderProvider.MEMORY_CACHE_BLOCK_ALIGNED);
-    public static final Param MEMORY_CACHE_BLOCK_SIZE =
-            dataStoreParam(AbstractRangeReaderProvider.MEMORY_CACHE_BLOCK_SIZE);
+    public static final Param MEMORY_CACHE_ENABLED = dataStoreParam(AbstractStorageProvider.MEMORY_CACHE_ENABLED);
 
     public static final Param HTTP_CONNECTION_TIMEOUT_MILLIS =
-            dataStoreParam(HttpRangeReaderProvider.HTTP_CONNECTION_TIMEOUT_MILLIS);
+            dataStoreParam(HttpStorageProvider.HTTP_CONNECTION_TIMEOUT_MILLIS);
     public static final Param HTTP_TRUST_ALL_SSL_CERTIFICATES =
-            dataStoreParam(HttpRangeReaderProvider.HTTP_TRUST_ALL_SSL_CERTIFICATES);
-    public static final Param HTTP_AUTH_USERNAME = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_USERNAME);
-    public static final Param HTTP_AUTH_PASSWORD = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_PASSWORD);
-    public static final Param HTTP_AUTH_BEARER_TOKEN = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_BEARER_TOKEN);
+            dataStoreParam(HttpStorageProvider.HTTP_TRUST_ALL_SSL_CERTIFICATES);
+    public static final Param HTTP_AUTH_USERNAME = dataStoreParam(HttpStorageProvider.HTTP_AUTH_USERNAME);
+    public static final Param HTTP_AUTH_PASSWORD = dataStoreParam(HttpStorageProvider.HTTP_AUTH_PASSWORD);
+    public static final Param HTTP_AUTH_BEARER_TOKEN = dataStoreParam(HttpStorageProvider.HTTP_AUTH_BEARER_TOKEN);
     public static final Param HTTP_AUTH_API_KEY_HEADERNAME =
-            dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_API_KEY_HEADERNAME);
-    public static final Param HTTP_AUTH_API_KEY = dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_API_KEY);
+            dataStoreParam(HttpStorageProvider.HTTP_AUTH_API_KEY_HEADERNAME);
+    public static final Param HTTP_AUTH_API_KEY = dataStoreParam(HttpStorageProvider.HTTP_AUTH_API_KEY);
     public static final Param HTTP_AUTH_API_KEY_VALUE_PREFIX =
-            dataStoreParam(HttpRangeReaderProvider.HTTP_AUTH_API_KEY_VALUE_PREFIX);
+            dataStoreParam(HttpStorageProvider.HTTP_AUTH_API_KEY_VALUE_PREFIX);
 
-    public static final Param AZURE_BLOB_NAME = dataStoreParam(AzureBlobRangeReaderProvider.AZURE_BLOB_NAME);
-    public static final Param AZURE_ACCOUNT_KEY = dataStoreParam(AzureBlobRangeReaderProvider.AZURE_ACCOUNT_KEY);
-    public static final Param AZURE_SAS_TOKEN = dataStoreParam(AzureBlobRangeReaderProvider.AZURE_SAS_TOKEN);
+    public static final Param AZURE_BLOB_NAME = dataStoreParam(AzureBlobStorageProvider.AZURE_BLOB_NAME);
+    public static final Param AZURE_ANONYMOUS = dataStoreParam(AzureBlobStorageProvider.AZURE_ANONYMOUS);
+    public static final Param AZURE_ACCOUNT_KEY = dataStoreParam(AzureBlobStorageProvider.AZURE_ACCOUNT_KEY);
+    public static final Param AZURE_SAS_TOKEN = dataStoreParam(AzureBlobStorageProvider.AZURE_SAS_TOKEN);
+    public static final Param AZURE_CONNECTION_STRING =
+            dataStoreParam(AzureBlobStorageProvider.AZURE_CONNECTION_STRING);
+    public static final Param AZURE_ENDPOINT = dataStoreParam(AzureBlobStorageProvider.AZURE_ENDPOINT);
+    public static final Param AZURE_MAX_RETRIES = dataStoreParam(AzureBlobStorageProvider.AZURE_MAX_RETRIES);
+    public static final Param AZURE_RETRY_DELAY = dataStoreParam(AzureBlobStorageProvider.AZURE_RETRY_DELAY);
+    public static final Param AZURE_MAX_RETRY_DELAY = dataStoreParam(AzureBlobStorageProvider.AZURE_MAX_RETRY_DELAY);
+    public static final Param AZURE_TRY_TIMEOUT = dataStoreParam(AzureBlobStorageProvider.AZURE_TRY_TIMEOUT);
 
-    public static final Param S3_FORCE_PATH_STYLE = dataStoreParam(S3RangeReaderProvider.S3_FORCE_PATH_STYLE);
-    public static final Param S3_AWS_REGION = dataStoreParam(S3RangeReaderProvider.S3_REGION);
-    public static final Param S3_AWS_ACCESS_KEY_ID = dataStoreParam(S3RangeReaderProvider.S3_AWS_ACCESS_KEY_ID);
-    public static final Param S3_AWS_SECRET_ACCESS_KEY = dataStoreParam(S3RangeReaderProvider.S3_AWS_SECRET_ACCESS_KEY);
+    public static final Param S3_FORCE_PATH_STYLE = dataStoreParam(S3StorageProvider.S3_FORCE_PATH_STYLE);
+    public static final Param S3_REQUESTER_PAYS = dataStoreParam(S3StorageProvider.S3_REQUESTER_PAYS);
+    public static final Param S3_ENDPOINT = dataStoreParam(S3StorageProvider.S3_ENDPOINT);
+    public static final Param S3_AWS_REGION = dataStoreParam(S3StorageProvider.S3_REGION);
+    public static final Param S3_ANONYMOUS = dataStoreParam(S3StorageProvider.S3_ANONYMOUS);
+    public static final Param S3_AWS_ACCESS_KEY_ID = dataStoreParam(S3StorageProvider.S3_AWS_ACCESS_KEY_ID);
+    public static final Param S3_AWS_SECRET_ACCESS_KEY = dataStoreParam(S3StorageProvider.S3_AWS_SECRET_ACCESS_KEY);
     public static final Param S3_USE_DEFAULT_CREDENTIALS_PROVIDER =
-            dataStoreParam(S3RangeReaderProvider.S3_USE_DEFAULT_CREDENTIALS_PROVIDER);
+            dataStoreParam(S3StorageProvider.S3_USE_DEFAULT_CREDENTIALS_PROVIDER);
     public static final Param S3_DEFAULT_CREDENTIALS_PROFILE =
-            dataStoreParam(S3RangeReaderProvider.S3_DEFAULT_CREDENTIALS_PROFILE);
+            dataStoreParam(S3StorageProvider.S3_DEFAULT_CREDENTIALS_PROFILE);
 
-    public static final Param GCS_PROJECT_ID = dataStoreParam(GoogleCloudStorageRangeReaderProvider.GCS_PROJECT_ID);
-    public static final Param GCS_QUOTA_PROJECT_ID =
-            dataStoreParam(GoogleCloudStorageRangeReaderProvider.GCS_QUOTA_PROJECT_ID);
+    public static final Param GCS_PROJECT_ID = dataStoreParam(GoogleCloudStorageProvider.GCS_PROJECT_ID);
+    public static final Param GCS_QUOTA_PROJECT_ID = dataStoreParam(GoogleCloudStorageProvider.GCS_QUOTA_PROJECT_ID);
+    public static final Param GCS_USER_PROJECT = dataStoreParam(GoogleCloudStorageProvider.GCS_USER_PROJECT);
     public static final Param GCS_USE_DEFAULT_APPLICTION_CREDENTIALS =
-            dataStoreParam(GoogleCloudStorageRangeReaderProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS);
+            dataStoreParam(GoogleCloudStorageProvider.GCS_USE_DEFAULT_APPLICTION_CREDENTIALS);
+    public static final Param GCS_ENDPOINT = dataStoreParam(GoogleCloudStorageProvider.GCS_ENDPOINT);
 
     /**
-     * Aggregated list of supported {@link RangeReaderProvider#getParameters() range reader parameters} converted to
+     * Aggregated list of supported {@link StorageProvider#getParameters() storage provider parameters} converted to
      * {@link Param DataAccessFactory.Param}
      */
     public static final List<Param> PROVIDER_PARAMS = List.of(
             RANGEREADER_PROVIDER_ID,
             MEMORY_CACHE_ENABLED,
-            MEMORY_CACHE_BLOCK_ALIGNED,
-            MEMORY_CACHE_BLOCK_SIZE,
             HTTP_CONNECTION_TIMEOUT_MILLIS,
             HTTP_TRUST_ALL_SSL_CERTIFICATES,
             HTTP_AUTH_USERNAME,
@@ -141,56 +149,80 @@ public class RangeReaderParams {
             HTTP_AUTH_API_KEY,
             HTTP_AUTH_API_KEY_VALUE_PREFIX,
             AZURE_BLOB_NAME,
+            AZURE_ANONYMOUS,
             AZURE_ACCOUNT_KEY,
             AZURE_SAS_TOKEN,
+            AZURE_CONNECTION_STRING,
+            AZURE_ENDPOINT,
+            AZURE_MAX_RETRIES,
+            AZURE_RETRY_DELAY,
+            AZURE_MAX_RETRY_DELAY,
+            AZURE_TRY_TIMEOUT,
             S3_FORCE_PATH_STYLE,
+            S3_REQUESTER_PAYS,
+            S3_ENDPOINT,
             S3_AWS_REGION,
+            S3_ANONYMOUS,
             S3_AWS_ACCESS_KEY_ID,
             S3_AWS_SECRET_ACCESS_KEY,
             S3_USE_DEFAULT_CREDENTIALS_PROVIDER,
             S3_DEFAULT_CREDENTIALS_PROFILE,
             GCS_PROJECT_ID,
             GCS_QUOTA_PROJECT_ID,
-            GCS_USE_DEFAULT_APPLICTION_CREDENTIALS);
+            GCS_USER_PROJECT,
+            GCS_USE_DEFAULT_APPLICTION_CREDENTIALS,
+            GCS_ENDPOINT);
 
     private RangeReaderParams() {
         // private constructor, utility class
     }
 
     /**
-     * Appends Range Reader configuration parameters after the specified datastore parameters.
+     * Appends all storage configuration parameters after the specified datastore parameters.
      *
-     * <p>This method is used by {@link PMTilesDataStoreFactory#getParametersInfo()} to dynamically include all Range
-     * Reader configuration parameters based on available providers.
+     * <p>This method is used by {@link PMTilesDataStoreFactory#getParametersInfo()} to dynamically include all storage
+     * configuration parameters based on available providers.
+     *
+     * @param dataStoreParams the base datastore parameters (e.g., URI, namespace)
+     * @return array combining datastore parameters followed by all storage parameters
+     */
+    public static Param[] appendAfter(Param... dataStoreParams) {
+        return appendAfter(param -> true, dataStoreParams);
+    }
+
+    /**
+     * Appends storage configuration parameters after the specified datastore parameters.
+     *
+     * <p>This method is used by {@link PMTilesDataStoreFactory#getParametersInfo()} to dynamically include all storage
+     * configuration parameters based on available providers.
      *
      * @param filter a filter predicate to apply in case some parameters need to be excluded
      * @param dataStoreParams the base datastore parameters (e.g., URI, namespace)
-     * @return array combining datastore parameters followed by all Range Reader parameters
+     * @return array combining datastore parameters followed by all storage parameters
      */
     public static Param[] appendAfter(Predicate<Param> filter, Param... dataStoreParams) {
-        List<Param> rangeReaderParams = PROVIDER_PARAMS;
-        return Stream.concat(
-                        Stream.of(dataStoreParams), rangeReaderParams.stream().filter(filter))
+        List<Param> storageParams = PROVIDER_PARAMS;
+        return Stream.concat(Stream.of(dataStoreParams), storageParams.stream().filter(filter))
                 .toArray(Param[]::new);
     }
 
     /**
-     * Converts a {@link RangeReaderParameter} to a GeoTools {@link Param}.
+     * Converts a {@link StorageParameter} to a GeoTools {@link Param}.
      *
      * <p>This conversion handles:
      *
      * <ul>
-     *   <li>Key mapping from Range Reader parameter keys
+     *   <li>Key mapping from storage parameter keys
      *   <li>Type conversion to GeoTools-compatible types
      *   <li>Default values and sample values
      *   <li>Parameter groups (basic vs advanced)
      *   <li>Descriptions and titles for UI display
      * </ul>
      *
-     * @param param the Range Reader parameter to convert
+     * @param param the storage parameter to convert
      * @return the equivalent GeoTools Param
      */
-    public static Param dataStoreParam(RangeReaderParameter<?> param) {
+    public static Param dataStoreParam(StorageParameter<?> param) {
         Object defaultValue = param.defaultValue().orElse(null);
         List<?> sampleValues = param.sampleValues();
         Object[] options = sampleValues.isEmpty() ? null : sampleValues.toArray();
@@ -211,10 +243,11 @@ public class RangeReaderParams {
     }
 
     /**
-     * Converts DataStore connection parameters to Range Reader configuration properties.
+     * Converts DataStore connection parameters to storage configuration properties.
      *
-     * <p>This method extracts all Range Reader-related parameters from the DataStore connection parameters map and
-     * converts them to a {@link Properties} object suitable for passing to {@link RangeReaderFactory#create}.
+     * <p>This method extracts all storage-related parameters from the DataStore connection parameters map and converts
+     * them to a {@link Properties} object suitable for passing to {@link StorageFactory#open(java.net.URI,
+     * Properties)}.
      *
      * <p>The conversion includes:
      *
@@ -231,10 +264,13 @@ public class RangeReaderParams {
      *
      * @param connectionParams the DataStore connection parameters (from
      *     {@link PMTilesDataStoreFactory#createDataStore})
-     * @return properties object suitable for {@link RangeReaderFactory#create}
+     * @return properties object suitable for {@link StorageFactory#open(java.net.URI, Properties)}
      */
     public static Properties toProperties(Map<String, ?> connectionParams) {
-        Map<String, Object> normalized = RangeReaderConfig.normalizeKeys(connectionParams);
+        // Rewrite any legacy io.tileverse.rangereader.* keys into the canonical storage.* form;
+        // Param.lookUp is keyed off param.key(), now storage.*, and would otherwise miss values
+        // persisted in older GeoServer catalogs.
+        Map<String, Object> normalized = StorageConfig.normalizeKeys(connectionParams);
         Properties configOpts = new Properties();
         addProperty(RANGEREADER_PROVIDER_ID, normalized, configOpts);
         PROVIDER_PARAMS.forEach(param -> addProperty(param, normalized, configOpts));
@@ -252,5 +288,17 @@ public class RangeReaderParams {
             String val = Converters.convert(lookUp, String.class);
             configOpts.setProperty(param.key, val);
         }
+    }
+
+    /**
+     * Builds a {@link StorageConfig} addressing {@code uri} as the leaf object, with backend-specific tuning taken from
+     * GeoTools connection {@code params}. Pass the result to {@code PMTilesReader.open(StorageConfig)} or
+     * {@code VersatilesReader.open(StorageConfig)}; the reader owns the resulting {@code Storage} and
+     * {@code RangeReader} and closes both.
+     */
+    public static StorageConfig toStorageConfig(URI uri, Map<String, ?> params) {
+        Properties merged = toProperties(params);
+        merged.setProperty(StorageConfig.URI_KEY, uri.toString());
+        return StorageConfig.fromProperties(merged);
     }
 }

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesDataStore.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesDataStore.java
@@ -19,7 +19,7 @@ package org.geotools.vectortiles.store;
 import static java.util.Objects.requireNonNull;
 
 import io.tileverse.jackson.databind.tilejson.v3.VectorLayer;
-import io.tileverse.pmtiles.store.VectorTileStore;
+import io.tileverse.vectortile.store.VectorTileStore;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/VectorTilesFeatureSource.java
@@ -24,15 +24,15 @@ import static org.geotools.util.factory.Hints.GEOMETRY_GENERALIZATION;
 import static org.geotools.util.factory.Hints.JTS_COORDINATE_SEQUENCE_FACTORY;
 import static org.geotools.util.factory.Hints.JTS_GEOMETRY_FACTORY;
 
+import io.tileverse.geom.BoundingBox2D;
 import io.tileverse.jackson.databind.tilejson.v3.VectorLayer;
-import io.tileverse.pmtiles.store.VectorTileStore;
-import io.tileverse.pmtiles.store.VectorTilesQuery;
-import io.tileverse.tiling.common.BoundingBox2D;
 import io.tileverse.tiling.matrix.TileMatrixSet;
 import io.tileverse.tiling.store.TileStore;
 import io.tileverse.tiling.store.TileStore.Strategy;
 import io.tileverse.vectortile.model.VectorTile;
 import io.tileverse.vectortile.model.VectorTile.Layer.Feature;
+import io.tileverse.vectortile.store.VectorTileStore;
+import io.tileverse.vectortile.store.VectorTilesQuery;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -121,7 +121,7 @@ import org.locationtech.jts.geom.util.AffineTransformation;
  *
  * @see VectorTilesDataStore
  * @see VectorTilesFeatureReader
- * @see io.tileverse.pmtiles.store.VectorTileStore
+ * @see io.tileverse.vectortile.store.VectorTileStore
  */
 public class VectorTilesFeatureSource extends ContentFeatureSource {
 

--- a/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/package-info.java
+++ b/modules/unsupported/pmtiles/src/main/java/org/geotools/vectortiles/store/package-info.java
@@ -22,7 +22,7 @@
  *
  * <p>This package provides reusable abstractions for creating GeoTools DataStores that read vector tiles from tile
  * archives or services. While designed primarily for PMTiles, these abstractions can be used with any tiled vector data
- * source that implements the Tileverse {@link io.tileverse.pmtiles.store.VectorTileStore} interface.
+ * source that implements the Tileverse {@link io.tileverse.vectortile.store.VectorTileStore} interface.
  *
  * <h2>Architecture</h2>
  *
@@ -81,8 +81,8 @@
  *       pagination
  *   <li>{@link org.geotools.vectortiles.store.ExtractMultiBoundsFilterVisitor} - Extracts bounding boxes from complex
  *       filters as a list of individual envelopes from spatial predicates, for
- *       {@link io.tileverse.pmtiles.store.VectorTileStore} to skip tiles that would otherwise be included only as the
- *       result of union'ing all the bounding boxes in the GeoTools filter.
+ *       {@link io.tileverse.vectortile.store.VectorTileStore} to skip tiles that would otherwise be included only as
+ *       the result of union'ing all the bounding boxes in the GeoTools filter.
  *   <li>{@link org.geotools.vectortiles.store.VectorTilesFeaturePropertyAccessorFactory} - Property access for
  *       filtering at the {@link io.tileverse.vectortile.model.VectorTile.Layer.Feature vector tile} level
  * </ul>
@@ -182,7 +182,7 @@
  * <h2>Thread Safety</h2>
  *
  * <p>All classes in this package are designed for thread-safe concurrent access. The underlying
- * {@link io.tileverse.pmtiles.store.VectorTileStore} must also be thread-safe.
+ * {@link io.tileverse.vectortile.store.VectorTileStore} must also be thread-safe.
  *
  * <h2>Performance Considerations</h2>
  *
@@ -202,7 +202,7 @@
  *
  * @see org.geotools.vectortiles.store.VectorTilesDataStore
  * @see org.geotools.vectortiles.store.VectorTilesFeatureSource
- * @see io.tileverse.pmtiles.store.VectorTileStore
+ * @see io.tileverse.vectortile.store.VectorTileStore
  * @see <a href="https://github.com/mapbox/vector-tile-spec">Mapbox Vector Tile Specification</a>
  * @see <a href="https://github.com/mapbox/tilejson-spec">TileJSON Specification</a>
  */

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreFactoryTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreFactoryTest.java
@@ -30,11 +30,12 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Streams;
 import io.tileverse.pmtiles.PMTilesTestData;
-import io.tileverse.rangereader.azure.AzureBlobRangeReaderProvider;
-import io.tileverse.rangereader.gcs.GoogleCloudStorageRangeReaderProvider;
-import io.tileverse.rangereader.s3.S3RangeReaderProvider;
-import io.tileverse.rangereader.spi.AbstractRangeReaderProvider;
-import io.tileverse.rangereader.spi.RangeReaderParameter;
+import io.tileverse.storage.NotFoundException;
+import io.tileverse.storage.StorageParameter;
+import io.tileverse.storage.azure.AzureBlobStorageProvider;
+import io.tileverse.storage.gcs.GoogleCloudStorageProvider;
+import io.tileverse.storage.s3.S3StorageProvider;
+import io.tileverse.storage.spi.AbstractStorageProvider;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -99,19 +100,19 @@ public class PMTilesDataStoreFactoryTest {
     public void testGetParametersInfoS3() {
         Param[] parametersInfo = new PMTilesDataStoreFactory().getParametersInfo();
 
-        List<RangeReaderParameter<?>> s3Params = new S3RangeReaderProvider().getParameters();
-        assertTrue(s3Params.stream().anyMatch(p -> p.key().contains("io.tileverse.rangereader.s3.")));
+        List<StorageParameter<?>> s3Params = new S3StorageProvider().getParameters();
+        assertTrue(s3Params.stream().anyMatch(p -> p.key().contains("storage.s3.")));
         assertParams(s3Params, parametersInfo);
 
-        System.setProperty(S3RangeReaderProvider.ENABLED_KEY, "false");
+        System.setProperty(S3StorageProvider.ENABLED_KEY, "false");
         try {
             parametersInfo = new PMTilesDataStoreFactory().getParametersInfo();
-            List<RangeReaderParameter<?>> noS3Params = s3Params.stream()
-                    .filter(p -> !p.key().contains("io.tileverse.rangereader.s3."))
+            List<StorageParameter<?>> noS3Params = s3Params.stream()
+                    .filter(p -> !p.key().contains("storage.s3."))
                     .toList();
             assertParams(noS3Params, parametersInfo);
         } finally {
-            System.clearProperty(S3RangeReaderProvider.ENABLED_KEY);
+            System.clearProperty(S3StorageProvider.ENABLED_KEY);
         }
     }
 
@@ -119,19 +120,19 @@ public class PMTilesDataStoreFactoryTest {
     public void testGetParametersInfoAzureBlobStorage() {
         Param[] parametersInfo = new PMTilesDataStoreFactory().getParametersInfo();
 
-        List<RangeReaderParameter<?>> azureParams = new AzureBlobRangeReaderProvider().getParameters();
-        assertTrue(azureParams.stream().anyMatch(p -> p.key().contains("io.tileverse.rangereader.azure.")));
+        List<StorageParameter<?>> azureParams = new AzureBlobStorageProvider().getParameters();
+        assertTrue(azureParams.stream().anyMatch(p -> p.key().contains("storage.azure.")));
 
         assertParams(azureParams, parametersInfo);
-        System.setProperty(AzureBlobRangeReaderProvider.ENABLED_KEY, "false");
+        System.setProperty(AzureBlobStorageProvider.ENABLED_KEY, "false");
         try {
             parametersInfo = new PMTilesDataStoreFactory().getParametersInfo();
-            List<RangeReaderParameter<?>> noAzureParams = azureParams.stream()
-                    .filter(p -> !p.key().contains("io.tileverse.rangereader.azure."))
+            List<StorageParameter<?>> noAzureParams = azureParams.stream()
+                    .filter(p -> !p.key().contains("storage.azure."))
                     .toList();
             assertParams(noAzureParams, parametersInfo);
         } finally {
-            System.clearProperty(AzureBlobRangeReaderProvider.ENABLED_KEY);
+            System.clearProperty(AzureBlobStorageProvider.ENABLED_KEY);
         }
     }
 
@@ -139,39 +140,39 @@ public class PMTilesDataStoreFactoryTest {
     public void testGetParametersInfoGoogleCloudStorage() {
         Param[] parametersInfo = new PMTilesDataStoreFactory().getParametersInfo();
 
-        List<RangeReaderParameter<?>> gcsParams = new GoogleCloudStorageRangeReaderProvider().getParameters();
-        assertTrue(gcsParams.stream().anyMatch(p -> p.key().contains("io.tileverse.rangereader.gcs.")));
+        List<StorageParameter<?>> gcsParams = new GoogleCloudStorageProvider().getParameters();
+        assertTrue(gcsParams.stream().anyMatch(p -> p.key().contains("storage.gcs.")));
         assertParams(gcsParams, parametersInfo);
 
-        System.setProperty(GoogleCloudStorageRangeReaderProvider.ENABLED_KEY, "false");
+        System.setProperty(GoogleCloudStorageProvider.ENABLED_KEY, "false");
         try {
             parametersInfo = new PMTilesDataStoreFactory().getParametersInfo();
-            List<RangeReaderParameter<?>> noGCSParams = gcsParams.stream()
-                    .filter(p -> !p.key().contains("io.tileverse.rangereader.gcs."))
+            List<StorageParameter<?>> noGCSParams = gcsParams.stream()
+                    .filter(p -> !p.key().contains("storage.gcs."))
                     .toList();
             assertParams(noGCSParams, parametersInfo);
         } finally {
-            System.clearProperty(GoogleCloudStorageRangeReaderProvider.ENABLED_KEY);
+            System.clearProperty(GoogleCloudStorageProvider.ENABLED_KEY);
         }
     }
 
-    private void assertParams(List<RangeReaderParameter<?>> expected, Param[] actual) {
+    private void assertParams(List<StorageParameter<?>> expected, Param[] actual) {
         expected = new ArrayList<>(expected);
-        expected.remove(AbstractRangeReaderProvider.MEMORY_CACHE_BLOCK_ALIGNED);
-        expected.remove(AbstractRangeReaderProvider.MEMORY_CACHE_BLOCK_SIZE);
+        expected.remove(AbstractStorageProvider.MEMORY_CACHE_BLOCK_ALIGNED);
+        expected.remove(AbstractStorageProvider.MEMORY_CACHE_BLOCK_SIZE);
 
         List<Param> dataStoreParams = new ArrayList<>(Arrays.asList(actual));
         dataStoreParams.remove(URIP);
         dataStoreParams.remove(NAMESPACEP);
 
-        for (RangeReaderParameter<?> param : expected) {
+        for (StorageParameter<?> param : expected) {
             Param expectedParam = RangeReaderParams.dataStoreParam(param);
             assertTrue(dataStoreParams.contains(expectedParam));
         }
     }
 
     private void assertCachingParameters(Param[] parametersInfo) {
-        Predicate<? super Param> filter = p -> p.key.startsWith("io.tileverse.rangereader.caching.");
+        Predicate<? super Param> filter = p -> p.key.startsWith("storage.caching.");
         List<Param> cachingParams = Stream.of(parametersInfo).filter(filter).toList();
         List<Param> expected = List.of(RangeReaderParams.MEMORY_CACHE_ENABLED);
         assertEquals(expected, cachingParams);
@@ -190,13 +191,13 @@ public class PMTilesDataStoreFactoryTest {
 
         assertFalse(factory.canProcess(Map.of()));
         assertFalse(factory.canProcess(Map.of(URIP.key, "not a valid URI")));
-        assertFalse(factory.canProcess(Map.of(URIP.key + "1", andorra.toUri())));
+        assertFalse(factory.canProcess(Map.of(URIP.key + "1", andorra)));
 
         URI notfound = tmp.getRoot().toPath().resolve("notfound.pmtiles").toUri();
         assertTrue(factory.canProcess(Map.of(URIP.key, notfound)));
         assertTrue(factory.canProcess(Map.of(URIP.key, notfound, NAMESPACEP.key, "pmtiles.io")));
 
-        assertTrue("should support URI", factory.canProcess(Map.of(URIP.key, andorra.toUri())));
+        assertTrue("should support URI", factory.canProcess(Map.of(URIP.key, andorra)));
         assertTrue(
                 "should support String",
                 factory.canProcess(Map.of(URIP.key, andorra.toAbsolutePath().toString())));
@@ -231,7 +232,9 @@ public class PMTilesDataStoreFactoryTest {
     public void testCreateDataStoreNotFound() {
         PMTilesDataStoreFactory factory = new PMTilesDataStoreFactory();
         URI notfound = tmp.getRoot().toPath().resolve("notfound.pmtiles").toUri();
-        assertThrows(IOException.class, () -> factory.createDataStore(Map.of(URIP.key, notfound)));
+        // tileverse-storage 2.0 surfaces missing-key errors as unchecked NotFoundException (extends StorageException
+        // / RuntimeException) rather than IOException.
+        assertThrows(NotFoundException.class, () -> factory.createDataStore(Map.of(URIP.key, notfound)));
     }
 
     @Test
@@ -268,10 +271,9 @@ public class PMTilesDataStoreFactoryTest {
     }
 
     /**
-     * Forward compatibility check: a DataStoreInfo persisted by a future tileverse 2.x consumer (GeoServer 3.1+)
-     * carries connection parameters with the {@code storage.*} prefix. Tileverse 1.4 must still be able to create the
-     * store -- {@link RangeReaderParams#toProperties(Map)} translates the future prefix back to the canonical
-     * {@code io.tileverse.rangereader.*} form before lookup.
+     * Forward compatibility check: a DataStoreInfo persisted by a future tileverse consumer may include
+     * {@code storage.*} connection parameters this factory does not expose. Store creation must tolerate them --
+     * {@link RangeReaderParams#toProperties(Map)} passes them through for the storage provider to interpret or ignore.
      */
     @Test
     public void testCreateDataStoreWithFutureStorageKeys() throws IOException {
@@ -283,8 +285,8 @@ public class PMTilesDataStoreFactoryTest {
                 "file",
                 "storage.caching.enabled",
                 Boolean.TRUE,
-                "storage.caching.blocksize",
-                65536);
+                "storage.caching.futuresetting",
+                "some future value");
         PMTilesDataStore store = factory.createDataStore(params);
         try {
             assertNotNull(store);

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/pmtiles/store/PMTilesDataStoreTest.java
@@ -26,10 +26,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import io.tileverse.geom.BoundingBox2D;
 import io.tileverse.pmtiles.InvalidHeaderException;
 import io.tileverse.pmtiles.PMTilesReader;
 import io.tileverse.pmtiles.PMTilesTestData;
-import io.tileverse.tiling.common.BoundingBox2D;
 import io.tileverse.tiling.matrix.TileMatrix;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -79,7 +79,7 @@ public class PMTilesDataStoreTest {
     @Before
     public void setUp() throws IOException, InvalidHeaderException {
         Path andorraPMTiles = PMTilesTestData.andorra(tmpFolder.getRoot().toPath());
-        reader = new PMTilesReader(andorraPMTiles);
+        reader = PMTilesReader.open(andorraPMTiles.toUri());
         store = new PMTilesDataStore(new PMTilesDataStoreFactory(), reader);
         store.setNamespaceURI(namespaceURI);
         store.setFeatureTypeFactory(CommonFactoryFinder.getFeatureTypeFactory(null));

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/tileverse/rangereader/RangeReaderParamsTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/tileverse/rangereader/RangeReaderParamsTest.java
@@ -26,40 +26,39 @@ import java.util.Properties;
 import org.junit.Test;
 
 /**
- * Verifies that {@link RangeReaderParams#toProperties(Map)} accepts forward-compatible {@code storage.*} parameter keys
- * (canonical in tileverse 2.x) by translating them to the canonical {@code io.tileverse.rangereader.*} form tileverse
- * 1.4 understands.
+ * Verifies that {@link RangeReaderParams#toProperties(Map)} accepts pre-{@code storage.*} legacy parameter keys as
+ * emitted by existing GeoServer catalogs.
  */
 public class RangeReaderParamsTest {
 
     @Test
-    public void toPropertiesNormalizesFutureKeys() {
+    public void toPropertiesNormalizesLegacyKeys() {
         Map<String, Object> connectionParams = new HashMap<>();
         connectionParams.put("pmtiles", "file:///tmp/sample.pmtiles");
-        connectionParams.put("storage.provider", "file");
-        connectionParams.put("storage.caching.enabled", Boolean.TRUE);
-        connectionParams.put("storage.s3.region", "us-west-2");
+        connectionParams.put("io.tileverse.rangereader.provider", "file");
+        connectionParams.put("io.tileverse.rangereader.caching.enabled", Boolean.TRUE);
+        connectionParams.put("io.tileverse.rangereader.s3.region", "us-west-2");
 
         Properties props = RangeReaderParams.toProperties(connectionParams);
 
-        assertEquals("file", props.getProperty("io.tileverse.rangereader.provider"));
-        assertEquals("true", props.getProperty("io.tileverse.rangereader.caching.enabled"));
-        assertEquals("us-west-2", props.getProperty("io.tileverse.rangereader.s3.region"));
+        assertEquals("file", props.getProperty("storage.provider"));
+        assertEquals("true", props.getProperty("storage.caching.enabled"));
+        assertEquals("us-west-2", props.getProperty("storage.s3.region"));
         assertFalse(
-                "no storage.* keys should remain in the output",
-                props.stringPropertyNames().stream().anyMatch(k -> k.startsWith("storage.")));
+                "no legacy keys should remain in the output",
+                props.stringPropertyNames().stream().anyMatch(k -> k.startsWith("io.tileverse.rangereader.")));
     }
 
     @Test
     public void toPropertiesPassesCanonicalKeys() {
         Map<String, Object> connectionParams = new HashMap<>();
         connectionParams.put("pmtiles", "file:///tmp/sample.pmtiles");
-        connectionParams.put("io.tileverse.rangereader.provider", "file");
-        connectionParams.put("io.tileverse.rangereader.caching.enabled", Boolean.TRUE);
+        connectionParams.put("storage.provider", "file");
+        connectionParams.put("storage.caching.enabled", Boolean.TRUE);
 
         Properties props = RangeReaderParams.toProperties(connectionParams);
 
-        assertEquals("file", props.getProperty("io.tileverse.rangereader.provider"));
-        assertEquals("true", props.getProperty("io.tileverse.rangereader.caching.enabled"));
+        assertEquals("file", props.getProperty("storage.provider"));
+        assertEquals("true", props.getProperty("storage.caching.enabled"));
     }
 }

--- a/modules/unsupported/pmtiles/src/test/java/org/geotools/vectortiles/store/VectorTilesFeatureSourceTest.java
+++ b/modules/unsupported/pmtiles/src/test/java/org/geotools/vectortiles/store/VectorTilesFeatureSourceTest.java
@@ -47,7 +47,7 @@ public class VectorTilesFeatureSourceTest {
     @Before
     public void setUp() throws IOException {
         Path andorra = PMTilesTestData.andorra(tmpFolder.getRoot().toPath());
-        reader = new PMTilesReader(andorra);
+        reader = PMTilesReader.open(andorra.toUri());
         store = new PMTilesDataStore(new PMTilesDataStoreFactory(), reader);
         store.setNamespaceURI("http://test");
         store.setFeatureTypeFactory(CommonFactoryFinder.getFeatureTypeFactory(null));


### PR DESCRIPTION
Tileverse 2.0 replaces the rangereader library with the storage library.

The dependency moves from `tileverse-rangereader-all` to `tileverse-storage-all`, range readers are opened through the storage API, and connection parameter keys use the `storage.*` prefix, with legacy `io.tileverse.rangereader.*` keys from persisted configurations still accepted. Datastore behavior is unchanged.

Tileverse 2.0.1 makes block-aligned caching opt-in. The datastore keeps exposing only `storage.caching.enabled`; the blockaligned and blocksize parameters are no longer mentioned in the README, package javadoc, and user docs.

Tileverse 2.0.2 fixes support for strict S3 emulators due to AWS SDK 2.30+ default checksum behavior defaulting to enabled.

on-behalf-of: @camptocamp <info@camptocamp.com>

<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Downstream integration builds: if this change needs matching PRs in GeoWebCache,
GeoServer or mapfish-print-v2 to compile or pass tests, add one line per companion so
the integration workflow checks out that PR instead of the default branch:
Downstream GeoWebCache PR: <number>
Downstream GeoServer PR: <number>
Downstream mapfish-print-v2 PR: <number>
Otherwise the workflow uses a companion branch with the same name as this PR's branch,
or the default branch. -->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [ ] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->