### PR TITLE
[GEOT-7954] - interoperability issue with gt-geojson-core 35.0 and Ja…

### DIFF
--- a/modules/unsupported/geojson-core/pom.xml
+++ b/modules/unsupported/geojson-core/pom.xml
@@ -33,6 +33,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>

--- a/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/ObjectMapperFactory.java
+++ b/modules/unsupported/geojson-core/src/main/java/org/geotools/data/geojson/ObjectMapperFactory.java
@@ -23,7 +23,7 @@ import tools.jackson.databind.json.JsonMapper;
 /**
  * Support class providing {@link tools.jackson.databind.ObjectMapper} instances configured with the desired settings.
  */
-class ObjectMapperFactory {
+public class ObjectMapperFactory {
 
     private static final ObjectMapper DEFAULT_MAPPER;
 

--- a/modules/unsupported/geojson-core/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
+++ b/modules/unsupported/geojson-core/src/main/resources/META-INF/services/com.fasterxml.jackson.databind.Module
@@ -1,1 +1,0 @@
-com.bedatadriven.jackson.datatype.jts.JtsModule

--- a/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/JtsModuleTest.java
+++ b/modules/unsupported/geojson-core/src/test/java/com/bedatadriven/jackson/datatype/jts/JtsModuleTest.java
@@ -1,7 +1,9 @@
 package com.bedatadriven.jackson.datatype.jts;
 
 import java.io.IOException;
+import java.util.ServiceConfigurationError;
 import org.easymock.EasyMock;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -17,6 +19,20 @@ public class JtsModuleTest {
     public void setupMapper() {
 
         mapper = JsonMapper.builder().addModule(new JtsModule()).build();
+    }
+
+    /**
+     * Make sure to remove JtsModule from Service registration as Jackson 2 module.
+     *
+     * <p>https://osgeo-org.atlassian.net/browse/GEOT-7954
+     */
+    @Test
+    public void serviceLoaderTest() {
+        try {
+            com.fasterxml.jackson.databind.ObjectMapper.findModules();
+        } catch (ServiceConfigurationError e) {
+            Assert.fail("JtsModule should not be registered as com.fasterxml.jackson.databind.Module");
+        }
     }
 
     @Test(expected = DatabindException.class)


### PR DESCRIPTION
[![GEOT-7954](https://badgen.net/badge/JIRA/GEOT-7954/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7954) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

A response to a reported failure at GeoTools mailing list from Bas Duineveld.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [X] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [X] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [X] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [X] Bug fixes and small new features are presented as a single commit.
- [X] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 