### PR TITLE
[GEOT-7960] MySQL 8 geographic SRS geometries are read/written with swapped axis order

### DIFF
--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialect.java
@@ -244,6 +244,11 @@ public class MySQLDialect extends SQLDialect {
             sql.append("asWKB(");
         }
         encodeColumnName(prefix, gatt.getLocalName(), sql);
+        // MySQL 8 returns geographic SRS ordinates in latitude-longitude order; ask for
+        // east/north to match GeoTools' internal convention without reordering JTS coordinates.
+        if (this.usePreciseSpatialOps && this.isMySqlVersion80OrAbove) {
+            sql.append(", 'axis-order=long-lat'");
+        }
         sql.append(")");
     }
 
@@ -281,7 +286,13 @@ public class MySQLDialect extends SQLDialect {
             sql.append("envelope(");
             encodeColumnName(null, geometryColumn, sql);
         }
-        sql.append("))");
+        if (this.usePreciseSpatialOps && this.isMySqlVersion80OrAbove) {
+            // Close the outer ST_SRID, then pass the axis-order option to ST_asWKB so that
+            // MySQL 8 returns geographic SRS ordinates in east/north order.
+            sql.append("), 'axis-order=long-lat')");
+        } else {
+            sql.append("))");
+        }
     }
 
     @Override

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectBasic.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectBasic.java
@@ -176,7 +176,12 @@ public class MySQLDialectBasic extends BasicSQLDialect {
     @Override
     public void encodeGeometryValue(Geometry value, int dimension, int srid, StringBuffer sql) throws IOException {
         if (value != null) {
-            if (delegate.usePreciseSpatialOps) {
+            boolean usePreciseSpatialOps = delegate.usePreciseSpatialOps;
+            // MySQL 8 stores geographic SRS ordinates in latitude-longitude order; declare
+            // GeoTools' east/north convention so the server does not swap them.
+            String axisOrder =
+                    (usePreciseSpatialOps && delegate.isMySqlVersion80OrAbove) ? ", 'axis-order=long-lat'" : "";
+            if (usePreciseSpatialOps) {
                 sql.append("ST_GeomFromText('");
                 // HACK; mysql 8 will throw a MysqlDataTruncation exception if srid == -1 which
                 // happens when JDBCDataStore#getDescriptorSRID(AttributeDescriptor) can't find the
@@ -188,7 +193,7 @@ public class MySQLDialectBasic extends BasicSQLDialect {
                 sql.append("GeomFromText('");
             }
             sql.append(new WKTWriter().write(value));
-            sql.append("', ").append(srid).append(")");
+            sql.append("', ").append(srid).append(axisOrder).append(")");
         } else {
             sql.append("NULL");
         }
@@ -238,7 +243,8 @@ public class MySQLDialectBasic extends BasicSQLDialect {
 
     @Override
     public FilterToSQL createFilterToSQL() {
-        MySQLFilterToSQL fts = new MySQLFilterToSQL(delegate.getUsePreciseSpatialOps());
+        MySQLFilterToSQL fts =
+                new MySQLFilterToSQL(delegate.getUsePreciseSpatialOps(), delegate.isMySqlVersion80OrAbove());
         // see https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_backslash_escapes
         // NOTE: for future enhancement, do not escape backslashes when the NO_BACKSLASH_ESCAPES
         // mode is enabled since that would create an incorrect string in the SQL

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectPrepared.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLDialectPrepared.java
@@ -197,7 +197,14 @@ public class MySQLDialectPrepared extends PreparedStatementSQLDialect {
             Class<? extends Geometry> gClass, int dimension, int srid, Class binding, StringBuffer sql) {
         if (gClass != null) {
             if (delegate.usePreciseSpatialOps) {
-                sql.append("ST_GeometryFromWKB(?)");
+                sql.append("ST_GeometryFromWKB(?");
+                if (delegate.isMySqlVersion80OrAbove) {
+                    // Declare east/north order; MySQL 8 defaults geographic SRS to lat/lon.
+                    // Match MySQLDialectBasic: MySQL 8 rejects a negative SRID.
+                    if (srid < 0) srid = 0;
+                    sql.append(", ").append(srid).append(", 'axis-order=long-lat'");
+                }
+                sql.append(")");
             } else {
                 sql.append("GeomFromWKB(?)");
             }

--- a/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLFilterToSQL.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/main/java/org/geotools/data/mysql/MySQLFilterToSQL.java
@@ -42,13 +42,20 @@ public class MySQLFilterToSQL extends FilterToSQL {
 
     protected boolean usePreciseSpatialOps;
 
+    protected boolean mySqlVersion80OrAbove;
+
     public MySQLFilterToSQL() {
-        this(false);
+        this(false, false);
     }
 
     public MySQLFilterToSQL(boolean usePreciseSpatialOps) {
+        this(usePreciseSpatialOps, false);
+    }
+
+    public MySQLFilterToSQL(boolean usePreciseSpatialOps, boolean mySqlVersion80OrAbove) {
         super();
         this.usePreciseSpatialOps = usePreciseSpatialOps;
+        this.mySqlVersion80OrAbove = mySqlVersion80OrAbove;
     }
 
     @Override
@@ -76,8 +83,11 @@ public class MySQLFilterToSQL extends FilterToSQL {
             // WKT does not support linear rings
             g = g.getFactory().createLineString(ring.getCoordinateSequence());
         }
+        // MySQL 8 stores geographic SRS ordinates in latitude-longitude order; declare GeoTools'
+        // east/north (x=longitude, y=latitude) convention so the server does not swap them.
+        String axisOrder = mySqlVersion80OrAbove ? ", 'axis-order=long-lat'" : "";
         if (usePreciseSpatialOps) {
-            out.write("ST_GeomFromText('" + g.toText() + "', " + currentSRID + ")");
+            out.write("ST_GeomFromText('" + g.toText() + "', " + currentSRID + axisOrder + ")");
         } else {
             out.write("GeomFromText('" + g.toText() + "', " + currentSRID + ")");
         }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreAPITestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLDataStoreAPITestSetup.java
@@ -30,39 +30,43 @@ public class MySQLDataStoreAPITestSetup extends JDBCDataStoreAPITestSetup {
 
     @Override
     protected void createRoadTable() throws Exception {
+        String axisOrder = ((MySQLTestSetup) delegate).axisOrderOption();
         run("CREATE TABLE road(fid int AUTO_INCREMENT PRIMARY KEY, id int, "
                 + "geom LINESTRING, name varchar(255) ) ENGINE=InnoDB;");
         run("INSERT INTO road (id,geom,name) VALUES (0,"
-                + "ST_GeomFromText('LINESTRING(1 1, 2 2, 4 2, 5 1)',4326),"
+                + "ST_GeomFromText('LINESTRING(1 1, 2 2, 4 2, 5 1)',4326" + axisOrder + "),"
                 + "'r1')");
         run("INSERT INTO road (id,geom,name) VALUES ( 1,"
-                + "ST_GeomFromText('LINESTRING(3 0, 3 2, 3 3, 3 4)',4326),"
+                + "ST_GeomFromText('LINESTRING(3 0, 3 2, 3 3, 3 4)',4326" + axisOrder + "),"
                 + "'r2')");
         run("INSERT INTO road (id,geom,name) VALUES ( 2,"
-                + "ST_GeomFromText('LINESTRING(3 2, 4 2, 5 3)',4326),"
+                + "ST_GeomFromText('LINESTRING(3 2, 4 2, 5 3)',4326" + axisOrder + "),"
                 + "'r3')");
     }
 
     @Override
     protected void createRiverTable() throws Exception {
+        String axisOrder = ((MySQLTestSetup) delegate).axisOrderOption();
         run("CREATE TABLE river(fid int AUTO_INCREMENT PRIMARY KEY, id int, "
                 + "geom MULTILINESTRING, river varchar(255) , flow double ) ENGINE=InnoDB;");
 
         run("INSERT INTO river (id,geom,river, flow)  VALUES ( 0,"
-                + "ST_GeomFromText('MULTILINESTRING((5 5, 7 4),(7 5, 9 7, 13 7),(7 5, 9 3, 11 3))',4326),"
+                + "ST_GeomFromText('MULTILINESTRING((5 5, 7 4),(7 5, 9 7, 13 7),(7 5, 9 3, 11 3))',4326"
+                + axisOrder + "),"
                 + "'rv1', 4.5)");
         run("INSERT INTO river (id,geom,river, flow) VALUES ( 1,"
-                + "ST_GeomFromText('MULTILINESTRING((4 6, 4 8, 6 10))',4326),"
+                + "ST_GeomFromText('MULTILINESTRING((4 6, 4 8, 6 10))',4326" + axisOrder + "),"
                 + "'rv2', 3.0)");
     }
 
     @Override
     protected void createLakeTable() throws Exception {
+        String axisOrder = ((MySQLTestSetup) delegate).axisOrderOption();
         run("CREATE TABLE lake(fid int AUTO_INCREMENT PRIMARY KEY, id int, "
                 + "geom POLYGON, name varchar(255) ) ENGINE=InnoDB;");
 
         run("INSERT INTO lake (id,geom,name) VALUES ( 0,"
-                + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))', 4326),"
+                + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))', 4326" + axisOrder + "),"
                 + "'muddy')");
     }
 

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLFilterToSQLTest.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLFilterToSQLTest.java
@@ -17,9 +17,12 @@
 package org.geotools.data.mysql;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.geotools.api.filter.FilterFactory;
 import org.geotools.api.filter.PropertyIsEqualTo;
+import org.geotools.api.filter.spatial.BBOX;
 import org.geotools.data.jdbc.SQLFilterTestSupport;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
@@ -44,5 +47,27 @@ public class MySQLFilterToSQLTest extends SQLFilterTestSupport {
         PropertyIsEqualTo expr = ff.equals(ff.property("testString"), ff.literal("\\'FOO"));
         String actual = filterToSql.encodeToString(expr);
         assertEquals("WHERE testString = '\\\\''FOO'", actual);
+    }
+
+    @Test
+    public void testBboxLiteralCarriesAxisOrderOnMySql8() throws Exception {
+        // MySQL 8 defaults geographic SRS to lat/lon; the dialect must declare east/north order.
+        String sql = encodeBbox(true, true);
+        assertTrue(sql, sql.contains("ST_GeomFromText"));
+        assertTrue(sql, sql.contains("'axis-order=long-lat'"));
+    }
+
+    @Test
+    public void testBboxLiteralOmitsAxisOrderBeforeMySql8() throws Exception {
+        String sql = encodeBbox(true, false);
+        assertTrue(sql, sql.contains("ST_GeomFromText"));
+        assertFalse(sql, sql.contains("axis-order"));
+    }
+
+    private String encodeBbox(boolean usePreciseSpatialOps, boolean mySqlVersion80OrAbove) throws Exception {
+        MySQLFilterToSQL toSql = new MySQLFilterToSQL(usePreciseSpatialOps, mySqlVersion80OrAbove);
+        toSql.setFeatureType(testSchema);
+        BBOX bbox = ff.bbox("testGeometry", 0, 0, 1, 1, "EPSG:4326");
+        return toSql.encodeToString(bbox);
     }
 }

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLNoPrimaryKeyTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLNoPrimaryKeyTestSetup.java
@@ -26,10 +26,11 @@ public class MySQLNoPrimaryKeyTestSetup extends JDBCNoPrimaryKeyTestSetup {
 
     @Override
     protected void createLakeTable() throws Exception {
+        String axisOrder = ((MySQLTestSetup) delegate).axisOrderOption();
         run("CREATE TABLE lake(id int, " + "geom POLYGON, name varchar(255) ) ENGINE=InnoDB;");
 
         run("INSERT INTO lake (id,geom,name) VALUES ( 0,"
-                + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326),"
+                + "ST_GeomFromText('POLYGON((12 6, 14 8, 16 6, 16 4, 14 4, 12 6))',4326" + axisOrder + "),"
                 + "'muddy')");
     }
 

--- a/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTestSetup.java
+++ b/modules/plugin/jdbc/jdbc-mysql/src/test/java/org/geotools/data/mysql/MySQLTestSetup.java
@@ -42,6 +42,23 @@ public class MySQLTestSetup extends JDBCTestSetup {
         return new MySQLDataStoreFactory();
     }
 
+    private Boolean mySqlVersion80OrAbove;
+
+    /**
+     * Axis-order clause for geographic SRS test data. MySQL 8.0+ interprets WKT/WKB in latitude-longitude order and
+     * supports the 'axis-order' option; GeoTools hands geometries to the dialect in east/north (longitude/latitude)
+     * order, so data inserted for 8.0+ must declare long-lat to match. The option is unknown on 5.x, which keeps the
+     * legacy Cartesian behavior.
+     */
+    protected String axisOrderOption() throws Exception {
+        if (mySqlVersion80OrAbove == null) {
+            try (Connection cx = getConnection()) {
+                mySqlVersion80OrAbove = cx.getMetaData().getDatabaseMajorVersion() >= 8;
+            }
+        }
+        return mySqlVersion80OrAbove ? ", 'axis-order=long-lat'" : "";
+    }
+
     @Override
     protected void setUpData() throws Exception {
         // allow time parsing in str_to_date


### PR DESCRIPTION
[![GEOT-7960](https://badgen.net/badge/JIRA/GEOT-7960/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7960) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

MySQL 8 interprets WKT/WKB for geographic SRS such as EPSG:4326 in latitude-longitude order, while GeoTools hands geometry literals to the dialect in east/north (x=longitude, y=latitude) order. With precise spatial ops this caused "Latitude out of range" errors or flipped geometries when reading/writing/filtering geographic columns.

Pass MySQL's native 'axis-order=long-lat' option on the geometry I/O and filter encoder paths, gated on usePreciseSpatialOps && isMySqlVersion80OrAbove: ST_GeomFromText/ST_GeomFromWKB on write and filter pushdown, and ST_asWKB on read. The option is a no-op for projected/SRID 0 geometries. JTS coordinates are not reordered.

Also wire isMySqlVersion80OrAbove through MySQLFilterToSQL and normalize a negative SRID to 0 in the prepared path, matching MySQLDialectBasic.

<!--Include a few sentences describing the overall goals for this Pull Request-->

<!-- Downstream integration builds: if this change needs matching PRs in GeoWebCache,
GeoServer or mapfish-print-v2 to compile or pass tests, add one line per companion so
the integration workflow checks out that PR instead of the default branch:
Downstream GeoWebCache PR: <number>
Downstream GeoServer PR: <number>
Downstream mapfish-print-v2 PR: <number>
Otherwise the workflow uses a companion branch with the same name as this PR's branch,
or the default branch. -->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [ ] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 