### PR TITLE
[GEOT-7956] Log SchemaCache resolveLocation use

### DIFF
--- a/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaEntityResolver.java
+++ b/modules/extension/app-schema/app-schema-resolver/src/main/java/org/geotools/appschema/resolver/xml/AppSchemaEntityResolver.java
@@ -47,6 +47,7 @@ public class AppSchemaEntityResolver implements EntityResolver3 {
     public AppSchemaEntityResolver(SchemaResolver resolver) {
         this.resolver = resolver;
         this.entityResolver = NullEntityResolver.INSTANCE;
+        this.resolver.setEntityResolver(this.entityResolver);
     }
 
     /**
@@ -59,6 +60,7 @@ public class AppSchemaEntityResolver implements EntityResolver3 {
     public AppSchemaEntityResolver(SchemaResolver resolver, Hints hints) {
         this.resolver = resolver;
         this.entityResolver = GeoTools.getEntityResolver(hints);
+        this.resolver.setEntityResolver(this.entityResolver);
     }
 
     /**
@@ -71,6 +73,7 @@ public class AppSchemaEntityResolver implements EntityResolver3 {
     public AppSchemaEntityResolver(SchemaResolver resolver, EntityResolver entityResolver) {
         this.resolver = resolver;
         this.entityResolver = entityResolver != null ? entityResolver : NullEntityResolver.INSTANCE;
+        this.resolver.setEntityResolver(this.entityResolver);
     }
 
     @Override

--- a/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCache.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaCache.java
@@ -19,6 +19,7 @@ package org.geotools.xml.resolver;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -275,19 +276,27 @@ public class SchemaCache {
      *
      * @param location the absolute http/https URL of the schema
      * @return the canonical local file URL of the schema, or null if not found
+     * @throws FileNotFoundException if the location resolves to a path outside the cache directory
      */
-    public String resolveLocation(String location) {
+    public String resolveLocation(String location) throws IOException {
         String path = SchemaResolver.getSimpleHttpResourcePath(location, this.keepQuery);
         if (path == null) {
             return null;
         }
         String relativePath = path.substring(1);
         File file;
+        File canonicalDirectory;
 
         try {
             file = new File(getDirectory(), relativePath).getCanonicalFile();
+            canonicalDirectory = getDirectory().getCanonicalFile();
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+
+        if (!file.toPath().startsWith(canonicalDirectory.toPath())) {
+            LOGGER.fine("Reject relative location outside of cache directory: " + location);
+            throw new FileNotFoundException("Schema location restricted to cache directory");
         }
 
         synchronized (SchemaCache.class) {
@@ -297,6 +306,7 @@ public class SchemaCache {
         }
 
         if (isDownloadAllowed()) {
+
             byte[] bytes = download(location);
             if (bytes == null) {
                 return null;

--- a/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaResolver.java
+++ b/modules/library/xml/src/main/java/org/geotools/xml/resolver/SchemaResolver.java
@@ -17,6 +17,7 @@
 
 package org.geotools.xml.resolver;
 
+import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -25,7 +26,12 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.geotools.util.factory.GeoTools;
+import org.xml.sax.EntityResolver;
+import org.xml.sax.SAXException;
+import org.xml.sax.ext.EntityResolver2;
 
 /**
  * XML Schema resolver that maps absolute URLs to local URL resources.
@@ -63,6 +69,8 @@ public class SchemaResolver {
      */
     private Map<String, String> resolvedLocationToOriginalLocationMap = new ConcurrentHashMap<>();
 
+    /** Used to verify {@code xsd} */
+    private EntityResolver entityResolver;
     /**
      * Constructor.
      *
@@ -72,6 +80,7 @@ public class SchemaResolver {
         this.catalog = catalog;
         this.classpath = classpath;
         this.cache = cache;
+        this.entityResolver = GeoTools.getEntityResolver();
     }
 
     /** Constructor. */
@@ -95,6 +104,27 @@ public class SchemaResolver {
     }
 
     /**
+     * Set the entity resolver used to verify xsd locations.
+     *
+     * @param entityResolver
+     */
+    public void setEntityResolver(EntityResolver entityResolver) {
+        this.entityResolver = entityResolver;
+    }
+
+    /**
+     * Get entity resolver used to verify xsd locations.
+     *
+     * @return EntityResolver
+     */
+    public EntityResolver getEntityResolver() {
+        if (this.entityResolver == null) {
+            return GeoTools.getEntityResolver();
+        }
+        return this.entityResolver;
+    }
+
+    /**
      * Resolve an absolute or relative URL to a local file or jar URL. Relative URLs are resolved against a context
      * schema URL if provided.
      *
@@ -105,14 +135,25 @@ public class SchemaResolver {
      */
     public String resolve(String location, String context) {
         URI locationUri;
+        if (getEntityResolver() instanceof EntityResolver2 entityResolver2) {
+            try {
+                entityResolver2.resolveEntity(null, null, context, location);
+            } catch (SAXException | IOException e) {
+                LOGGER.log(Level.FINE, "Unable to resolve '" + location + "' with context: '" + context + "'", e);
+                throw new RuntimeException(
+                        "Failed to resolve schema location: " + location + " with context: " + context);
+            }
+        }
         try {
             locationUri = new URI(location);
         } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            LOGGER.log(Level.FINE, "Unable to resolve '" + location + "' with context: '" + context + "'", e);
+            throw new RuntimeException("Failed to resolve schema location: " + location + " with context: " + context);
         }
         if (!locationUri.isAbsolute()) {
             // Location is relative, so need to resolve against context.
             if (context == null) {
+                LOGGER.log(Level.FINE, "Unable to resolve '" + location + "' with context: '" + context + "'");
                 throw new RuntimeException("Could not determine absolute schema location for "
                         + location
                         + " because context schema location is unknown");
@@ -130,7 +171,17 @@ public class SchemaResolver {
             try {
                 contextUri = new URI(originalContext);
             } catch (URISyntaxException e) {
+                LOGGER.log(Level.FINE, "Unable to resolve context: '" + originalContext + "'", e);
                 throw new RuntimeException(e);
+            }
+            if (getEntityResolver() instanceof EntityResolver2 entityResolver2) {
+                try {
+                    entityResolver2.resolveEntity(null, null, originalContext, location);
+                } catch (SAXException | IOException e) {
+                    LOGGER.log(Level.FINE, "Unable to resolve '" + location + "' with context: '" + context + "'", e);
+                    throw new RuntimeException(
+                            "Failed to resolve schema location: " + location + " with context: " + context);
+                }
             }
             locationUri = contextUri.resolve(locationUri);
         }
@@ -165,7 +216,12 @@ public class SchemaResolver {
         }
         // Use download cache.
         if (resolvedLocation == null && cache != null) {
-            resolvedLocation = cache.resolveLocation(location);
+            try {
+                getEntityResolver().resolveEntity(null, location);
+                resolvedLocation = cache.resolveLocation(location);
+            } catch (SAXException | IOException e) {
+                throw new RuntimeException("Failed to resolve %s".formatted(location), e);
+            }
         }
         // Fail if still not resolved.
         if (resolvedLocation == null) {
@@ -204,6 +260,9 @@ public class SchemaResolver {
      */
     public static String getSimpleHttpResourcePath(String location, boolean keepQuery) {
         URI locationUri;
+        if (location == null) {
+            throw new NullPointerException("Unable to resolve location: null");
+        }
         try {
             locationUri = new URI(location);
         } catch (URISyntaxException e) {

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
@@ -28,10 +28,13 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.geotools.http.commons.MultithreadedHttpClientFactory;
 import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
+import org.geotools.util.logging.Logging;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -125,12 +128,19 @@ public class SchemaCacheTest {
     /** Test that a circular redirect is not followed indefinitely when using the multithreaded HTTP client */
     @Test
     public void circularRedirectMultithreadedHttpClient() {
-        Hints.putSystemDefault(Hints.HTTP_CLIENT_FACTORY, MultithreadedHttpClientFactory.class);
-        String redirectUrl = "http://localhost:" + service.port() + "/test";
-        service.stubFor(
-                get(urlEqualTo("/test")).willReturn(aResponse().withStatus(301).withHeader("Location", redirectUrl)));
-        byte[] responseBody = SchemaCache.download(redirectUrl);
-        Assert.assertNull(responseBody);
-        Hints.removeSystemDefault(Hints.HTTP_CLIENT_FACTORY);
+        final Logger LOGGER = Logging.getLogger("org.geotools.xml.resolver");
+        Level level = LOGGER.getLevel();
+        try {
+            LOGGER.setLevel(Level.OFF);
+            Hints.putSystemDefault(Hints.HTTP_CLIENT_FACTORY, MultithreadedHttpClientFactory.class);
+            String redirectUrl = "http://localhost:" + service.port() + "/test";
+            service.stubFor(get(urlEqualTo("/test"))
+                    .willReturn(aResponse().withStatus(301).withHeader("Location", redirectUrl)));
+            byte[] responseBody = SchemaCache.download(redirectUrl);
+            Assert.assertNull(responseBody);
+            Hints.removeSystemDefault(Hints.HTTP_CLIENT_FACTORY);
+        } finally {
+            LOGGER.setLevel(level);
+        }
     }
 }

--- a/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
+++ b/modules/library/xml/src/test/java/org/geotools/xml/resolver/SchemaCacheTest.java
@@ -29,6 +29,7 @@ import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import org.geotools.http.commons.MultithreadedHttpClientFactory;
+import org.geotools.util.NullEntityResolver;
 import org.geotools.util.URLs;
 import org.geotools.util.factory.Hints;
 import org.junit.Assert;
@@ -81,6 +82,7 @@ public class SchemaCacheTest {
         File cacheDirectory =
                 new File(URLs.urlToFile(SchemaCacheTest.class.getResource("/test-data/cache")), "../cache");
         SchemaResolver resolver = new SchemaResolver(new SchemaCache(cacheDirectory, false));
+        resolver.setEntityResolver(NullEntityResolver.INSTANCE);
         String resolvedLocation = resolver.resolve("http://schemas.example.org/cache-test/cache-test.xsd");
         Assert.assertTrue(resolvedLocation.startsWith("file:"));
         Assert.assertTrue(resolvedLocation.endsWith("cache-test.xsd"));


### PR DESCRIPTION
[![GEOT-7956](https://badgen.net/badge/JIRA/GEOT-7956/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7956) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Adding additional logging and checks to aid in troubleshooting SchemaCache.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 