### PR TITLE
[GEOT-7965] Javadoc error in gt-coverage

### DIFF
--- a/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Absolute.java
+++ b/modules/library/coverage/src/main/java/org/geotools/coverage/processing/operation/Absolute.java
@@ -38,7 +38,7 @@ import org.geotools.util.NumberRange;
  * Computes the mathematical absolute value of each sample value.
  *
  * <p><STRONG>Name:</STRONG>&nbsp;<CODE>"Absolute"</CODE><br>
- * <STRONG>ImageN operator:</STRONG>&nbsp;<CODE>"{@linkplain Algebra/Absolute}"</CODE><br>
+ * <STRONG>ImageN operator:</STRONG>&nbsp;<CODE>"{@linkplain Operator#ABSOLUTE}"</CODE><br>
  * <STRONG>Parameters:</STRONG>
  *
  * <table border='3' cellpadding='6' bgcolor='F4F8FF'>


### PR DESCRIPTION
[![GEOT-7965](https://badgen.net/badge/JIRA/GEOT-7965/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7965) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Just a fix for the Javadoc.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [X] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [X] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [X] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [x] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [ ] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 