### PR TITLE
Optimizations for raster reprojection

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/ReadResolutionCalculator.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/grid/io/ReadResolutionCalculator.java
@@ -129,12 +129,29 @@ public class ReadResolutionCalculator {
                 throw new UnsupportedOperationException(MessageFormat.format(ErrorKeys.UNSUPPORTED_OPERATION_$1, arg0));
             }
         } catch (Throwable e) {
-            if (LOGGER.isLoggable(Level.INFO)) LOGGER.log(Level.INFO, "Unable to compute requested resolution", e);
+            if (LOGGER.isLoggable(Level.INFO))
+                LOGGER.log(Level.INFO, "Unable to compute the accurate requested resolution", e);
         }
 
-        //
-        // use the coverage resolution since we cannot compute the requested one
-        //
+        // The accurate computation failed, fall back on the classic envelope based resolution:
+        // far better than the native one, which forces a full resolution read and downsampling.
+        // Skipped when the classic computation is the one that just failed, it is deterministic
+        // and would fail the same way. Any other failure still gets the fallback: the classic
+        // computation ignores the requested grid to world, so it can succeed where the branches
+        // above threw.
+        boolean classicAlreadyFailed = !accurateResolution
+                && destinationToSourceTransform != null
+                && !destinationToSourceTransform.isIdentity();
+        if (!classicAlreadyFailed) {
+            try {
+                return computeClassicResolution(readBounds);
+            } catch (RuntimeException e) {
+                if (LOGGER.isLoggable(Level.INFO))
+                    LOGGER.log(Level.INFO, "Unable to compute the classic requested resolution", e);
+            }
+        }
+
+        // last resort: nothing worked, read at the native resolution
         LOGGER.log(Level.WARNING, "Unable to compute requested resolution, the reader will pick the native one");
         return fullResolution;
     }
@@ -198,16 +215,18 @@ public class ReadResolutionCalculator {
                 points[k + 7] = y + resY / 2;
             }
         }
-        destinationToSourceTransform.transform(points, 0, points, 0, NPOINTS);
-
-        double minDistance = Double.MAX_VALUE;
-        for (int i = 0; i < points.length && minDistance > 0; i += 4) {
-            double dx = points[i + 2] - points[i];
-            double dy = points[i + 3] - points[i + 1];
-            double d = Math.sqrt(dx * dx + dy * dy);
-            if (d < minDistance) {
-                minDistance = d;
-            }
+        // One transform call for all the probes, the normal case. Only when it throws, which means
+        // at least one point falls outside the projection validity area, the points are transformed
+        // one segment at a time to find which ones can be kept.
+        double minDistance;
+        // a separate destination, the fallback needs the source points that a partial in place
+        // transform would have overwritten
+        double[] transformed = new double[points.length];
+        try {
+            destinationToSourceTransform.transform(points, 0, transformed, 0, NPOINTS);
+            minDistance = minSegmentLength(transformed);
+        } catch (TransformException e) {
+            minDistance = minSegmentLengthSkippingInvalid(points);
         }
 
         // reprojection can turn a segment into a zero length one
@@ -238,6 +257,59 @@ public class ReadResolutionCalculator {
         double minDistanceX = Math.max(limitResX, minDistance);
         double minDistanceY = Math.max(limitResY, minDistance);
         return new double[] {minDistanceX, minDistanceY};
+    }
+
+    /** Length of the shortest probe segment, over an array of already transformed point pairs. */
+    private static double minSegmentLength(double[] points) {
+        double min = Double.MAX_VALUE;
+        for (int i = 0; i < points.length && min > 0; i += 4) {
+            min = Math.min(min, segmentLength(points, i));
+        }
+        return min;
+    }
+
+    /**
+     * Length of the shortest probe segment when at least one point cannot be transformed: with projections not defined
+     * over the whole plane (e.g. geostationary, whose disc border is not transformable) the failing segments are
+     * skipped, so a tile straddling the border still uses the probe logic, and stays consistent with its fully interior
+     * neighbours.
+     *
+     * @throws TransformException if no segment at all could be transformed
+     */
+    private double minSegmentLengthSkippingInvalid(double[] points) throws TransformException {
+        double min = Double.MAX_VALUE;
+        double[] segment = new double[4];
+        int dropped = 0;
+        for (int i = 0; i < points.length && min > 0; i += 4) {
+            try {
+                destinationToSourceTransform.transform(points, i, segment, 0, 2);
+            } catch (TransformException e) {
+                // the exception carries no detail beyond "out of domain", the count is the signal
+                dropped++;
+                continue;
+            }
+            min = Math.min(min, segmentLength(segment, 0));
+        }
+        if (min == Double.MAX_VALUE) {
+            throw new TransformException("All resolution probe points fall outside the projection validity area");
+        }
+        // FINE, not INFO: a mosaic straddling the border hits this on every tile
+        if (LOGGER.isLoggable(Level.FINE)) {
+            LOGGER.fine("Skipped "
+                    + dropped
+                    + " of "
+                    + points.length / 4
+                    + " resolution probe segments falling outside the projection validity"
+                    + " area, resolution computed from the remaining ones");
+        }
+        return min;
+    }
+
+    /** Length of the segment held in {@code points} at {@code offset}, as two consecutive x/y pairs. */
+    private static double segmentLength(double[] points, int offset) {
+        double dx = points[offset + 2] - points[offset];
+        double dy = points[offset + 3] - points[offset + 1];
+        return Math.sqrt(dx * dx + dy * dy);
     }
 
     public boolean isAccurateResolution() {

--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/CoverageProcessor.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/CoverageProcessor.java
@@ -23,13 +23,12 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -153,7 +152,10 @@ public class CoverageProcessor {
      * not contains duplicated values. Note that while keys are {@link String} objects, the operation name are actually
      * case-insensitive because of the comparator used in the sorted map.
      */
-    private final Map<String, Operation> operations = Collections.synchronizedMap(new TreeMap<>(COMPARATOR));
+    private final Map<String, Operation> operations = new ConcurrentSkipListMap<>(COMPARATOR);
+
+    /** Set once {@link #scanForPlugins()} completed, gates the lock free {@link #operations} reads. */
+    private volatile boolean scanned;
 
     /**
      * The rendering hints for ImageN operations (never {@code null}). This field is usually given as argument to
@@ -364,28 +366,23 @@ public class CoverageProcessor {
      */
     protected void addOperation(final Operation operation) throws IllegalStateException {
         Utilities.ensureNonNull("operation", operation);
+        ensureScanned();
+        // the put/rollback in addOperation0 has to be atomic against a concurrent add
         synchronized (operations) {
-            if (operations.isEmpty()) {
-                scanForPlugins();
-            }
             addOperation0(operation);
         }
     }
 
     /**
-     * Removes the specified operation to this processor. This method is usually invoked at construction time before
-     * this processor is made accessible.
+     * Removes the specified operation from this processor. The removal is atomic, but it is not ordered against the
+     * put/rollback pair in {@link #addOperation(Operation)}: callers that may run concurrently with an operation being
+     * added have to serialize themselves.
      *
      * @param operation The operation to remove.
      */
     protected void removeOperation(final Operation operation) {
         Utilities.ensureNonNull("operation", operation);
-        synchronized (operations) {
-            if (operations.isEmpty()) {
-                return;
-            }
-            operations.remove(operation.getName().trim());
-        }
+        operations.remove(operation.getName().trim());
     }
 
     /**
@@ -407,12 +404,8 @@ public class CoverageProcessor {
      * as well as a list of its parameters.
      */
     public Collection<Operation> getOperations() {
-        synchronized (operations) {
-            if (operations.isEmpty()) {
-                scanForPlugins();
-            }
-            return operations.values();
-        }
+        ensureScanned();
+        return operations.values();
     }
 
     /**
@@ -425,15 +418,24 @@ public class CoverageProcessor {
     public Operation getOperation(String name) throws OperationNotFoundException {
         Utilities.ensureNonNull("name", name);
         name = name.trim();
+        ensureScanned();
+        final Operation operation = operations.get(name);
+        if (operation != null) {
+            return operation;
+        }
+        throw new OperationNotFoundException(MessageFormat.format(ErrorKeys.OPERATION_NOT_FOUND_$1, name));
+    }
+
+    /**
+     * Runs the lazy plugin scan once, and returns only once it completed: readers must not see a half populated map, so
+     * the map being non empty cannot be the signal, {@link #scanned} is.
+     */
+    private void ensureScanned() {
+        if (scanned) return;
         synchronized (operations) {
-            if (operations.isEmpty()) {
+            if (!scanned) {
                 scanForPlugins();
             }
-            final Operation operation = operations.get(name);
-            if (operation != null) {
-                return operation;
-            }
-            throw new OperationNotFoundException(MessageFormat.format(ErrorKeys.OPERATION_NOT_FOUND_$1, name));
         }
     }
 
@@ -545,6 +547,8 @@ public class CoverageProcessor {
                     .filter(operation ->
                             !operations.containsKey(operation.getName().trim()))
                     .forEach(this::addOperation0);
+            // written last: the volatile write publishes the operations added above
+            scanned = true;
         }
     }
 

--- a/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
+++ b/modules/library/coverage/src/main/java/org/geotools/image/ImageWorker.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.DoubleStream;
 import javax.imageio.IIOException;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -293,6 +294,15 @@ public class ImageWorker {
     static boolean WARP_REDUCTION_ENABLED =
             Boolean.parseBoolean(System.getProperty(WARP_REDUCTION_ENABLED_KEY, "TRUE"));
 
+    /** Controls the mosaic-crop reduction */
+    public static final String MOSAIC_CROP_REDUCTION_ENABLED_KEY = "org.geotools.image.reduceMosaicCrop";
+
+    static boolean MOSAIC_CROP_REDUCTION_ENABLED =
+            Boolean.parseBoolean(System.getProperty(MOSAIC_CROP_REDUCTION_ENABLED_KEY, "TRUE"));
+
+    private static final int LAYOUT_BOUNDS_MASK =
+            ImageLayout.MIN_X_MASK | ImageLayout.MIN_Y_MASK | ImageLayout.WIDTH_MASK | ImageLayout.HEIGHT_MASK;
+
     /**
      * Workaround class for compressing PNG using the default PNGImageEncoder shipped with the JDK.
      *
@@ -379,6 +389,7 @@ public class ImageWorker {
             GTWarpPropertyGenerator.register(false);
         }
         LOGGER.log(Level.INFO, "Warp/affine reduction enabled: " + WARP_REDUCTION_ENABLED);
+        LOGGER.log(Level.INFO, "Mosaic/crop reduction enabled: " + MOSAIC_CROP_REDUCTION_ENABLED);
         GTAffinePropertyGenerator.register(false);
     }
 
@@ -4306,6 +4317,26 @@ public class ImageWorker {
             }
         }
 
+        // Single image mosaic over a nodata driven crop? Such a crop is a mosaic itself (see
+        // cropNoData), so the two copy every tile in turn, a destination raster and a pixel
+        // copy each. Fuse them, only the nodata range has to move over.
+        boolean fusedCropNoData = false;
+        if (MOSAIC_CROP_REDUCTION_ENABLED
+                && nodata == null
+                && type == MosaicDescriptor.MOSAIC_TYPE_OVERLAY
+                && images != null
+                && images.length == 1
+                && images[0] instanceof RenderedOp crop) {
+            Range cropNoData = singleSourceNoData(crop, background);
+            // the mosaic must stay inside the crop, or pixels the crop excluded would come back
+            if (cropNoData != null && crop.getBounds().contains(layoutBounds())) {
+                // replace the mosaic images, skipping the source operation and going to its source
+                images = new RenderedImage[] {(RenderedImage) crop.getSources().get(0)};
+                nodata = new Range[] {cropNoData};
+                fusedCropNoData = true;
+            }
+        }
+
         // ParameterBlock creation
         ParameterBlock pb = new ParameterBlock();
         int srcNum = 0;
@@ -4351,7 +4382,9 @@ public class ImageWorker {
             }
         }
 
-        if (noInternalNoData && thresholds != null) {
+        // thresholds stand in for a missing nodata: without the fusion the crop nodata would have
+        // reached this method as a source property, taking the same precedence over them
+        if (noInternalNoData && thresholds != null && !fusedCropNoData) {
             nodataNew = handleMosaicThresholds(thresholds, srcNum);
         }
         // Setting the parameters
@@ -4379,6 +4412,79 @@ public class ImageWorker {
             setROI(null);
         }
         return this;
+    }
+
+    /**
+     * The nodata range of a single source operation that crops/mosaic by filling with nodata, {@code null} when it does
+     * anything more, or when the fill is not a {@link #harmlessFill harmless} one. This "crop" is a mosaic: either a
+     * Mosaic operation, which is what {@link org.geotools.coverage.processing.operation.Crop} builds when nodata or a
+     * ROI are involved, or a Crop operation, which image processing renders as a mosaic too once it sees the nodata
+     * range. A Crop without nodata is instead a pure bounds change, its tiles are the source ones, so there is nothing
+     * to fuse and this method returns {@code null} for it.
+     */
+    private static Range singleSourceNoData(RenderedOp op, double[] background) {
+        if (op.getNumSources() != 1 || !(op.getSources().get(0) instanceof RenderedImage)) return null;
+        ParameterBlock params = op.getParameterBlock();
+        if ("Crop".equals(op.getOperationName())) {
+            // x, y, width, height, ROI, NoData, destNoData. destNoData is set only when the crop
+            // fills, hence the count check. The ROI needs no check of its own: the operation reduces
+            // it to its bounding box, so its whole effect is already in the bounds checked above.
+            if (params.getNumParameters() < 7) return null;
+            return harmlessFill(params.getObjectParameter(5), params.getObjectParameter(6), background);
+        }
+        if ("Mosaic".equals(op.getOperationName())) {
+            // type, alphas, ROIs, thresholds, background, NoData. Alphas or ROIs mean masking, not
+            // just cropping, and fusing those would need a ROI intersection.
+            if (params.getNumParameters() < 6
+                    || !MosaicDescriptor.MOSAIC_TYPE_OVERLAY.equals(params.getObjectParameter(0))
+                    || params.getObjectParameter(1) != null
+                    || params.getObjectParameter(2) != null) return null;
+            Object nodata = params.getObjectParameter(5);
+            if (!(nodata instanceof Range[] ranges) || ranges.length != 1) return null;
+            return harmlessFill(ranges[0], params.getObjectParameter(4), background);
+        }
+        return null;
+    }
+
+    /**
+     * The nodata range, when the fill that comes with it is one the enclosing mosaic writes anyway: either the fill is
+     * nodata itself, so the mosaic matches those pixels and replaces them, or it is the same constant the mosaic fills
+     * with. {@code null} when the two differ, dropping the crop would then change pixels.
+     *
+     * <p>Fill inside the nodata range: crop has {@code NoData = [0,0]} and {@code destNoData = {0}}, mosaic background
+     * 255. Before fusion the crop writes 0, then the mosaic matches it against {@code [0,0]} and writes 255. After
+     * fusion the mosaic matches the source nodata directly and writes 255, same pixels.
+     *
+     * <p>Fill equal to the mosaic background: {@code NoData = [0,0]}, {@code destNoData = {255}}, background 255.
+     * Before fusion the crop writes 255 and the mosaic passes it through, after fusion the mosaic matches the source
+     * nodata and fills 255, same pixels again.
+     *
+     * <p>Rejected instead: {@code NoData = [0,0]}, {@code destNoData = {1}}, background 255. Those pixels are 1 with
+     * the crop in place, they would become 255 without it.
+     */
+    private static Range harmlessFill(Object nodata, Object fill, double[] background) {
+        if (!(nodata instanceof Range range) || !(fill instanceof double[] fillValues)) return null;
+        if (fillValues.length == 0) return null;
+        if (DoubleStream.of(fillValues).allMatch(range::contains)) return range;
+
+        // same constant on both sides, lengths may differ (per band background, single value fill)
+        if (background == null || background.length == 0) return null;
+        double constant = background[0];
+        return DoubleStream.concat(DoubleStream.of(fillValues), DoubleStream.of(background))
+                        .allMatch(v -> v == constant)
+                ? range
+                : null;
+    }
+
+    /**
+     * Bounds pinned by the image layout hint, empty when it does not pin all four. An empty rectangle is contained in
+     * nothing, so a missing layout blocks the crop fusion.
+     */
+    private Rectangle layoutBounds() {
+        Object hint = getRenderingHint(ImageN.KEY_IMAGE_LAYOUT);
+        if (!(hint instanceof ImageLayout layout)) return new Rectangle();
+        if (!layout.isValid(LAYOUT_BOUNDS_MASK)) return new Rectangle();
+        return new Rectangle(layout.getMinX(null), layout.getMinY(null), layout.getWidth(null), layout.getHeight(null));
     }
 
     private ROI mosaicROIs(List sources, ROI... roiArray) {

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/ReadResolutionCalculatorTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/grid/io/ReadResolutionCalculatorTest.java
@@ -29,6 +29,13 @@ public class ReadResolutionCalculatorTest {
 
     private static final double NATIVE_RES = 0.02;
 
+    /** Geostationary projection, defined only over the satellite disc. */
+    private static final String GEOS_WKT = "PROJCS[\"GEOS\", GEOGCS[\"WGS84\", DATUM[\"WGS84\", "
+            + "SPHEROID[\"WGS84\", 6378137.0, 298.257223563]], PRIMEM[\"Greenwich\", 0.0], "
+            + "UNIT[\"degree\", 0.017453292519943295]], PROJECTION[\"GEOS\"], "
+            + "PARAMETER[\"central_meridian\", 0.0], PARAMETER[\"satellite_height\", 35785831.0], "
+            + "PARAMETER[\"false_easting\", 0.0], PARAMETER[\"false_northing\", 0.0], UNIT[\"m\", 1.0]]";
+
     @Test
     public void testReadResolutionCalculator() throws Exception {
         // &BBOX=-10000000,10000000,0,20000000&WIDTH=256&HEIGHT=256
@@ -65,6 +72,31 @@ public class ReadResolutionCalculatorTest {
         // Before the fix, that computation would have returned a wrong full resolution
         assertEquals(1.53466E-4, requestedResolution[0], 1e-6);
         assertEquals(1.53466E-4, requestedResolution[1], 1e-6);
+    }
+
+    @Test
+    public void testAccurateResolutionToleratesPointsOutsideProjectionValidity() throws Exception {
+        // a geostationary tile straddling the disc border: the calculator must skip the probe
+        // points that fail to transform and still return a computed resolution, not the native one
+        final CoordinateReferenceSystem requestCRS = CRS.parseWKT(GEOS_WKT);
+        final CoordinateReferenceSystem nativeCRS = CRS.decode("EPSG:4326", true);
+        // a tile in the geostationary CRS whose area reaches past the disc edge
+        final ReferencedEnvelope requestBounds = new ReferencedEnvelope(4000000, 5400000, 0, 1400000, requestCRS);
+        final ReferencedEnvelope readBounds = requestBounds.transform(nativeCRS, true);
+        GridGeometry2D gg = new GridGeometry2D(new GridEnvelope2D(0, 0, 256, 256), requestBounds);
+
+        // a native resolution fine enough that maxOversamplingFactor does not clamp the result,
+        // otherwise the assertions below would check the clamp instead of the probe minimum
+        final double nativeRes = 0.001;
+        ReadResolutionCalculator calculator =
+                new ReadResolutionCalculator(gg, nativeCRS, new double[] {nativeRes, nativeRes});
+        calculator.setAccurateResolution(true);
+        double[] res = calculator.computeRequestedResolution(readBounds);
+
+        // the shortest reprojected probe segment, well away from both the native resolution and
+        // the classic envelope based one, so this pins the accurate computation itself
+        assertEquals(0.0517345, res[0], 1e-7);
+        assertEquals(0.0517345, res[1], 1e-7);
     }
 
     @Test

--- a/modules/library/coverage/src/test/java/org/geotools/coverage/processing/CoverageProcessorTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/coverage/processing/CoverageProcessorTest.java
@@ -1,0 +1,154 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.coverage.processing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.geotools.api.coverage.processing.Operation;
+import org.geotools.api.coverage.processing.OperationNotFoundException;
+import org.geotools.coverage.processing.operation.Crop;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/** Checks the lazy plugin scan of {@link CoverageProcessor} under concurrent access. */
+public class CoverageProcessorTest {
+
+    private static final int THREADS = 16;
+
+    /** Lookups per thread performed by {@link #benchmarkConcurrentLookup()}. */
+    private static final int BENCHMARK_LOOKUPS = 2_000_000;
+
+    /** Counts the scans, the whole point of the lazy scan is that it runs once. */
+    private static class CountingProcessor extends CoverageProcessor {
+        final AtomicInteger scans = new AtomicInteger();
+
+        @Override
+        public void scanForPlugins() {
+            scans.incrementAndGet();
+            super.scanForPlugins();
+        }
+    }
+
+    /**
+     * Threads racing on a fresh processor must all get the same operation, from a single scan: the lookup itself is
+     * lock free, so only the scan may be serialized.
+     */
+    @Test
+    public void testConcurrentFirstLookupScansOnce() throws Exception {
+        CountingProcessor processor = new CountingProcessor();
+        assertEquals("the scan must still be pending", 0, processor.scans.get());
+        List<Operation> found = runConcurrently(() -> processor.getOperation("CoverageCrop"));
+
+        assertEquals(1, processor.scans.get());
+        Operation first = found.get(0);
+        assertNotNull(first);
+        assertEquals(Crop.class, first.getClass());
+        for (Operation operation : found) {
+            assertSame(first, operation);
+        }
+    }
+
+    /** Same race on the whole collection: every thread sees the fully scanned set. */
+    @Test
+    public void testConcurrentGetOperationsScansOnce() throws Exception {
+        CountingProcessor processor = new CountingProcessor();
+        int expected = new CoverageProcessor().getOperations().size();
+        assertEquals("the scan must still be pending", 0, processor.scans.get());
+        List<Collection<Operation>> found = runConcurrently(() -> processor.getOperations());
+
+        assertEquals(1, processor.scans.get());
+        for (Collection<Operation> operations : found) {
+            assertEquals(expected, operations.size());
+        }
+    }
+
+    /** A miss must not be mistaken for an unscanned processor and trigger a classpath rescan. */
+    @Test
+    public void testUnknownOperationDoesNotRescan() {
+        CountingProcessor processor = new CountingProcessor();
+        for (int i = 0; i < 3; i++) {
+            assertThrows(OperationNotFoundException.class, () -> processor.getOperation("NotAnOperation"));
+        }
+        assertEquals(1, processor.scans.get());
+    }
+
+    /**
+     * Measures the contention the lock free lookup is meant to remove. Not an assertion, and not part of the build: run
+     * it from the IDE against this and the previous locking strategy, and compare the printed times.
+     *
+     * <p>On a 12 core Ryzen 9 AI: 17862 ms with the operations held in a {@code Collections.synchronizedMap(TreeMap)},
+     * 2230 ms with the current {@code ConcurrentSkipListMap}. Absolute numbers depend on the machine, the ratio is the
+     * point.
+     */
+    @Ignore("manual benchmark, run it from the IDE")
+    @Test
+    public void benchmarkConcurrentLookup() throws Exception {
+        CoverageProcessor processor = new CoverageProcessor();
+        timeLookups(processor); // warmup, so the measured run finds the lookup path compiled
+        long millis = TimeUnit.NANOSECONDS.toMillis(timeLookups(processor));
+        CoverageProcessor.LOGGER.info(THREADS + " threads x " + BENCHMARK_LOOKUPS + " lookups: " + millis + " ms");
+    }
+
+    /** Wall clock nanos for every thread to complete {@link #BENCHMARK_LOOKUPS} lookups. */
+    private static long timeLookups(CoverageProcessor processor) throws Exception {
+        long start = System.nanoTime();
+        runConcurrently(() -> {
+            // returned so the loop cannot be optimized away
+            Operation last = null;
+            for (int i = 0; i < BENCHMARK_LOOKUPS; i++) {
+                last = processor.getOperation("CoverageCrop");
+            }
+            return last;
+        });
+        return System.nanoTime() - start;
+    }
+
+    /** Runs the task on all threads at once, so they contend on the very first lookup. */
+    private static <T> List<T> runConcurrently(Callable<T> task) throws Exception {
+        CyclicBarrier barrier = new CyclicBarrier(THREADS);
+        List<Callable<T>> tasks = new ArrayList<>();
+        for (int i = 0; i < THREADS; i++) {
+            tasks.add(() -> {
+                barrier.await();
+                return task.call();
+            });
+        }
+        ExecutorService executor = Executors.newFixedThreadPool(THREADS);
+        try {
+            List<T> results = new ArrayList<>();
+            for (Future<T> future : executor.invokeAll(tasks)) {
+                results.add(future.get());
+            }
+            return results;
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/modules/library/coverage/src/test/java/org/geotools/image/MosaicCropReductionTest.java
+++ b/modules/library/coverage/src/test/java/org/geotools/image/MosaicCropReductionTest.java
@@ -1,0 +1,289 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.image;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import org.eclipse.imagen.ImageLayout;
+import org.eclipse.imagen.ImageN;
+import org.eclipse.imagen.ROI;
+import org.eclipse.imagen.ROIShape;
+import org.eclipse.imagen.RenderedOp;
+import org.eclipse.imagen.media.mosaic.MosaicDescriptor;
+import org.eclipse.imagen.media.range.Range;
+import org.eclipse.imagen.media.range.RangeFactory;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.After;
+import org.junit.Test;
+
+/** Checks the mosaic over nodata-crop reduction: same pixels, one operation less. */
+public class MosaicCropReductionTest {
+
+    // the source is larger than the crop, otherwise ImageWorker.crop eliminates the operation
+    private static final int SRC_W = 140;
+    private static final int SRC_H = 120;
+    private static final int W = 100;
+    private static final int H = 80;
+    private static final double FILL = 255;
+    private static final Rectangle FULL = new Rectangle(0, 0, W, H);
+    private static final Range NODATA = RangeFactory.create((byte) 0, true, (byte) 0, true);
+
+    /** Thresholds of the outer mosaic, most tests do not set any. */
+    private double[][] thresholds;
+
+    @After
+    public void restoreFlag() {
+        ImageWorker.MOSAIC_CROP_REDUCTION_ENABLED = true;
+    }
+
+    /** The crop leaves the chain, and the pixels do not change with it. */
+    @Test
+    public void testCropFusedIntoMosaic() {
+        RenderedImage chained = buildMosaicOverCrop(false, FULL);
+        RenderedImage reduced = buildMosaicOverCrop(true, FULL);
+        assertThat(firstSource(chained), isOperation("Crop"));
+
+        // no operation took the crop's place, the mosaic reads the source itself, at its own size
+        // (a plain BufferedImage source gets wrapped into a rendered image adapter)
+        RenderedImage fused = firstSource(reduced);
+        assertThat(fused, not(instanceOf(RenderedOp.class)));
+        assertSize(fused, SRC_W, SRC_H);
+        assertSamePixels(dataOf(chained), dataOf(reduced));
+    }
+
+    /** A layout reaching outside the crop must block the reduction, the crop bounds still matter. */
+    @Test
+    public void testLayoutWiderThanCropNotReduced() {
+        RenderedImage wider = buildMosaicOverCrop(true, new Rectangle(0, 0, W + 20, H + 20));
+        RenderedImage kept = firstSource(wider);
+        assertThat(kept, isOperation("Crop"));
+        assertSize(kept, W, H);
+    }
+
+    /**
+     * The inner cropping operation is a single source Mosaic, which is what
+     * {@link org.geotools.coverage.processing.operation.Crop} builds when nodata is involved.
+     */
+    @Test
+    public void testMosaicOverMosaicReduced() {
+        // reduction not enabled, mosaic over mosaic
+        RenderedImage chained = buildMosaicOverMosaic(false, null);
+        assertThat(firstSource(chained), isOperation("Mosaic"));
+
+        // reduction enabled, single mosaic over bufferd image
+        RenderedImage reduced = buildMosaicOverMosaic(true, null);
+        RenderedImage fused = firstSource(reduced);
+        assertThat(fused, instanceOf(BufferedImage.class));
+        assertSize(fused, SRC_W, SRC_H);
+
+        // however, the pixels in output are the same for the reduced and non reduced case
+        assertSamePixels(dataOf(chained), dataOf(reduced));
+    }
+
+    /**
+     * A ROI on the Crop does not block the reduction: the operation reduces the ROI to its bounding box, so it can only
+     * shrink the crop bounds, never mask pixels inside them, and the bounds are checked already. A triangle whose
+     * bounds cover the crop therefore masks nothing at all.
+     */
+    @Test
+    public void testCropWithRoiReduced() {
+        ROI roi = new ROIShape(new Polygon(new int[] {0, W, 0}, new int[] {0, 0, H}, 3));
+        RenderedImage chained = buildMosaicOverCrop(false, FULL, roi);
+        RenderedImage reduced = buildMosaicOverCrop(true, FULL, roi);
+        assertThat(firstSource(chained), isOperation("Crop"));
+        assertThat(firstSource(reduced), not(instanceOf(RenderedOp.class)));
+        assertSamePixels(dataOf(chained), dataOf(reduced));
+    }
+
+    /**
+     * The fusion works because the crop advertises its nodata range as a GC_NODATA property, so the outer mosaic was
+     * already skipping the fill. Checked with a range wider than the fill, and hole pixels that differ from it, so the
+     * two would part ways if that stopped holding.
+     */
+    @Test
+    public void testRangeNoDataWiderThanFill() {
+        Range wide = RangeFactory.create((byte) 0, true, (byte) 10, true);
+        Raster chained = dataOf(buildMosaicOverCrop(false, FULL, null, wide, 7));
+        Raster reduced = dataOf(buildMosaicOverCrop(true, FULL, null, wide, 7));
+        assertSamePixels(chained, reduced);
+    }
+
+    /** An inner mosaic carrying its own ROI is masking, not cropping: it must be left alone. */
+    @Test
+    public void testInnerMosaicWithRoiNotReduced() {
+        ROI roi = new ROIShape(new Rectangle(5, 5, 50, 40));
+        RenderedImage kept = firstSource(buildMosaicOverMosaic(true, roi));
+        assertThat(kept, isOperation("Mosaic"));
+        assertSize(kept, W, H);
+    }
+
+    /**
+     * The outer mosaic carrying thresholds must still honour the nodata range the fusion moves into it: thresholds only
+     * stand in for a nodata that is not there.
+     */
+    @Test
+    public void testMosaicThresholdsDoNotHideMovedNoData() {
+        thresholds = new double[][] {{0}};
+        Raster chained = dataOf(buildMosaicOverCrop(false, FULL));
+        Raster reduced = dataOf(buildMosaicOverCrop(true, FULL));
+        assertSamePixels(chained, reduced);
+        // the fill really is there, the nodata block of the source is not showing through
+        assertEquals(FILL, reduced.getSampleDouble(70, 20, 0), 0d);
+    }
+
+    /** Crop operation cropping with nodata, as the render chain builds it, then the mosaic over it. */
+    private RenderedImage buildMosaicOverCrop(boolean reductionEnabled, Rectangle layoutBounds) {
+        return buildMosaicOverCrop(reductionEnabled, layoutBounds, null, NODATA, 0);
+    }
+
+    private RenderedImage buildMosaicOverCrop(boolean reductionEnabled, Rectangle layoutBounds, ROI cropRoi) {
+        return buildMosaicOverCrop(reductionEnabled, layoutBounds, cropRoi, NODATA, 0);
+    }
+
+    private RenderedImage buildMosaicOverCrop(
+            boolean reductionEnabled, Rectangle layoutBounds, ROI cropRoi, Range cropNoData, int holeValue) {
+        ImageWorker.MOSAIC_CROP_REDUCTION_ENABLED = reductionEnabled;
+        int validFloor = cropNoData.getMax().intValue() + 1;
+        ImageWorker crop = new ImageWorker(source(holeValue, validFloor));
+        crop.setNoData(cropNoData);
+        crop.setBackground(new double[] {FILL});
+        crop.setROI(cropRoi);
+        crop.crop(0, 0, W, H);
+        return terminalMosaic(crop.getRenderedImage(), layoutBounds);
+    }
+
+    /** Single source Mosaic cropping through its layout, then the mosaic over it. */
+    private RenderedImage buildMosaicOverMosaic(boolean reductionEnabled, ROI innerRoi) {
+        ImageWorker.MOSAIC_CROP_REDUCTION_ENABLED = reductionEnabled;
+        RenderedImage inner = singleSourceMosaic(source(0, 1), FULL, new double[] {FILL}, innerRoi, NODATA, null);
+        return terminalMosaic(inner, FULL);
+    }
+
+    /** The mosaic the reduction acts on: three band background, a ROI, no nodata of its own. */
+    private RenderedImage terminalMosaic(RenderedImage source, Rectangle layoutBounds) {
+        double[] background = {FILL, FILL, FILL};
+        ROI roi = new ROIShape(new Rectangle(10, 10, 60, 50));
+        return singleSourceMosaic(source, layoutBounds, background, roi, null, thresholds);
+    }
+
+    /** OVERLAY mosaic with the layout pinning its bounds, the only shape these tests build. */
+    private RenderedImage singleSourceMosaic(
+            RenderedImage source,
+            Rectangle layoutBounds,
+            double[] background,
+            ROI roi,
+            Range nodata,
+            double[][] thresholds) {
+        ImageWorker iw = new ImageWorker(source);
+        iw.setRenderingHint(ImageN.KEY_IMAGE_LAYOUT, layout(layoutBounds));
+        iw.setBackground(background);
+        iw.mosaic(
+                new RenderedImage[] {source},
+                MosaicDescriptor.MOSAIC_TYPE_OVERLAY,
+                null,
+                roi == null ? null : new ROI[] {roi},
+                thresholds,
+                nodata == null ? null : new Range[] {nodata});
+        return iw.getRenderedImage();
+    }
+
+    private ImageLayout layout(Rectangle bounds) {
+        ImageLayout layout = new ImageLayout(bounds.x, bounds.y, bounds.width, bounds.height);
+        layout.setTileWidth(32);
+        layout.setTileHeight(32);
+        return layout;
+    }
+
+    /** Matches an image that is the given image processing operation. */
+    private static Matcher<RenderedImage> isOperation(String operation) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(RenderedImage image) {
+                return image instanceof RenderedOp op && operation.equals(op.getOperationName());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the ").appendText(operation).appendText(" operation");
+            }
+
+            @Override
+            protected void describeMismatchSafely(RenderedImage image, Description mismatch) {
+                mismatch.appendText(
+                        image instanceof RenderedOp op
+                                ? "the " + op.getOperationName() + " operation"
+                                : "no operation, " + image.getClass().getSimpleName());
+            }
+        };
+    }
+
+    private RenderedImage firstSource(RenderedImage mosaic) {
+        return (RenderedImage) ((RenderedOp) mosaic).getSources().get(0);
+    }
+
+    private void assertSize(RenderedImage image, int width, int height) {
+        assertEquals(width, image.getWidth());
+        assertEquals(height, image.getHeight());
+    }
+
+    private Raster dataOf(RenderedImage image) {
+        return image.getData(FULL);
+    }
+
+    private void assertSamePixels(Raster expected, Raster actual) {
+        for (int y = 0; y < H; y++) {
+            for (int x = 0; x < W; x++) {
+                for (int b = 0; b < 3; b++) {
+                    assertEquals(
+                            "pixel " + x + "," + y + " band " + b,
+                            expected.getSample(x, y, b),
+                            actual.getSample(x, y, b));
+                }
+            }
+        }
+    }
+
+    /**
+     * Three band byte image with a uniform {@code holeValue} block standing in for nodata. Every other sample is kept
+     * at or above {@code validFloor}, so only the block matches the nodata range under test.
+     */
+    private RenderedImage source(int holeValue, int validFloor) {
+        BufferedImage bi = new BufferedImage(SRC_W, SRC_H, BufferedImage.TYPE_3BYTE_BGR);
+        for (int y = 0; y < SRC_H; y++) {
+            for (int x = 0; x < SRC_W; x++) {
+                boolean nodata = x >= 60 && x < 90 && y >= 10 && y < 50;
+                int v = (x + y) % 256;
+                for (int b = 0; b < 3; b++) {
+                    int sample = nodata ? holeValue : validFloor + (v + 30 * b) % (256 - validFloor);
+                    bi.getRaster().setSample(x, y, b, sample);
+                }
+            }
+        }
+        return bi;
+    }
+}

--- a/modules/library/main/src/main/java/org/geotools/renderer/crs/GeosValidAreaCache.java
+++ b/modules/library/main/src/main/java/org/geotools/renderer/crs/GeosValidAreaCache.java
@@ -20,7 +20,6 @@ import static org.geotools.referencing.operation.projection.GeostationarySatelli
 import static org.geotools.referencing.operation.projection.MapProjection.AbstractProvider.CENTRAL_MERIDIAN;
 
 import java.awt.geom.Point2D;
-import java.util.regex.Pattern;
 import org.geotools.api.parameter.ParameterValueGroup;
 import org.geotools.api.referencing.FactoryException;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
@@ -64,8 +63,8 @@ final class GeosValidAreaCache {
     private static final Geometry WORLD_LEFT = GF.toGeometry(new Envelope(-360, -180, -90, 90));
     private static final Geometry WORLD_RIGHT = GF.toGeometry(new Envelope(180, 360, -90, 90));
 
-    /** CRS signature -> valid area already. */
-    private final SoftValueHashMap<CrsKey, Geometry> validAreaCache = new SoftValueHashMap<>();
+    /** GEOS CRS -> valid area. */
+    private final SoftValueHashMap<CoordinateReferenceSystem, Geometry> validAreaCache = new SoftValueHashMap<>();
 
     /**
      * Returns the valid area geometry for GEOS projected CRS in WGS84.
@@ -75,16 +74,19 @@ final class GeosValidAreaCache {
      */
     public Geometry getValidAreaInGeosCrs(CoordinateReferenceSystem geosCrs)
             throws FactoryException, TransformException {
-        CrsKey key = CrsKey.of(geosCrs);
-        Geometry cached = validAreaCache.get(key);
+        // the CRS is the key: equals/hashCode are structural, so two equal CRS instances share the
+        // entry. The comparison covers metadata too, not just the projection parameters, so CRSs
+        // that differ only by name or authority code get separate entries: a few wasted entries,
+        // never a wrong valid area
+        Geometry cached = validAreaCache.get(geosCrs);
         if (cached != null) return cached;
 
         synchronized (validAreaCache) {
-            cached = validAreaCache.get(key);
+            cached = validAreaCache.get(geosCrs);
             if (cached != null) return cached;
 
             Geometry wgs84 = buildValidAreaWgs84(geosCrs);
-            validAreaCache.put(key, wgs84);
+            validAreaCache.put(geosCrs, wgs84);
             return wgs84;
         }
     }
@@ -236,35 +238,6 @@ final class GeosValidAreaCache {
             return rightTranslated.union(left);
         } else {
             return poly;
-        }
-    }
-
-    /** CRS key based on normalized WKT, with pre-computed hash for faster lookups. */
-    private static final class CrsKey {
-        private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
-
-        private final String signature;
-        private final int hash;
-
-        private CrsKey(String signature) {
-            this.signature = signature;
-            this.hash = signature.hashCode();
-        }
-
-        static CrsKey of(CoordinateReferenceSystem crs) {
-            String wkt = crs.toWKT().replaceAll("\\s+", " ").trim();
-            String canonical = WHITESPACE_PATTERN.matcher(wkt).replaceAll(" ").trim();
-            return new CrsKey(canonical);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return (this == o) || (o instanceof CrsKey && signature.equals(((CrsKey) o).signature));
-        }
-
-        @Override
-        public int hashCode() {
-            return hash;
         }
     }
 }

--- a/modules/library/main/src/test/java/org/geotools/renderer/crs/GeosValidAreaCacheTest.java
+++ b/modules/library/main/src/test/java/org/geotools/renderer/crs/GeosValidAreaCacheTest.java
@@ -1,0 +1,144 @@
+/*
+ *    GeoTools - The Open Source Java GIS Toolkit
+ *    http://geotools.org
+ *
+ *    (C) 2026, Open Source Geospatial Foundation (OSGeo)
+ *
+ *    This library is free software; you can redistribute it and/or
+ *    modify it under the terms of the GNU Lesser General Public
+ *    License as published by the Free Software Foundation;
+ *    version 2.1 of the License.
+ *
+ *    This library is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    Lesser General Public License for more details.
+ */
+package org.geotools.renderer.crs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
+import org.geotools.referencing.CRS;
+import org.geotools.referencing.factory.ReferencingObjectFactory;
+import org.geotools.util.logging.Logging;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+
+/** Checks that the valid area cache keys on the projection parameters, and only on those. */
+public class GeosValidAreaCacheTest {
+
+    private static final Logger LOGGER = Logging.getLogger(GeosValidAreaCacheTest.class);
+
+    private static final double GEOSTATIONARY_HEIGHT = 35785831;
+
+    /** Warm cache lookups performed by {@link #benchmarkWarmLookup()}. */
+    private static final int BENCHMARK_LOOKUPS = 200_000;
+
+    private final GeosValidAreaCache cache = new GeosValidAreaCache();
+
+    /**
+     * Two factories have separate canonicalization pools, so they return distinct but equal CRS instances: those must
+     * share the cache entry, or the valid area gets recomputed per instance.
+     */
+    @Test
+    public void testEqualCrsShareEntry() throws Exception {
+        String wkt = wkt(0, GEOSTATIONARY_HEIGHT);
+        CoordinateReferenceSystem first = new ReferencingObjectFactory().createFromWKT(wkt);
+        CoordinateReferenceSystem second = new ReferencingObjectFactory().createFromWKT(wkt);
+        assertNotSame(first, second);
+        assertEquals(first, second);
+
+        Geometry area = cache.getValidAreaInGeosCrs(first);
+        assertSame(area, cache.getValidAreaInGeosCrs(second));
+    }
+
+    /** The disc follows the satellite, so the central meridian has to be part of the key. */
+    @Test
+    public void testCentralMeridianNotShared() throws Exception {
+        CoordinateReferenceSystem greenwichCrs = geos(0, GEOSTATIONARY_HEIGHT);
+        CoordinateReferenceSystem shiftedCrs = geos(60, GEOSTATIONARY_HEIGHT);
+        Geometry greenwich = cache.getValidAreaInGeosCrs(greenwichCrs);
+        Geometry shifted = cache.getValidAreaInGeosCrs(shiftedCrs);
+
+        // the repeat lookups matter: assertNotSame alone would also pass on a cache that never
+        // caches and rebuilds the valid area on every call
+        assertNotSame(greenwich, shifted);
+        assertSame(greenwich, cache.getValidAreaInGeosCrs(greenwichCrs));
+        assertSame(shifted, cache.getValidAreaInGeosCrs(shiftedCrs));
+
+        assertEquals(0, greenwich.getCentroid().getX(), 0.5);
+        assertEquals(60, shifted.getCentroid().getX(), 0.5);
+        assertEquals(81.3, greenwich.getEnvelopeInternal().getMaxX(), 0.5);
+        assertEquals(141.3, shifted.getEnvelopeInternal().getMaxX(), 0.5);
+    }
+
+    /** A lower satellite sees a smaller disc, so the height has to be part of the key too. */
+    @Test
+    public void testSatelliteHeightNotShared() throws Exception {
+        CoordinateReferenceSystem highCrs = geos(0, GEOSTATIONARY_HEIGHT);
+        CoordinateReferenceSystem lowCrs = geos(0, 5000);
+        Geometry high = cache.getValidAreaInGeosCrs(highCrs);
+        Geometry low = cache.getValidAreaInGeosCrs(lowCrs);
+
+        assertNotSame(high, low);
+        assertSame(high, cache.getValidAreaInGeosCrs(highCrs));
+        assertSame(low, cache.getValidAreaInGeosCrs(lowCrs));
+
+        assertEquals(81.3, high.getEnvelopeInternal().getMaxX(), 0.5);
+        assertEquals(2.3, low.getEnvelopeInternal().getMaxX(), 0.1);
+    }
+
+    /**
+     * Measures the per lookup cost of the cache key on an already populated entry, which is what the rendering path
+     * pays on every request. Not an assertion, and not part of the build: run it from the IDE against this and the
+     * previous key strategy, and compare the printed times.
+     *
+     * <p>Uses a single CRS instance, the common case: readers and map contexts hand out the same canonicalized instance
+     * for the life of a request.
+     *
+     * <p>On a 12 core Ryzen 9 AI: 9309 ms with the normalized WKT key, 26 ms with the current CRS key, that is 46.5 us
+     * against 0.13 us per lookup. Absolute numbers depend on the machine, the ratio is the point.
+     */
+    @Ignore("manual benchmark, run it from the IDE")
+    @Test
+    public void benchmarkWarmLookup() throws Exception {
+        CoordinateReferenceSystem geos = geos(0, GEOSTATIONARY_HEIGHT);
+        timeLookups(geos); // warmup, also populates the entry
+        long millis = TimeUnit.NANOSECONDS.toMillis(timeLookups(geos));
+        LOGGER.info(BENCHMARK_LOOKUPS + " warm lookups: " + millis + " ms");
+    }
+
+    /** Wall clock nanos for {@link #BENCHMARK_LOOKUPS} lookups of an already cached valid area. */
+    private long timeLookups(CoordinateReferenceSystem geos) throws Exception {
+        long start = System.nanoTime();
+        Geometry last = null;
+        for (int i = 0; i < BENCHMARK_LOOKUPS; i++) {
+            last = cache.getValidAreaInGeosCrs(geos);
+        }
+        assertNotNull(last); // so the loop cannot be optimized away
+        return System.nanoTime() - start;
+    }
+
+    private static CoordinateReferenceSystem geos(double centralMeridian, double satelliteHeight) throws Exception {
+        return CRS.parseWKT(wkt(centralMeridian, satelliteHeight));
+    }
+
+    private static String wkt(double centralMeridian, double satelliteHeight) {
+        return "PROJCS[\"GEOS\", GEOGCS[\"WGS 84\", DATUM[\"WGS84\", "
+                + "SPHEROID[\"WGS84\", 6378137.0, 298.257223563]], "
+                + "PRIMEM[\"Greenwich\", 0.0], UNIT[\"degree\", 0.017453292519943295]], "
+                + "PROJECTION[\"GEOS\"], "
+                + "PARAMETER[\"central_meridian\", "
+                + centralMeridian
+                + "], PARAMETER[\"satellite_height\", "
+                + satelliteHeight
+                + "], UNIT[\"m\", 1.0]]";
+    }
+}


### PR DESCRIPTION
Assorted speedups found profiling raster reprojection under load, specifically under hard-to-reproject cases (geostationary satellite). One commit each:

* [GEOT-7945](https://osgeo-org.atlassian.net/browse/GEOT-7945) Read resolution
  computation gave up when some test points fell outside the projection valid
  area (common with geostationary), so the reader read the granule at full
  resolution. Now bad points are skipped, and there is a last ditch fallback before
  giving up.
* [GEOT-7946](https://osgeo-org.atlassian.net/browse/GEOT-7946) The
  geostationary valid area cache built a WKT string and ran two regexes on every
  lookup. Uses the CRS itself as key now.
* [GEOT-7947](https://osgeo-org.atlassian.net/browse/GEOT-7947) Every coverage
  processor operation lookup took a lock. Reads are lock-free now.
* [GEOT-7948](https://osgeo-org.atlassian.net/browse/GEOT-7948) A mosaic on top
  of a crop with nodata/roi copies all the pixels twice (because the Crop is implemented as a second mosaic).   
  When it is safe, the two are merged into one. Disable with `-Dorg.geotools.image.reduceMosaicCrop=false`.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [ ] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [ ] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [ ] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->