### PR TITLE
[GEOT-7966] ZonalStatistics return unexpected values when no pixel has been matched

### DIFF
--- a/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/RasterZonalStatistics.java
+++ b/modules/unsupported/process-raster/src/main/java/org/geotools/process/raster/RasterZonalStatistics.java
@@ -274,17 +274,22 @@ public class RasterZonalStatistics implements RasterProcess {
         void addStatsToFeature(Statistics[] stats) {
             // the statistics are returned in the order of the requested stats, for reference:
             // {StatsType.EXTREMA, StatsType.MEAN, StatsType.DEV_STD, StatsType.SUM};
-            double[] minMax = (double[]) stats[0].getResult();
             double count = stats[0].getNumSamples().doubleValue();
-            double avg = ((Number) stats[1].getResult()).doubleValue();
-            double stdDev = ((Number) stats[2].getResult()).doubleValue();
-            double sum = ((Number) stats[3].getResult()).doubleValue();
-            builder.add(count); // count
+            builder.add(count);
+            if (count == 0) {
+                // With no accepted samples the accumulators are still at their initial values:
+                // extrema would report +/-Infinity, sum and mean zero. Report no value instead.
+                for (int i = 0; i < 5; i++) {
+                    builder.add(Double.NaN);
+                }
+                return;
+            }
+            double[] minMax = (double[]) stats[0].getResult();
             builder.add(minMax[0]);
             builder.add(minMax[1]);
-            builder.add(sum);
-            builder.add(avg);
-            builder.add(stdDev);
+            builder.add(((Number) stats[3].getResult()).doubleValue()); // sum
+            builder.add(((Number) stats[1].getResult()).doubleValue()); // avg
+            builder.add(((Number) stats[2].getResult()).doubleValue()); // stddev
         }
 
         @SuppressWarnings("unchecked")

--- a/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/ZonalStatsProcessTest.java
+++ b/modules/unsupported/process-raster/src/test/java/org/geotools/process/raster/ZonalStatsProcessTest.java
@@ -37,6 +37,7 @@ import org.geotools.api.feature.simple.SimpleFeature;
 import org.geotools.api.feature.simple.SimpleFeatureType;
 import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.MathTransform;
+import org.geotools.coverage.Category;
 import org.geotools.coverage.CoverageFactoryFinder;
 import org.geotools.coverage.GridSampleDimension;
 import org.geotools.coverage.grid.GridCoverage2D;
@@ -308,5 +309,51 @@ public class ZonalStatsProcessTest extends Assert {
         SimpleFeature result = resultList.get(0);
         assertEquals(1d, result.getAttribute("max"));
         assertEquals(5000l, result.getAttribute("count"));
+    }
+
+    @Test
+    public void testEmptyZoneReportsNoValue() {
+        CoordinateReferenceSystem crs = DefaultEngineeringCRS.GENERIC_2D;
+
+        // left half holds 1, right half holds 0, and 0 is declared as no data
+        BufferedImage image = new BufferedImage(100, 100, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D graphics = image.createGraphics();
+        graphics.setColor(Color.WHITE);
+        graphics.fillRect(0, 0, 50, 100);
+        graphics.dispose();
+        GridSampleDimension band =
+                new GridSampleDimension("coverage", new Category[] {new Category("no data", (Color) null, 0)}, null);
+        GridCoverage2D coverage2D = CoverageFactoryFinder.getGridCoverageFactory(null)
+                .create(
+                        "coverage",
+                        image,
+                        new GridGeometry2D(
+                                new GridEnvelope2D(
+                                        PlanarImage.wrapRenderedImage(image).getBounds()),
+                                new AffineTransform2D(AffineTransform.getScaleInstance(1, 1)),
+                                crs),
+                        new GridSampleDimension[] {band},
+                        null,
+                        null);
+        assertNotNull(coverage2D);
+
+        // one zone, entirely inside the no data half
+        SimpleFeatureTypeBuilder tb = new SimpleFeatureTypeBuilder();
+        tb.add("geom", Polygon.class, crs);
+        tb.setName("zones");
+        SimpleFeatureType schema = tb.buildFeatureType();
+        Polygon poly = JTS.toGeometry(new Envelope(60, 90, 10, 90));
+        SimpleFeatureCollection zones =
+                DataUtilities.collection(SimpleFeatureBuilder.build(schema, new Object[] {poly}, "empty"));
+
+        SimpleFeatureCollection results = new RasterZonalStatistics().execute(coverage2D, 0, zones, null);
+        List<SimpleFeature> resultList = DataUtilities.list(results);
+
+        assertEquals(1, resultList.size());
+        SimpleFeature result = resultList.get(0);
+        assertEquals(0L, result.getAttribute("count"));
+        for (String stat : new String[] {"min", "max", "sum", "avg", "stddev"}) {
+            assertEquals(stat, Double.NaN, (Double) result.getAttribute(stat), 0d);
+        }
     }
 }


### PR DESCRIPTION
[![GEOT-7966](https://badgen.net/badge/JIRA/GEOT-7966/0052CC)](https://osgeo-org.atlassian.net/browse/GEOT-7966) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=geotools&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

RasterZonalStatistics returns invalid statistics for a zone where no pixel was accepted, either because the zone falls outside the data or because every pixel in it is no-data:

```
count=0, min=+Infinity, max=-Infinity, sum=0, avg=0, stddev=0
```

Those are the initial values of the extrema, sum and mean accumulators, not statistics of the zone.

Before 34.x GeoTools returned NaN for all five fields when the count was 0. The JAI-Ext to ImageN migration replaced the jaitools accessors, which returned NaN with no samples, by direct reads of the ImageN accumulators, with no check on the sample count.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geotools/geotools/blob/main/CONTRIBUTING.md).
- [x] I have sent a [Contribution Licence Agreement](https://docs.geotools.org/latest/developer/procedures/contribution_license.html) (not required for small changes, e.g., fixing typos in documentation).
- [x] First PR targets the `main` branch (backports managed later; ignore for branch specific issues).
- [x] Avoid [Java 9+ split packages](http://tutorials.jenkov.com/java/modules.html#split-packages-not-allowed).
- [ ] All the build checks are green ([see automated QA checks](https://docs.geotools.org/latest/developer/conventions/code/qa.html)).

For core and extension modules:

- [x] New unit tests have been added covering the changes.
- [ ] [Documentation](https://github.com/geotools/geotools/tree/main/docs) has been updated (if change is visible to end users).
- [x] There is an issue in [GeoTools Jira](https://osgeo-org.atlassian.net/projects/GEOT) (except for changes not visible to end users). 
- [x] Commit message(s) must be in the form ``[GEOT-XYZW] Title of the Jira ticket``.
- [x] Bug fixes and small new features are presented as a single commit.
- [x] The commit targets a single objective (if multiple focuses cannot be avoided, each one is in its own commit, and has a separate ticket describing it).

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.--> 