### PR TITLE
[GEOT-7955]: Merging adjacent zones before producing the BETWEEN filter

### DIFF
--- a/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/DGGSFilterTransformer.java
+++ b/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/DGGSFilterTransformer.java
@@ -19,11 +19,11 @@ package org.geotools.dggs;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.commons.collections4.IteratorUtils;
 import org.geotools.api.feature.type.AttributeDescriptor;
 import org.geotools.api.filter.Filter;
 import org.geotools.api.filter.FilterFactory;
-import org.geotools.api.filter.Or;
 import org.geotools.api.filter.PropertyIsEqualTo;
 import org.geotools.api.filter.expression.Expression;
 import org.geotools.api.filter.expression.Function;
@@ -173,21 +173,21 @@ public class DGGSFilterTransformer extends DuplicatingFilterVisitor {
         List<Filter> filters = new ArrayList<>();
         List<Expression> inExpressions = new ArrayList<>();
         inExpressions.add(FF.property(zoneAttribute.getLocalName()));
+        List<String> parentZoneIds = new ArrayList<>();
         while (zones.hasNext()) {
             Zone zone = zones.next();
             // exact match
             if (zone.getResolution() == resolution) {
                 inExpressions.add(buildZoneLiteral(dggs, zoneAttribute, zone.getId()));
             } else { // parent match
-                Filter childFilter = buildChildFilter(dggs, zone.getId(), resolution, zoneAttribute);
-                filters.add(childFilter);
+                // collected, not turned into a filter right away, so getChildrenFilter can merge
+                // adjacent/overlapping child ranges across all of them instead of one at a time
+                parentZoneIds.add(zone.getId());
             }
         }
 
-        if (!filters.isEmpty()) {
-            Or or = FF.or(new ArrayList<>(filters));
-            filters.clear();
-            filters.add(or);
+        if (!parentZoneIds.isEmpty()) {
+            filters.add(buildChildrenFilter(dggs, parentZoneIds, resolution, zoneAttribute));
         }
         if (inExpressions.size() > 1) {
             Function inFunction = FF.function("in", inExpressions.toArray(new Expression[inExpressions.size()]));
@@ -247,10 +247,10 @@ public class DGGSFilterTransformer extends DuplicatingFilterVisitor {
                 "Zone attribute is numeric but DGGSInstance ID type is not Number: " + dggs.idType());
     }
 
-    private static <I> Filter buildChildFilter(
-            DGGSInstance<I> dggs, String id, int resolution, AttributeDescriptor zoneAttribute) {
+    private static <I> Filter buildChildrenFilter(
+            DGGSInstance<I> dggs, List<String> ids, int resolution, AttributeDescriptor zoneAttribute) {
 
-        I zoneId = dggs.parseId(id);
-        return dggs.getChildFilter(FF, zoneId, resolution, false, zoneAttribute);
+        List<I> zoneIds = ids.stream().map(dggs::parseId).collect(Collectors.toList());
+        return dggs.getChildrenFilter(FF, zoneIds, resolution, false, zoneAttribute);
     }
 }

--- a/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/DGGSInstance.java
+++ b/modules/unsupported/dggs/dggs-core/src/main/java/org/geotools/dggs/DGGSInstance.java
@@ -17,6 +17,7 @@
 package org.geotools.dggs;
 
 import com.google.common.collect.Iterators;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.geotools.api.feature.type.AttributeDescriptor;
@@ -190,6 +191,22 @@ public interface DGGSInstance<I> extends AutoCloseable {
      *     If false, return a filter matching only the children at the target resolution instead.
      */
     Filter getChildFilter(FilterFactory ff, I zoneId, int resolution, boolean upTo, AttributeDescriptor zoneAttribute);
+
+    /**
+     * Given several parent ids, returns a filter matching all possible children of any of them, at the given
+     * resolution. The default implementation just OR's the individual {@link #getChildFilter} results; subclasses can
+     * override to coalesce adjacent/overlapping child ranges into fewer predicates.
+     *
+     * @param zoneIds The parent zone ids
+     */
+    default Filter getChildrenFilter(
+            FilterFactory ff, List<I> zoneIds, int resolution, boolean upTo, AttributeDescriptor zoneAttribute) {
+        List<Filter> filters = new ArrayList<>();
+        for (I zoneId : zoneIds) {
+            filters.add(getChildFilter(ff, zoneId, resolution, upTo, zoneAttribute));
+        }
+        return filters.size() == 1 ? filters.get(0) : ff.or(filters);
+    }
 
     /** Parses a string representation of a zone id into the proper type */
     I parseId(String id);

--- a/modules/unsupported/dggs/dggs-h3/src/main/java/org/geotools/dggs/h3/H3DGGSInstance.java
+++ b/modules/unsupported/dggs/dggs-h3/src/main/java/org/geotools/dggs/h3/H3DGGSInstance.java
@@ -347,8 +347,60 @@ public class H3DGGSInstance implements DGGSInstance<Long> {
     @Override
     public Filter getChildFilter(
             FilterFactory ff, Long zoneId, int resolution, boolean upTo, AttributeDescriptor zoneAttribute) {
+        // upTo is not honored: the resolution bits outrank the digit ones, so a range only ever covers
+        // the target resolution. No caller passes upTo = true today.
         H3Index idx = new H3Index(zoneId);
         return buildChildRangeFilter(ff, zoneAttribute, idx, resolution);
+    }
+
+    @Override
+    public Filter getChildrenFilter(
+            FilterFactory ff, List<Long> zoneIds, int resolution, boolean upTo, AttributeDescriptor zoneAttribute) {
+        // each zone's range is the full contiguous block of its subtree id space, so blocks that touch
+        // can be merged without matching any id that was not already matched
+        List<long[]> ranges = new ArrayList<>();
+        for (Long zoneId : zoneIds) {
+            H3Index idx = new H3Index(zoneId);
+            ranges.add(new long[] {idx.lowestIdChild(resolution), idx.highestIdChild(resolution)});
+        }
+        List<long[]> merged = mergeRanges(ranges);
+
+        Expression prop = ff.property(zoneAttribute.getLocalName());
+        boolean numeric = Number.class.isAssignableFrom(zoneAttribute.getType().getBinding());
+        List<Filter> filters = merged.stream()
+                .map(range -> numeric ? between(ff, prop, range) : betweenAsString(ff, prop, range))
+                .collect(Collectors.toList());
+        return filters.size() == 1 ? filters.get(0) : ff.or(filters);
+    }
+
+    private static Filter between(FilterFactory ff, Expression prop, long[] range) {
+        return ff.between(prop, ff.literal(range[0]), ff.literal(range[1]));
+    }
+
+    /**
+     * Cell ids always have the mode bits set, so they sit in [2^59, 2^60) and {@code h3ToString} renders them as 15
+     * lowercase hex chars: fixed width means the string order matches the numeric one, and range filters work too.
+     */
+    private Filter betweenAsString(FilterFactory ff, Expression prop, long[] range) {
+        return ff.between(prop, ff.literal(h3.h3ToString(range[0])), ff.literal(h3.h3ToString(range[1])));
+    }
+
+    /** Sorts ranges by lower bound and coalesces adjacent/overlapping ones, each range as {@code [lowest, highest]}. */
+    private static List<long[]> mergeRanges(List<long[]> ranges) {
+        List<long[]> sorted = new ArrayList<>(ranges);
+        sorted.sort((a, b) -> Long.compare(a[0], b[0]));
+
+        List<long[]> merged = new ArrayList<>();
+        for (long[] range : sorted) {
+            long[] last = merged.isEmpty() ? null : merged.get(merged.size() - 1);
+            // "+ 1" also merges touching ranges (no gap between them), not just overlapping ones
+            if (last != null && range[0] <= last[1] + 1) {
+                last[1] = Math.max(last[1], range[1]);
+            } else {
+                merged.add(range);
+            }
+        }
+        return merged;
     }
 
     @Override

--- a/modules/unsupported/dggs/dggs-h3/src/test/java/org/geotools/dggs/h3/H3DGGSInstanceTest.java
+++ b/modules/unsupported/dggs/dggs-h3/src/test/java/org/geotools/dggs/h3/H3DGGSInstanceTest.java
@@ -28,6 +28,7 @@ import com.uber.h3core.H3Core;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -36,10 +37,17 @@ import java.util.Random;
 import java.util.Set;
 import java.util.logging.Logger;
 import jep.JepException;
+import org.geotools.api.feature.type.AttributeDescriptor;
+import org.geotools.api.filter.Filter;
+import org.geotools.api.filter.FilterFactory;
+import org.geotools.api.filter.Or;
+import org.geotools.api.filter.PropertyIsBetween;
 import org.geotools.dggs.DGGSFactory;
 import org.geotools.dggs.DGGSFactoryFinder;
 import org.geotools.dggs.DGGSInstance;
 import org.geotools.dggs.Zone;
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.feature.AttributeTypeBuilder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.util.logging.Logging;
 import org.hamcrest.CoreMatchers;
@@ -288,5 +296,127 @@ public class H3DGGSInstanceTest {
                         "81997ffffffffff",
                         "817dbffffffffff",
                         "81547ffffffffff"));
+    }
+
+    @Test
+    public void testGetChildrenFilterMergesSiblingRanges() throws Exception {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+        AttributeDescriptor zoneAttribute = zoneAttribute(Long.class);
+
+        // an INCOMPLETE set of siblings under the same parent (3 of the 7): this is the boundary
+        // fringe case h3.compact() cannot merge (it only folds a parent back together when all 7
+        // children are present), yet their child ranges at the target resolution are still
+        // numerically contiguous with each other, so the batched merge should collapse them into
+        // a single BETWEEN spanning the union of their individual ranges
+        String parent = "8029fffffffffff";
+        List<Long> allSiblings = new ArrayList<>();
+        for (String child : h3.h3ToChildren(parent, 1)) allSiblings.add(Long.parseUnsignedLong(child, 16));
+        assertEquals(7, allSiblings.size());
+        Collections.sort(allSiblings);
+        List<Long> siblings = allSiblings.subList(0, 3);
+
+        int targetResolution = 3;
+        long expectedLowest = Long.MAX_VALUE;
+        long expectedHighest = Long.MIN_VALUE;
+        for (Long sibling : siblings) {
+            PropertyIsBetween childFilter = (PropertyIsBetween)
+                    ((H3DGGSInstance) h3i).getChildFilter(ff, sibling, targetResolution, false, zoneAttribute);
+            long lowest = (Long) childFilter.getLowerBoundary().evaluate(null);
+            long highest = (Long) childFilter.getUpperBoundary().evaluate(null);
+            expectedLowest = Math.min(expectedLowest, lowest);
+            expectedHighest = Math.max(expectedHighest, highest);
+        }
+
+        Filter merged = ((H3DGGSInstance) h3i).getChildrenFilter(ff, siblings, targetResolution, false, zoneAttribute);
+        assertTrue("3 adjacent sibling ranges should merge into a single BETWEEN", merged instanceof PropertyIsBetween);
+        PropertyIsBetween mergedBetween = (PropertyIsBetween) merged;
+        assertEquals(expectedLowest, mergedBetween.getLowerBoundary().evaluate(null));
+        assertEquals(expectedHighest, mergedBetween.getUpperBoundary().evaluate(null));
+    }
+
+    @Test
+    public void testGetChildrenFilterKeepsDistantRangesSeparate() throws Exception {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+        AttributeDescriptor zoneAttribute = zoneAttribute(Long.class);
+
+        // two zones from unrelated base cells: their child ranges do not touch, so they must
+        // stay as two separate BETWEEN clauses, not be incorrectly coalesced
+        Long zoneA = Long.parseUnsignedLong("8029fffffffffff", 16);
+        Long zoneB = Long.parseUnsignedLong("8075fffffffffff", 16);
+
+        Filter merged =
+                ((H3DGGSInstance) h3i).getChildrenFilter(ff, Arrays.asList(zoneA, zoneB), 3, false, zoneAttribute);
+        assertTrue(merged instanceof Or);
+        assertEquals(2, ((Or) merged).getChildren().size());
+    }
+
+    @Test
+    public void testGetChildrenFilterMergesOnStringColumn() throws Exception {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+
+        // same 3 incomplete siblings as the numeric merge test: a hex string column has to collapse
+        // them into one BETWEEN too, with the very same bounds, just rendered as ids
+        String parent = "8029fffffffffff";
+        List<Long> allSiblings = new ArrayList<>();
+        for (String child : h3.h3ToChildren(parent, 1)) allSiblings.add(Long.parseUnsignedLong(child, 16));
+        Collections.sort(allSiblings);
+        List<Long> siblings = allSiblings.subList(0, 3);
+
+        PropertyIsBetween numeric = (PropertyIsBetween)
+                ((H3DGGSInstance) h3i).getChildrenFilter(ff, siblings, 3, false, zoneAttribute(Long.class));
+        Filter merged = ((H3DGGSInstance) h3i).getChildrenFilter(ff, siblings, 3, false, zoneAttribute(String.class));
+
+        assertTrue(
+                "3 adjacent sibling ranges should merge on a string column too", merged instanceof PropertyIsBetween);
+        PropertyIsBetween between = (PropertyIsBetween) merged;
+        long expectedLowest = (Long) numeric.getLowerBoundary().evaluate(null);
+        long expectedHighest = (Long) numeric.getUpperBoundary().evaluate(null);
+        assertEquals(h3.h3ToString(expectedLowest), between.getLowerBoundary().evaluate(null));
+        assertEquals(h3.h3ToString(expectedHighest), between.getUpperBoundary().evaluate(null));
+    }
+
+    @Test
+    public void testGetChildrenFilterKeepsDistantRangesSeparateOnStringColumn() throws Exception {
+        FilterFactory ff = CommonFactoryFinder.getFilterFactory();
+        Long zoneA = Long.parseUnsignedLong("8029fffffffffff", 16);
+        Long zoneB = Long.parseUnsignedLong("8075fffffffffff", 16);
+
+        Filter merged = ((H3DGGSInstance) h3i)
+                .getChildrenFilter(ff, Arrays.asList(zoneA, zoneB), 3, false, zoneAttribute(String.class));
+        assertTrue(merged instanceof Or);
+        assertEquals(2, ((Or) merged).getChildren().size());
+    }
+
+    /**
+     * The string ranges are only valid because the hex encoding is fixed width: cell ids always have the mode bits set,
+     * so they sit in [2^59, 2^60) and render as exactly 15 lowercase chars, making the string order match the numeric
+     * one. If that ever stops holding, BETWEEN on a string column silently returns the wrong zones.
+     */
+    @Test
+    public void testIdStringEncodingIsFixedWidthAndOrderPreserving() {
+        Random random = new Random(0);
+        String previousId = null;
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < 500; i++) {
+            double lat = random.nextDouble() * 180 - 90;
+            double lon = random.nextDouble() * 360 - 180;
+            ids.add(h3.geoToH3(lat, lon, random.nextInt(16)));
+        }
+        Collections.sort(ids);
+        for (Long id : ids) {
+            String stringId = h3.h3ToString(id);
+            assertEquals("H3 ids must render as 15 hex chars: " + stringId, 15, stringId.length());
+            assertEquals(stringId, stringId.toLowerCase());
+            if (previousId != null) {
+                assertTrue(
+                        "string order must follow numeric order: " + previousId + " vs " + stringId,
+                        previousId.compareTo(stringId) <= 0);
+            }
+            previousId = stringId;
+        }
+    }
+
+    private static AttributeDescriptor zoneAttribute(Class<?> binding) {
+        return new AttributeTypeBuilder().binding(binding).buildDescriptor("cell_h3index");
     }
 }


### PR DESCRIPTION
[![GEOT-7955](https://badgen.net/badge/JIRA/GEOT-7955/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7955) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Downstream integration builds: if this change needs matching PRs in GeoWebCache,
GeoServer or mapfish-print-v2 to compile or pass tests, add one line per companion so
the integration workflow checks out that PR instead of the default branch:
Downstream GeoWebCache PR: <number>
Downstream GeoServer PR: <number>
Downstream mapfish-print-v2 PR: <number>
Otherwise the workflow uses a companion branch with the same name as this PR's branch,
or the default branch. -->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 