### PR TITLE
[33.x backport] [GEOT-7958] Increase FilterToSqlHelper test coverage

### DIFF
--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -804,7 +804,7 @@ class FilterToSqlHelper {
             return String.format("(@.%s == %f)", jsonPath[lastIndex], (Double) value);
         }
         String literal = escapeJsonLiteral(String.valueOf(value));
-        return "(@.%s == \"%s\")".formatted(jsonPath[lastIndex], literal);
+        return String.format("(@.%s == \"%s\")", jsonPath[lastIndex], literal);
     }
 
     private String constructPath(String[] jsonPath) {

--- a/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/main/java/org/geotools/data/postgis/FilterToSqlHelper.java
@@ -803,7 +803,8 @@ class FilterToSqlHelper {
         } else if (value instanceof Double) {
             return String.format("(@.%s == %f)", jsonPath[lastIndex], (Double) value);
         }
-        return String.format("(@.%s == \"%s\")", jsonPath[lastIndex], value);
+        String literal = escapeJsonLiteral(String.valueOf(value));
+        return "(@.%s == \"%s\")".formatted(jsonPath[lastIndex], literal);
     }
 
     private String constructPath(String[] jsonPath) {

--- a/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJsonPathExistsTest.java
+++ b/modules/plugin/jdbc/jdbc-postgis/src/test/java/org/geotools/data/postgis/PostgisJsonPathExistsTest.java
@@ -60,6 +60,14 @@ public class PostgisJsonPathExistsTest extends SQLFilterTestSupport {
         filterToSql.encode(pointer);
         String sql = writer.toString().trim();
         assertEquals("jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.operations == \"OP1\")')", sql);
+
+        writer = new StringWriter();
+        filterToSql.setWriter(writer);
+
+        pointer = ff.function("jsonArrayContains", ff.property("WON'T"), ff.literal("/won't"), ff.literal("can't"));
+        filterToSql.encode(pointer);
+        sql = writer.toString().trim();
+        assertEquals("jsonb_path_exists(WON'T::jsonb, '$ ? (@.won''t == \"can''t\")')", sql);
     }
 
     @Test
@@ -99,6 +107,6 @@ public class PostgisJsonPathExistsTest extends SQLFilterTestSupport {
                 "jsonArrayContains", ff.property("OPERATIONS"), ff.literal("/operations"), ff.literal("\"'FOO"));
         filterToSql.encode(pointer);
         String sql = writer.toString().trim();
-        assertEquals("jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.operations == \"\"'FOO\")')", sql);
+        assertEquals("jsonb_path_exists(OPERATIONS::jsonb, '$ ? (@.operations == \"\\\"''FOO\")')", sql);
     }
 }


### PR DESCRIPTION
[![GEOT-7958](https://badgen.net/badge/JIRA/GEOT-7958/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7958) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Increasing test case while verifying PostGIS >= 12 functionality.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 